### PR TITLE
fix(doc) Replace @{u} by upstream/master because @{u} represents the origin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,13 +73,13 @@ First, download the latest commits:
 
 Then, integrate those changes to your fork (whatever branch you're working on).
 
-First try a fast-forward merge: `git merge --ff-only @{u}`
+First try a fast-forward merge: `git merge --ff-only upstream/master`
   * that command tells git to merge the upstream branch ONLY if you local branch can be "fast forwarded" to the upstream branch (i.e., if it hasn't diverged)
 
-If the fast-forward merge fails, then you'll have to rebase with the upstream (i.e., align): `git rebase -p @{u}`
+If the fast-forward merge fails, then you'll have to rebase with the upstream (i.e., align): `git rebase -p upstream/master`
   * the `-p` options tells git to preserve merges. This prevents git from linearizing the commits being rebased
 
-Once done, make sure the history looks like what you expect: `git log --graph --oneline --decorate --date-order --color --boundary @{u}`
+Once done, make sure the history looks like what you expect: `git log --graph --oneline --decorate --date-order --color --boundary upstream/master`
 
 Certainly so before creating a Pull Request (PR). If you don't do it then we'll request it anyways.
 
@@ -139,8 +139,8 @@ Workflow and commands:
   * first fetch the changes: `git fetch upstream`
     * alternative: `git remote update -p`
   * then merge or rebase
-    * try fast-forward merge: `git merge --ff-only @{u}`
-    * rebase if fast-forward failed: `git rebase -p @{u}` 
+    * try fast-forward merge: `git merge --ff-only upstream/master`
+    * rebase if fast-forward failed: `git rebase -p upstream/master` 
   * see "Keeping in sync" section for details!
 * create your Pull Request (PR); see "Proposing your changes by submitting a Pull Request (PR)" for details
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
In doc, we said to merge upstream with our master, we had to do
```
git merge --ff-only @{u}
```
but @{u} is a shortcut upstream of the branch which is origin in most of the cases.

So, I think it's clearer and better to specify upstream/master as this:
```
git merge --ff-only upstream/master
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information