### PR TITLE
chore(rxjs): use pipeable operators instead of prototype-patched based operators

### DIFF
--- a/packages/rollup.config.common-data.js
+++ b/packages/rollup.config.common-data.js
@@ -7,33 +7,21 @@ const commonjs = require("rollup-plugin-commonjs");
 const sourcemaps = require("rollup-plugin-sourcemaps");
 
 const globals = {
-	"class-validator": "class-validator",
-	cerialize: "cerialize",
 	"@angular/core": "ng.core",
 	"@angular/common/http": "angular.common.http",
-	rxjs: "rxjs",
-
 	"@ngrx/store": "@ngrx/store",
+	"class-validator": "class-validator",
+	cerialize: "cerialize",
 	moment: "moment",
 	uuid: "uuid",
+
+	rxjs: "rxjs",
 
 	// this should be the preferred way to import RxJS operators: https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md
 	// we should only use that in our code base
 	"rxjs/operators": "rxjs.operators",
 
-	// so that we can get rid of those: https://github.com/NationalBankBelgium/stark/issues/232
-	"rxjs/add/operator/catch": "Rx.Observable.prototype",
-	"rxjs/add/operator/map": "Rx.Observable.prototype",
-	"rxjs/add/operator/mergeMap": "Rx.Observable.prototype",
-	"rxjs/add/operator/retryWhen": "Rx.Observable.prototype",
-	"rxjs/add/operator/toPromise": "Rx.Observable.prototype",
-
-	// TODO could we also get rid of those?
 	"rxjs/Observable": "Rx",
-	"rxjs/add/observable/of": "Rx.Observable.prototype",
-	"rxjs/add/observable/throw": "Rx.Observable.prototype",
-	"rxjs/add/observable/timer": "Rx.Observable.prototype",
-
 	"rxjs/Subject": "Rx",
 	//"rxjs/Subscription": "Rx",
 

--- a/packages/stark-build/config/build-utils.js
+++ b/packages/stark-build/config/build-utils.js
@@ -56,15 +56,16 @@ function getEnvFile(suffix) {
 /**
  * Read the tsconfig to determine if we should prefer ES2015 modules.
  * Load rxjs path aliases.
- * https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md#build-and-treeshaking
+ * https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md#build-and-treeshaking
  * @param supportES2015 Set to true when the output of typescript is >= ES6
  */
 function rxjsAlias(supportES2015) {
 	try {
 		const rxjsPathMappingImport = supportES2015 ? "rxjs/_esm2015/path-mapping" : "rxjs/_esm5/path-mapping";
 		const rxPaths = require(rxjsPathMappingImport);
-		return rxPaths(helpers.root("node_modules"));
+		return rxPaths();
 	} catch (e) {
+		console.warn(e);
 		return {};
 	}
 }

--- a/packages/stark-build/config/tslint.json
+++ b/packages/stark-build/config/tslint.json
@@ -183,7 +183,7 @@
     "no-import-side-effect": [
       true,
       {
-        "ignore-module": "(rxjs|reflect-metadata|core-js|ngrx-store|angular|polyfills|vendor|typings|\\.css|\\.pcss)"
+        "ignore-module": "(reflect-metadata|core-js|ngrx-store|angular|polyfills|vendor|typings|\\.css|\\.pcss)"
       }
     ],
     "no-non-null-assertion": true,

--- a/packages/stark-build/config/webpack.common.js
+++ b/packages/stark-build/config/webpack.common.js
@@ -39,7 +39,7 @@ module.exports = function(options) {
 	};
 
 	const tsConfigApp = buildUtils.readTsConfig(helpers.root(METADATA.tsConfigPath));
-	
+
 	const defaultNgcOptions = {
 		generateCodeForLibraries: true,
 		skipMetadataEmit: false,
@@ -70,12 +70,28 @@ module.exports = function(options) {
 	};
 
 	return {
+		/**
+		 * Stats lets you precisely control what bundle information gets displayed
+		 * reference: https://webpack.js.org/configuration/stats/
+		 */
 		stats: {
+			assets: true,
+			children: true,
+			chunks: true,
+			chunkModules: false,
+			chunkOrigins: false,
 			colors: true,
-			reasons: true,
-			errorDetails: true // display error details. Same as the --show-error-details flag
-			// maxModules: Infinity, // examine all modules (ModuleConcatenationPlugin debugging)
-			// optimizationBailout: true  // display bailout reasons (ModuleConcatenationPlugin debugging)
+			errors: true,
+			errorDetails: true, // display error details. Same as the --show-error-details flag,
+			hash: true,
+			modules: true,
+			moduleTrace: true,
+			performance: true,
+			reasons: false,
+			source: true,
+			timings: true,
+			version: true,
+			warnings: true
 		},
 
 		/**
@@ -114,23 +130,23 @@ module.exports = function(options) {
 			modules: [helpers.root("src"), helpers.root("node_modules")],
 
 			/**
-			 * Add support for lettable operators.
+			 * Add support for pipeable operators.
 			 *
 			 * For existing codebase a refactor is required.
 			 * All rxjs operator imports (e.g. `import 'rxjs/add/operator/map'` or `import { map } from `rxjs/operator/map'`
 			 * must change to `import { map } from 'rxjs/operators'` (note that all operators are now under that import.
 			 * Additionally some operators have changed to to JS keyword constraints (do => tap, catch => catchError)
 			 *
-			 * Remember to use the `pipe()` method to chain operators, this functinoally makes lettable operators similar to
+			 * Remember to use the `pipe()` method to chain operators, this functionally makes pipeable operators similar to
 			 * the old operators usage paradigm.
 			 *
 			 * For more details see:
-			 * https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md#build-and-treeshaking
+			 * https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md#build-and-treeshaking
 			 *
 			 * If you are not planning on refactoring your codebase (or not planning on using imports from `rxjs/operators`
 			 * comment out this line.
 			 *
-			 * BE AWARE that not using lettable operators will probably result in significant payload added to your bundle.
+			 * BE AWARE that not using pipeable operators will probably result in significant payload added to your bundle.
 			 */
 			alias: buildUtils.rxjsAlias(supportES2015)
 		},

--- a/packages/stark-build/config/webpack.prod.js
+++ b/packages/stark-build/config/webpack.prod.js
@@ -60,6 +60,18 @@ module.exports = function() {
 
 	return webpackMerge(commonConfig({ ENV: ENV, metadata: METADATA }), {
 		/**
+		 * Stats lets you precisely control what bundle information gets displayed
+		 * reference: https://webpack.js.org/configuration/stats/
+		 */
+		stats: {
+			chunkModules: true,
+			chunkOrigins: true,
+			reasons: true,
+			maxModules: Infinity, // examine all modules (ModuleConcatenationPlugin debugging)
+			optimizationBailout: true  // display bailout reasons (ModuleConcatenationPlugin debugging)
+		},
+		
+		/**
 		 * Options affecting the output of the compilation.
 		 *
 		 * See: http://webpack.github.io/docs/configuration.html#output

--- a/packages/stark-core/package.json
+++ b/packages/stark-core/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "ngc": "ngc",
-    "lint": "tslint --config tslint.json --project ./tsconfig.json --format codeFrame",
+    "lint": "tslint --config tslint.json --project ./tsconfig.spec.json --format codeFrame",
     "test-fast": "node ./node_modules/@nationalbankbelgium/stark-testing/node_modules/karma/bin/karma start ./karma.conf.typescript.js",
     "test-fast:ci": "node ./node_modules/@nationalbankbelgium/stark-testing/node_modules/karma/bin/karma start karma.conf.typescript.ci.js",
     "tsc": "tsc -p tsconfig.json",

--- a/packages/stark-core/src/http/http.module.ts
+++ b/packages/stark-core/src/http/http.module.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpClientModule } from "@angular/common/http";
 import { StarkHttpServiceImpl, starkHttpServiceName } from "./services/index";
 
 // FIXME: remove this factory once LoggingService and SessionService are implemented
-const starkHttpServiceFactory = (httpClient: HttpClient) => {
+export function starkHttpServiceFactory(httpClient: HttpClient): StarkHttpServiceImpl<any> {
 	const logger: any = {
 		debug: console.debug,
 		warn: console.warn,
@@ -18,7 +18,7 @@ const starkHttpServiceFactory = (httpClient: HttpClient) => {
 	};
 
 	return new StarkHttpServiceImpl(logger, sessionService, httpClient)
-};
+}
 
 @NgModule({
 	imports: [

--- a/packages/stark-core/src/http/http.module.ts
+++ b/packages/stark-core/src/http/http.module.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpClientModule } from "@angular/common/http";
 import { StarkHttpServiceImpl, starkHttpServiceName } from "./services/index";
 
 // FIXME: remove this factory once LoggingService and SessionService are implemented
-const starkHttpServiceFactory: any = (httpClient: HttpClient) => {
+const starkHttpServiceFactory = (httpClient: HttpClient) => {
 	const logger: any = {
 		debug: console.debug,
 		warn: console.warn,
@@ -12,17 +12,23 @@ const starkHttpServiceFactory: any = (httpClient: HttpClient) => {
 	};
 
 	const sessionService: any = {
-		fakePreAuthenticationHeaders: new Map<string, string>([["nbb-dummy-header", "some value"], ["nbb-another-header", "whatever"]])
+		fakePreAuthenticationHeaders: new Map<string, string>([
+			["nbb-dummy-header", "some value"], ["nbb-another-header", "whatever"]
+		])
 	};
 
-	return new StarkHttpServiceImpl(logger, sessionService, httpClient);
+	return new StarkHttpServiceImpl(logger, sessionService, httpClient)
 };
 
 @NgModule({
-	imports: [HttpClientModule],
+	imports: [
+		HttpClientModule
+	],
 	providers: [
 		// FIXME: replace this Factory provider by a simple Class provider once LoggingService and SessionService are implemented
-		{ provide: starkHttpServiceName, useFactory: starkHttpServiceFactory, deps: [HttpClient] }
+		{provide: starkHttpServiceName, useFactory: starkHttpServiceFactory, deps: [HttpClient]},
 	]
 })
-export class StarkHttpModule {}
+export class StarkHttpModule {
+
+}

--- a/packages/stark-core/src/http/services/http.service.spec.ts
+++ b/packages/stark-core/src/http/services/http.service.spec.ts
@@ -4,9 +4,12 @@ import createSpyObj = jasmine.createSpyObj;
 import Spy = jasmine.Spy;
 import { autoserialize, autoserializeAs, inheritSerialization, Serialize } from "cerialize";
 import { Observable } from "rxjs/Observable";
-import "rxjs/add/observable/of";
-import "rxjs/add/observable/throw";
-import "rxjs/add/operator/catch";
+import { of } from "rxjs/observable/of";
+import { _throw as observableThrow } from "rxjs/observable/throw";
+// FIXME: importing from single entry "rxjs/operators" together with webpack's scope hoisting prevents dead code removal  
+// see https://github.com/ReactiveX/rxjs/issues/2981
+// import { catchError } from "rxjs/operators";
+import { catchError } from "rxjs/operators/catchError";
 import { ErrorObservable } from "rxjs/observable/ErrorObservable";
 import { HttpClient, HttpHeaders, HttpResponse } from "@angular/common/http";
 
@@ -97,7 +100,9 @@ describe("Service: StarkHttpService", () => {
 				titleKey: "errors.user.invalid",
 				detail: mockHttpErrorDetail1,
 				detailKey: "errors.user.invalid.username.already.in.use",
-				fields: ["username"],
+				fields: [
+					"username"
+				],
 				instance: mockHttpErrorInstance
 			},
 			{
@@ -106,7 +111,9 @@ describe("Service: StarkHttpService", () => {
 				titleKey: "errors.user.invalid",
 				detail: mockHttpErrorDetail2,
 				detailKey: "errors.user.invalid.username.missing",
-				fields: [mockHttpErrorDetailField1, mockHttpErrorDetailField2],
+				fields: [
+					mockHttpErrorDetailField1, mockHttpErrorDetailField2
+				],
 				instance: mockHttpErrorInstance
 			},
 			{
@@ -115,7 +122,9 @@ describe("Service: StarkHttpService", () => {
 				titleKey: "errors.user.invalid",
 				detail: mockHttpErrorDetail3,
 				detailKey: "errors.user.invalid.e-mail",
-				fields: [" e-mail"],
+				fields: [
+					" e-mail"
+				],
 				instance: mockHttpErrorInstance
 			}
 		]
@@ -134,7 +143,7 @@ describe("Service: StarkHttpService", () => {
 		mockResourceWithoutEtag = new MockResource(mockUuid);
 		mockResourceWithoutEtag.property1 = mockProperty1;
 		mockResourceWithoutEtag.property2 = mockProperty2;
-		mockResourceWithEtag = { ...mockResourceWithoutEtag, etag: mockEtag };
+		mockResourceWithEtag = {...mockResourceWithoutEtag, etag: mockEtag};
 		mockResourceWithMetadata = {
 			...mockResourceWithoutEtag,
 			etag: mockEtag,
@@ -176,11 +185,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithEtag,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkSingleItemResponseWrapper<MockResource>) => {
@@ -198,12 +205,15 @@ describe("Service: StarkHttpService", () => {
 						expect(result.data.metadata).toBeUndefined();
 
 						expect(httpMock.get).toHaveBeenCalledTimes(1);
-						expect(httpMock.get).toHaveBeenCalledWith("www.awesomeapi.com/mock", {
-							params: convertMapIntoObject(request.queryParameters),
-							headers: convertMapIntoObject(headersMap),
-							observe: "response",
-							responseType: "json"
-						});
+						expect(httpMock.get).toHaveBeenCalledWith(
+							"www.awesomeapi.com/mock",
+							{
+								params: convertMapIntoObject(request.queryParameters),
+								headers: convertMapIntoObject(headersMap),
+								observe: "response",
+								responseType: "json"
+							}
+						);
 					},
 					() => {
 						fail("The 'error' function should not be called in case of success");
@@ -217,11 +227,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithMetadata,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkSingleItemResponseWrapper<MockResource>) => {
@@ -265,11 +273,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockHttpError,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.throw(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(observableThrow(httpResponse));
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -304,12 +310,15 @@ describe("Service: StarkHttpService", () => {
 						expect(errorWrapper.starkHttpHeaders.get(expiresKey)).toBe(expiresValue);
 
 						expect(httpMock.get).toHaveBeenCalledTimes(1);
-						expect(httpMock.get).toHaveBeenCalledWith("www.awesomeapi.com/mock", {
-							params: convertMapIntoObject(request.queryParameters),
-							headers: convertMapIntoObject(headersMap),
-							observe: "response",
-							responseType: "json"
-						});
+						expect(httpMock.get).toHaveBeenCalledWith(
+							"www.awesomeapi.com/mock",
+							{
+								params: convertMapIntoObject(request.queryParameters),
+								headers: convertMapIntoObject(headersMap),
+								observe: "response",
+								responseType: "json"
+							}
+						);
 					}
 				);
 			});
@@ -322,18 +331,16 @@ describe("Service: StarkHttpService", () => {
 					headers: httpHeadersGetter(httpHeaders)
 				};
 				let errorCounter: number = 0;
-				(<Spy>httpMock.get).and.returnValue(
-					Observable.throw(httpResponse).catch((err: any) => {
+				(<Spy> httpMock.get).and.returnValue(observableThrow(httpResponse).pipe(
+					catchError((err: any) => {
 						errorCounter++;
-						return Observable.throw(err);
+						return observableThrow(err);
 					})
-				);
+				));
 
 				request.retryCount = 2;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -374,11 +381,9 @@ describe("Service: StarkHttpService", () => {
 					body: undefined,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.delete).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.delete).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkSingleItemResponseWrapper<MockResource>) => {
@@ -391,12 +396,15 @@ describe("Service: StarkHttpService", () => {
 						expect(result.starkHttpHeaders.get(expiresKey)).toBe(expiresValue);
 
 						expect(httpMock.delete).toHaveBeenCalledTimes(1);
-						expect(httpMock.delete).toHaveBeenCalledWith("www.awesomeapi.com/mock", {
-							params: convertMapIntoObject(request.queryParameters),
-							headers: convertMapIntoObject(headersMap),
-							observe: "response",
-							responseType: "json"
-						});
+						expect(httpMock.delete).toHaveBeenCalledWith(
+							"www.awesomeapi.com/mock",
+							{
+								params: convertMapIntoObject(request.queryParameters),
+								headers: convertMapIntoObject(headersMap),
+								observe: "response",
+								responseType: "json"
+							}
+						);
 					},
 					() => {
 						fail("The 'error' function should not be called in case of success");
@@ -410,11 +418,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockHttpError,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.delete).and.returnValue(Observable.throw(httpResponse));
+				(<Spy> httpMock.delete).and.returnValue(observableThrow(httpResponse));
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -449,12 +455,15 @@ describe("Service: StarkHttpService", () => {
 						expect(errorWrapper.starkHttpHeaders.get(expiresKey)).toBe(expiresValue);
 
 						expect(httpMock.delete).toHaveBeenCalledTimes(1);
-						expect(httpMock.delete).toHaveBeenCalledWith("www.awesomeapi.com/mock", {
-							params: convertMapIntoObject(request.queryParameters),
-							headers: convertMapIntoObject(headersMap),
-							observe: "response",
-							responseType: "json"
-						});
+						expect(httpMock.delete).toHaveBeenCalledWith(
+							"www.awesomeapi.com/mock",
+							{
+								params: convertMapIntoObject(request.queryParameters),
+								headers: convertMapIntoObject(headersMap),
+								observe: "response",
+								responseType: "json"
+							}
+						);
 					}
 				);
 			});
@@ -467,18 +476,16 @@ describe("Service: StarkHttpService", () => {
 					headers: httpHeadersGetter(httpHeaders)
 				};
 				let errorCounter: number = 0;
-				(<Spy>httpMock.delete).and.returnValue(
-					Observable.throw(httpResponse).catch((err: any) => {
+				(<Spy> httpMock.delete).and.returnValue(observableThrow(httpResponse).pipe(
+					catchError((err: any) => {
 						errorCounter++;
-						return Observable.throw(err);
+						return observableThrow(err);
 					})
-				);
+				));
 
 				request.retryCount = 2;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -519,13 +526,11 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithEtag,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
 				request.requestType = StarkHttpRequestType.UPDATE;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe((result: StarkSingleItemResponseWrapper<MockResource>) => {
 					expect(result).toBeDefined();
@@ -549,13 +554,11 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithEtag,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
 				request.requestType = StarkHttpRequestType.UPDATE;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkSingleItemResponseWrapper<MockResource>) => {
@@ -596,13 +599,11 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithMetadata,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
 				request.requestType = StarkHttpRequestType.UPDATE;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkSingleItemResponseWrapper<MockResource>) => {
@@ -646,13 +647,11 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithEtag,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.put).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.put).and.returnValue(of(httpResponse));
 
 				request.requestType = StarkHttpRequestType.UPDATE_IDEMPOTENT;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkSingleItemResponseWrapper<MockResource>) => {
@@ -693,13 +692,11 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithMetadata,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.put).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.put).and.returnValue(of(httpResponse));
 
 				request.requestType = StarkHttpRequestType.UPDATE_IDEMPOTENT;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkSingleItemResponseWrapper<MockResource>) => {
@@ -743,13 +740,11 @@ describe("Service: StarkHttpService", () => {
 					body: mockHttpError,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.throw(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(observableThrow(httpResponse));
 
 				request.requestType = StarkHttpRequestType.UPDATE;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -806,19 +801,17 @@ describe("Service: StarkHttpService", () => {
 					headers: httpHeadersGetter(httpHeaders)
 				};
 				let errorCounter: number = 0;
-				(<Spy>httpMock.post).and.returnValue(
-					Observable.throw(httpResponse).catch((err: any) => {
+				(<Spy> httpMock.post).and.returnValue(observableThrow(httpResponse).pipe(
+					catchError((err: any) => {
 						errorCounter++;
-						return Observable.throw(err);
+						return observableThrow(err);
 					})
-				);
+				));
 
 				request.requestType = StarkHttpRequestType.UPDATE;
 				request.retryCount = 2;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -842,13 +835,11 @@ describe("Service: StarkHttpService", () => {
 					body: mockHttpError,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.put).and.returnValue(Observable.throw(httpResponse));
+				(<Spy> httpMock.put).and.returnValue(observableThrow(httpResponse));
 
 				request.requestType = StarkHttpRequestType.UPDATE_IDEMPOTENT;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -905,19 +896,17 @@ describe("Service: StarkHttpService", () => {
 					headers: httpHeadersGetter(httpHeaders)
 				};
 				let errorCounter: number = 0;
-				(<Spy>httpMock.put).and.returnValue(
-					Observable.throw(httpResponse).catch((err: any) => {
+				(<Spy> httpMock.put).and.returnValue(observableThrow(httpResponse).pipe(
+					catchError((err: any) => {
 						errorCounter++;
-						return Observable.throw(err);
+						return observableThrow(err);
 					})
-				);
+				));
 
 				request.requestType = StarkHttpRequestType.UPDATE_IDEMPOTENT;
 				request.retryCount = 2;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -958,11 +947,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithEtag,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe((result: StarkSingleItemResponseWrapper<MockResource>) => {
 					expect(result).toBeDefined();
@@ -986,11 +973,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithEtag,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkSingleItemResponseWrapper<MockResource>) => {
@@ -1030,11 +1015,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockResourceWithMetadata,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkSingleItemResponseWrapper<MockResource>) => {
@@ -1078,11 +1061,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockHttpError,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.throw(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(observableThrow(httpResponse));
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -1138,18 +1119,16 @@ describe("Service: StarkHttpService", () => {
 					headers: httpHeadersGetter(httpHeaders)
 				};
 				let errorCounter: number = 0;
-				(<Spy>httpMock.post).and.returnValue(
-					Observable.throw(httpResponse).catch((err: any) => {
+				(<Spy> httpMock.post).and.returnValue(observableThrow(httpResponse).pipe(
+					catchError((err: any) => {
 						errorCounter++;
-						return Observable.throw(err);
+						return observableThrow(err);
 					})
-				);
+				));
 
 				request.retryCount = 2;
 
-				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(
-					request
-				);
+				const resultObs: Observable<StarkSingleItemResponseWrapper<MockResource>> = starkHttpService.executeSingleItemRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -1191,7 +1170,16 @@ describe("Service: StarkHttpService", () => {
 			prop1: 1234,
 			prop2: "whatever",
 			prop3: "2016-03-18T18:25:43.511Z",
-			prop4: ["some value", "false", "null", "", true, false, 0, { name: "Christopher", surname: "Cortes" }]
+			prop4: [
+				"some value",
+				"false",
+				"null",
+				"",
+				true,
+				false,
+				0,
+				{name: "Christopher", surname: "Cortes"}
+			]
 		};
 
 		describe("with a GetCollection request", () => {
@@ -1217,7 +1205,9 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: {
 							sortedBy: [
 								{
@@ -1240,11 +1230,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -1293,12 +1281,15 @@ describe("Service: StarkHttpService", () => {
 						expect(loggerMock.warn).not.toHaveBeenCalled();
 
 						expect(httpMock.get).toHaveBeenCalledTimes(1);
-						expect(httpMock.get).toHaveBeenCalledWith("www.awesomeapi.com/mock", {
-							params: convertMapIntoObject(request.queryParameters),
-							headers: convertMapIntoObject(headersMap),
-							observe: "response",
-							responseType: "json"
-						});
+						expect(httpMock.get).toHaveBeenCalledWith(
+							"www.awesomeapi.com/mock",
+							{
+								params: convertMapIntoObject(request.queryParameters),
+								headers: convertMapIntoObject(headersMap),
+								observe: "response",
+								responseType: "json"
+							}
+						);
 					},
 					() => {
 						fail("The 'error' function should not be called in case of success");
@@ -1310,7 +1301,9 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: {
 							sortedBy: [],
 							pagination: {
@@ -1327,11 +1320,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -1363,7 +1354,9 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: {
 							sortedBy: [],
 							pagination: {
@@ -1380,11 +1373,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -1436,17 +1427,15 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
 						expect(result).toBeDefined();
 						expect(result.starkHttpStatusCode).toBe(StarkHttpStatusCodes.HTTP_200_OK);
-						expect(result.data).toBeDefined(); // the data is whatever it comes in the "items" property
+						expect(result.data).toBeDefined(); // the data is whatever it comes in the "items" property 
 						expect(result.metadata instanceof StarkCollectionMetadataImpl).toBe(true);
 						expect(result.metadata.sortedBy.length).toBe(0);
 						expect(result.metadata.pagination).toBeDefined();
@@ -1467,8 +1456,7 @@ describe("Service: StarkHttpService", () => {
 				const etags: { [uuid: string]: string } = {};
 				etags[mockUuid] = mockEtag;
 
-				const items: any[] = [
-					// non-object item in "items" array
+				const items: any[] = [ // non-object item in "items" array
 					"some value"
 				];
 
@@ -1492,11 +1480,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<any>) => {
@@ -1526,13 +1512,15 @@ describe("Service: StarkHttpService", () => {
 				const etags: { [uuid: string]: string } = {};
 				etags[mockUuid] = mockEtag;
 
-				const mockResourceWithoutUuid: MockResource = { ...mockResourceWithEtag };
+				const mockResourceWithoutUuid: MockResource = {...mockResourceWithEtag};
 				delete mockResourceWithoutUuid.uuid;
 
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutUuid],
+						items: [
+							mockResourceWithoutUuid
+						],
 						metadata: {
 							sortedBy: [],
 							pagination: {
@@ -1549,11 +1537,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -1589,7 +1575,9 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: {
 							sortedBy: [],
 							pagination: {
@@ -1607,11 +1595,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -1643,16 +1629,16 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: <any>undefined
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -1679,11 +1665,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockHttpError,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.get).and.returnValue(Observable.throw(httpResponse));
+				(<Spy> httpMock.get).and.returnValue(observableThrow(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -1718,12 +1702,15 @@ describe("Service: StarkHttpService", () => {
 						expect(errorWrapper.starkHttpHeaders.get(expiresKey)).toBe(expiresValue);
 
 						expect(httpMock.get).toHaveBeenCalledTimes(1);
-						expect(httpMock.get).toHaveBeenCalledWith("www.awesomeapi.com/mock", {
-							params: convertMapIntoObject(request.queryParameters),
-							headers: convertMapIntoObject(headersMap),
-							observe: "response",
-							responseType: "json"
-						});
+						expect(httpMock.get).toHaveBeenCalledWith(
+							"www.awesomeapi.com/mock",
+							{
+								params: convertMapIntoObject(request.queryParameters),
+								headers: convertMapIntoObject(headersMap),
+								observe: "response",
+								responseType: "json"
+							}
+						);
 					}
 				);
 			});
@@ -1736,18 +1723,16 @@ describe("Service: StarkHttpService", () => {
 					headers: httpHeadersGetter(httpHeaders)
 				};
 				let errorCounter: number = 0;
-				(<Spy>httpMock.get).and.returnValue(
-					Observable.throw(httpResponse).catch((err: any) => {
+				(<Spy> httpMock.get).and.returnValue(observableThrow(httpResponse).pipe(
+					catchError((err: any) => {
 						errorCounter++;
-						return Observable.throw(err);
+						return observableThrow(err);
 					})
-				);
+				));
 
 				request.retryCount = 2;
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -1768,7 +1753,7 @@ describe("Service: StarkHttpService", () => {
 
 		describe("with a Search request", () => {
 			let request: StarkHttpRequest<MockResource>;
-			const mockCriteria: { [key: string]: any } = { field1: "anything", field2: "whatever" };
+			const mockCriteria: { [key: string]: any } = {field1: "anything", field2: "whatever"};
 
 			beforeEach(() => {
 				request = {
@@ -1790,7 +1775,9 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: {
 							sortedBy: [
 								{
@@ -1813,11 +1800,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -1887,7 +1872,9 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: {
 							sortedBy: [],
 							pagination: {
@@ -1904,11 +1891,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -1940,7 +1925,9 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: {
 							sortedBy: [],
 							pagination: {
@@ -1957,11 +1944,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -2013,17 +1998,15 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
 						expect(result).toBeDefined();
 						expect(result.starkHttpStatusCode).toBe(StarkHttpStatusCodes.HTTP_200_OK);
-						expect(result.data).toBeDefined(); // the data is whatever it comes in the "items" property
+						expect(result.data).toBeDefined(); // the data is whatever it comes in the "items" property 
 						expect(result.metadata instanceof StarkCollectionMetadataImpl).toBe(true);
 						expect(result.metadata.sortedBy.length).toBe(0);
 						expect(result.metadata.pagination).toBeDefined();
@@ -2044,8 +2027,7 @@ describe("Service: StarkHttpService", () => {
 				const etags: { [uuid: string]: string } = {};
 				etags[mockUuid] = mockEtag;
 
-				const items: any[] = [
-					// non-object item in "items" array
+				const items: any[] = [ // non-object item in "items" array
 					"some value"
 				];
 
@@ -2069,11 +2051,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<any>) => {
@@ -2103,13 +2083,15 @@ describe("Service: StarkHttpService", () => {
 				const etags: { [uuid: string]: string } = {};
 				etags[mockUuid] = mockEtag;
 
-				const mockResourceWithoutUuid: MockResource = { ...mockResourceWithEtag };
+				const mockResourceWithoutUuid: MockResource = {...mockResourceWithEtag};
 				delete mockResourceWithoutUuid.uuid;
 
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutUuid],
+						items: [
+							mockResourceWithoutUuid
+						],
 						metadata: {
 							sortedBy: [],
 							pagination: {
@@ -2126,11 +2108,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -2166,7 +2146,9 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: {
 							sortedBy: [],
 							pagination: {
@@ -2184,11 +2166,9 @@ describe("Service: StarkHttpService", () => {
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -2220,16 +2200,16 @@ describe("Service: StarkHttpService", () => {
 				const httpResponse: Partial<HttpResponse<StarkHttpRawCollectionResponseData<MockResource>>> = {
 					status: StarkHttpStatusCodes.HTTP_200_OK,
 					body: {
-						items: [mockResourceWithoutEtag],
+						items: [
+							mockResourceWithoutEtag
+						],
 						metadata: <any>undefined
 					},
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.of(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(of(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					(result: StarkCollectionResponseWrapper<MockResource>) => {
@@ -2256,11 +2236,9 @@ describe("Service: StarkHttpService", () => {
 					body: mockHttpError,
 					headers: httpHeadersGetter(httpHeaders)
 				};
-				(<Spy>httpMock.post).and.returnValue(Observable.throw(httpResponse));
+				(<Spy> httpMock.post).and.returnValue(observableThrow(httpResponse));
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -2317,18 +2295,16 @@ describe("Service: StarkHttpService", () => {
 					headers: httpHeadersGetter(httpHeaders)
 				};
 				let errorCounter: number = 0;
-				(<Spy>httpMock.post).and.returnValue(
-					Observable.throw(httpResponse).catch((err: any) => {
+				(<Spy> httpMock.post).and.returnValue(observableThrow(httpResponse).pipe(
+					catchError((err: any) => {
 						errorCounter++;
-						return Observable.throw(err);
+						return observableThrow(err);
 					})
-				);
+				));
 
 				request.retryCount = 2;
 
-				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(
-					request
-				);
+				const resultObs: Observable<StarkCollectionResponseWrapper<MockResource>> = starkHttpService.executeCollectionRequest(request);
 
 				resultObs.subscribe(
 					() => {
@@ -2429,19 +2405,25 @@ describe("Service: StarkHttpService", () => {
 
 @inheritSerialization(StarkSingleItemMetadataImpl)
 class MockResourceMetadata extends StarkSingleItemMetadataImpl {
-	@autoserialize public someValue?: string;
+	@autoserialize
+	public someValue?: string;
 }
 
 class MockResource implements StarkResource {
-	@autoserialize public uuid: string;
+	@autoserialize
+	public uuid: string;
 
-	@autoserialize public etag: string;
+	@autoserialize
+	public etag: string;
 
-	@autoserializeAs(MockResourceMetadata) public metadata: MockResourceMetadata;
+	@autoserializeAs(MockResourceMetadata)
+	public metadata: MockResourceMetadata;
 
-	@autoserialize public property1: string;
+	@autoserialize
+	public property1: string;
 
-	@autoserialize public property2: string;
+	@autoserialize
+	public property2: string;
 
 	public constructor(uuid: string) {
 		this.uuid = uuid;
@@ -2465,6 +2447,7 @@ function convertMapIntoObject(map: Map<string, any>): object {
 }
 
 class HttpServiceHelper<P extends StarkResource> extends StarkHttpServiceImpl<P> {
+
 	public retryDelay: number;
 
 	public constructor(logger: StarkLoggingService, sessionService: StarkSessionService, $http: HttpClient) {

--- a/packages/stark-core/src/logging/services/logging.service.spec.ts
+++ b/packages/stark-core/src/logging/services/logging.service.spec.ts
@@ -3,8 +3,8 @@
 import Spy = jasmine.Spy;
 import { Action, Store } from "@ngrx/store";
 import { Observable } from "rxjs/Observable";
-import "rxjs/add/observable/of";
-import "rxjs/add/observable/throw";
+import { of } from "rxjs/observable/of";
+import { _throw as observableThrow } from "rxjs/observable/throw";
 import { Serialize } from "cerialize";
 
 import { StarkLoggingActionTypes, FlushLogMessages } from "../../logging/actions/index";
@@ -66,7 +66,7 @@ describe("Service: StarkLoggingService", () => {
 			applicationId: "dummy app id",
 			messages: []
 		};
-		(<Spy>mockStore.select).and.returnValue(Observable.of(mockStarkLogging));
+		(<Spy>mockStore.select).and.returnValue(of(mockStarkLogging));
 		loggingService = new LoggingServiceHelper(mockStore, appConfig /*, mockXSRFService*/);
 		// reset the calls counter because there is a log in the constructor
 		(<Spy>mockStore.dispatch).calls.reset();
@@ -248,7 +248,7 @@ describe("Service: StarkLoggingService", () => {
 		it("should persist messages to the back-end when the persist size exceeds", () => {
 			expect(mockStarkLogging.messages.length).toBe(loggingFlushPersistSize);
 
-			const sendRequestSpy: Spy = spyOn(loggingService, "sendRequest").and.callFake(() => Observable.of("ok"));
+			const sendRequestSpy: Spy = spyOn(loggingService, "sendRequest").and.callFake(() => of("ok"));
 			const data: string = JSON.stringify(Serialize(mockStarkLogging, StarkLoggingImpl));
 			(<LoggingServiceHelper>loggingService).persistLogMessagesHelper();
 			expect(sendRequestSpy).toHaveBeenCalledTimes(1);
@@ -263,7 +263,7 @@ describe("Service: StarkLoggingService", () => {
 		it("should fail to persist messages when the back-end fails", () => {
 			expect(mockStarkLogging.messages.length).toBe(loggingFlushPersistSize);
 
-			const sendRequestSpy: Spy = spyOn(loggingService, "sendRequest").and.callFake(() => Observable.throw("ko"));
+			const sendRequestSpy: Spy = spyOn(loggingService, "sendRequest").and.callFake(() => observableThrow("ko"));
 			const errorSpy: Spy = spyOn(loggingService, "error");
 			const data: string = JSON.stringify(Serialize(mockStarkLogging, StarkLoggingImpl));
 			(<LoggingServiceHelper>loggingService).persistLogMessagesHelper();
@@ -292,7 +292,7 @@ class LoggingServiceHelper extends StarkLoggingServiceImpl {
 	// override parent's implementation to prevent actual HTTP request to be sent!
 	public sendRequest(): Observable<void> {
 		/* dummy function to be mocked */
-		return Observable.of(undefined);
+		return of(undefined);
 	}
 
 	// override parent's implementation to prevent logging to the console

--- a/packages/stark-core/src/test/unit-testing/unit-testing-utils.ts
+++ b/packages/stark-core/src/test/unit-testing/unit-testing-utils.ts
@@ -1,8 +1,5 @@
 "use strict";
 
-import "rxjs/add/observable/of";
-import "rxjs/add/operator/toPromise";
-
 import { StarkLoggingService, starkLoggingServiceName } from "../..//logging/index";
 import { StarkSessionService, starkSessionServiceName } from "../../session/index";
 import { StarkHttpHeaders, StarkHttpService, starkHttpServiceName } from "../../http/index";

--- a/starter/src/app/app.routes.ts
+++ b/starter/src/app/app.routes.ts
@@ -3,7 +3,7 @@ import { AboutComponent } from "./about";
 import { NoContentComponent } from "./no-content";
 import { Ng2StateDeclaration, Transition } from "@uirouter/angular";
 import { of } from "rxjs/observable/of";
-import "rxjs/add/operator/delay";
+import { delay } from "rxjs/operators/delay";
 import { Observable } from "rxjs/Observable";
 
 export function getResolvedData(): Observable<any> {
@@ -12,14 +12,14 @@ export function getResolvedData(): Observable<any> {
 	// if resolve policy = 'WAIT' or 'NOWAIT' the component WILL BE LOADED WITHOUT
 	// WAITING FOR THE OBSERVABLE TO EMIT
 	// if resolve policy = 'RXWAIT', the component WILL BE LOADED UNTIL THE OBSERVABLE EMITS
-	return of({ resolve: "I am data from the resolve" }).delay(5000);
+	return of({ resolve: "I am data from the resolve" }).pipe(delay(5000));
 
 	// could return a promise
 	// when resolve policy is 'WAIT', the component WILL BE LOADED UNTIL THE PROMISE
 	// IS RESOLVED and the value will be already unwrapped
 	// when resolve policy is 'NOWAIT', the component WILL BE LOADED WITHOUT
 	// WAITING FOR IT but the component should unwrap the promise
-	// return of({ resolve: 'I am data from the resolve'}).delay(5000).toPromise();
+	// return of({ resolve: 'I am data from the resolve'}).pipe(delay(5000)).toPromise();
 }
 
 export function getParamData($transition$: Transition): any {

--- a/starter/src/app/home/home.component.ts
+++ b/starter/src/app/home/home.component.ts
@@ -11,7 +11,7 @@ import {
 	starkHttpServiceName,
 	StarkSingleItemResponseWrapper
 } from "@nationalbankbelgium/stark-core";
-import { Observable } from "rxjs/Observable"
+import { Observable } from "rxjs/Observable";
 
 import { AppState } from "../app.service";
 import { Title } from "./title";

--- a/starter/src/app/home/home.component.ts
+++ b/starter/src/app/home/home.component.ts
@@ -11,7 +11,7 @@ import {
 	starkHttpServiceName,
 	StarkSingleItemResponseWrapper
 } from "@nationalbankbelgium/stark-core";
-import { Observable } from "rxjs/Observable";
+import { Observable } from "rxjs/Observable"
 
 import { AppState } from "../app.service";
 import { Title } from "./title";
@@ -41,16 +41,15 @@ export class HomeComponent implements OnInit {
 	/**
 	 * Set our default values
 	 */
-	public localState: any = { value: " " };
+	public localState: any = {value: " "};
 
 	/**
 	 * TypeScript public modifiers
 	 */
-	public constructor(
-		public appState: AppState,
-		public title: Title,
-		@Inject(starkHttpServiceName) public httpService: StarkHttpService<any>
-	) {}
+	public constructor(public appState: AppState,
+					   public title: Title,
+					   @Inject(starkHttpServiceName) public httpService: StarkHttpService<any>) {
+	}
 
 	public ngOnInit(): void {
 		console.log("hello `Home` component");
@@ -78,25 +77,27 @@ export class HomeComponent implements OnInit {
 		let httpRequest$: Observable<StarkSingleItemResponseWrapper<Request> | StarkCollectionResponseWrapper<Request>>;
 
 		if (type === "singleItem") {
-			httpRequest$ = this.httpService.executeSingleItemRequest({
-				backend: backend,
-				resourcePath: "requests/11",
-				headers: new Map<string, string>(),
-				queryParameters: new Map<string, string | string[] | undefined>(),
-				requestType: StarkHttpRequestType.GET,
-				serializer: serializer,
-				retryCount: 4
-			});
+			httpRequest$ = this.httpService
+				.executeSingleItemRequest({
+					backend: backend,
+					resourcePath: "requests/11",
+					headers: new Map<string, string>(),
+					queryParameters: new Map<string, string | string[] | undefined>(),
+					requestType: StarkHttpRequestType.GET,
+					serializer: serializer,
+					retryCount: 4
+				})
 		} else {
-			httpRequest$ = this.httpService.executeCollectionRequest({
-				backend: backend,
-				resourcePath: "requests",
-				headers: new Map<string, string>(),
-				queryParameters: new Map<string, string | string[] | undefined>(),
-				requestType: StarkHttpRequestType.GET_COLLECTION,
-				serializer: serializer,
-				retryCount: 4
-			});
+			httpRequest$ = this.httpService
+				.executeCollectionRequest({
+					backend: backend,
+					resourcePath: "requests",
+					headers: new Map<string, string>(),
+					queryParameters: new Map<string, string | string[] | undefined>(),
+					requestType: StarkHttpRequestType.GET_COLLECTION,
+					serializer: serializer,
+					retryCount: 4
+				})
 		}
 
 		httpRequest$.subscribe(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Prototype-patched based observables/operators are used in all our codebase due to this kind of imports:
```javascript
import "rxjs/add/observable/of";
import "rxjs/add/operator/foo";
import "rxjs/add/operator/baz";
```

Issue Number: #258 


## What is the new behavior?
Pipeable observables/operators are used now by doing this kind of imports:
```javascript
import { of } from "rxjs/observable/of";
import { foo } from "rxjs/operators/foo";
import { baz } from "rxjs/operators/baz";
```

Currently, we cannot use the generic import for all operators: `import { foo, baz } from "rxjs/operators";`
due to ReactiveX/rxjs#2981

## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
**Now only pipeable operators should be used, otherwise Tslint will throw an error (due to the ["no-import-side-effect"](https://palantir.github.io/tslint/rules/no-import-side-effect/) rule)**