### PR TITLE
feat(logging): implement STARK_APP_CONFIG token and implement Stark logging in Starter

### DIFF
--- a/packages/stark-build/config/webpack.common.js
+++ b/packages/stark-build/config/webpack.common.js
@@ -55,10 +55,11 @@ module.exports = function(options) {
 		module: !isProd && METADATA.WATCH ? "commonjs" : "es2015" // TODO is it needed in our case? => Force commonjs module format for TS on dev watch builds.
 	};
 
-	const appNgcOptions = {
-		...defaultNgcOptions,
-		...tsConfigApp.raw.angularCompilerOptions
-	};
+	const appNgcOptions = Object.assign(
+		{},
+		defaultNgcOptions,
+		tsConfigApp.raw.angularCompilerOptions
+	);
 
 	const environment = buildUtils.getEnvFile(METADATA.envFileSuffix);
 

--- a/packages/stark-core/src/configuration/entities/application/app-config.entity.intf.ts
+++ b/packages/stark-core/src/configuration/entities/application/app-config.entity.intf.ts
@@ -1,8 +1,10 @@
 "use strict";
 
 import { StarkBackend } from "../../../http/entities/backend";
+import { InjectionToken } from '@angular/core';
 
-export const starkAppConfigConstantName: string = "StarkAppConfig";
+export const STARK_APP_CONFIG: InjectionToken<StarkApplicationConfig> = new InjectionToken<StarkApplicationConfig>('STARK_APP_CONFIG');
+
 /**
  * Minimal set of configuration options for Stark applications.
  * An implementation should be instantiated and be available under the name defined in the constants.

--- a/packages/stark-core/src/http/http.module.ts
+++ b/packages/stark-core/src/http/http.module.ts
@@ -1,15 +1,10 @@
 import { NgModule } from "@angular/core";
 import { HttpClient, HttpClientModule } from "@angular/common/http";
 import { StarkHttpServiceImpl, starkHttpServiceName } from "./services/index";
+import { StarkLoggingService, starkLoggingServiceName } from '../logging/index';
 
 // FIXME: remove this factory once LoggingService and SessionService are implemented
-export function starkHttpServiceFactory(httpClient: HttpClient): StarkHttpServiceImpl<any> {
-	const logger: any = {
-		debug: console.debug,
-		warn: console.warn,
-		error: console.error,
-		correlationId: "dummy-correlation-id"
-	};
+export function starkHttpServiceFactory(httpClient: HttpClient, starkLoggingService: StarkLoggingService): StarkHttpServiceImpl<any> {
 
 	const sessionService: any = {
 		fakePreAuthenticationHeaders: new Map<string, string>([
@@ -17,7 +12,7 @@ export function starkHttpServiceFactory(httpClient: HttpClient): StarkHttpServic
 		])
 	};
 
-	return new StarkHttpServiceImpl(logger, sessionService, httpClient)
+	return new StarkHttpServiceImpl(starkLoggingService, sessionService, httpClient);
 }
 
 @NgModule({
@@ -26,9 +21,9 @@ export function starkHttpServiceFactory(httpClient: HttpClient): StarkHttpServic
 	],
 	providers: [
 		// FIXME: replace this Factory provider by a simple Class provider once LoggingService and SessionService are implemented
-		{provide: starkHttpServiceName, useFactory: starkHttpServiceFactory, deps: [HttpClient]},
+		{ provide: starkHttpServiceName, useFactory: starkHttpServiceFactory, deps: [HttpClient, starkLoggingServiceName] }
 	]
 })
-export class StarkHttpModule {
 
+export class StarkHttpModule {
 }

--- a/packages/stark-core/src/logging/index.ts
+++ b/packages/stark-core/src/logging/index.ts
@@ -4,3 +4,4 @@ export * from "./actions/index";
 export * from "./entities/index";
 export * from "./reducers/index";
 export * from "./services/index";
+export * from "./logging.module";

--- a/packages/stark-core/src/logging/logging.module.ts
+++ b/packages/stark-core/src/logging/logging.module.ts
@@ -4,7 +4,6 @@ import { ActionReducerMap, StoreModule } from "@ngrx/store";
 import { loggingReducer } from "./reducers/index";
 import { StarkLoggingActions } from "./actions/index";
 import { StarkLoggingServiceImpl, starkLoggingServiceName } from "./services/index";
-import { starkAppConfigConstantName, StarkApplicationConfigImpl } from "../configuration/entities/index";
 import { StarkLoggingApplicationState } from "../common/store/starkCoreApplicationState";
 
 const reducers:ActionReducerMap<StarkLoggingApplicationState, StarkLoggingActions> = {
@@ -15,8 +14,7 @@ starkLogging: loggingReducer
 	imports: [StoreModule.forRoot(reducers)],
 	declarations: [],
 	providers: [
-		{ provide: starkLoggingServiceName, useClass: StarkLoggingServiceImpl },
-		{ provide: starkAppConfigConstantName, useClass: StarkApplicationConfigImpl }
+		{ provide: starkLoggingServiceName, useClass: StarkLoggingServiceImpl }
 	]
 })
-export class LoggingModule {}
+export class StarkLoggingModule {}

--- a/packages/stark-core/src/logging/services/logging.service.ts
+++ b/packages/stark-core/src/logging/services/logging.service.ts
@@ -12,7 +12,7 @@ import { Subject } from "rxjs/Subject";
 import { Inject, Injectable } from "@angular/core";
 
 import { StarkLoggingService, starkLoggingServiceName } from "./logging.service.intf";
-import { StarkApplicationConfig, starkAppConfigConstantName } from "../../configuration/entities/index";
+import { StarkApplicationConfig, STARK_APP_CONFIG } from "../../configuration/entities/index";
 import { StarkBackend } from "../../http/entities/backend/index";
 import { StarkCoreApplicationState, StarkLoggingApplicationState } from "../../common/store/starkCoreApplicationState";
 import { StarkHttpStatusCodes } from "../../http/enumerators/index";
@@ -52,8 +52,7 @@ export class StarkLoggingServiceImpl implements StarkLoggingService {
 	// FIXME: uncomment these lines once XSRF Service is implemented
 	public constructor(
 		private store: Store<StarkCoreApplicationState>,
-		@Inject(starkAppConfigConstantName)
-		private appConfig: StarkApplicationConfig /*,
+		@Inject(STARK_APP_CONFIG) private appConfig: StarkApplicationConfig /*,
 					   @Inject(starkXSRFServiceName) private xsrfService: StarkXSRFService*/
 	) {
 		this.isPersisting = false;
@@ -68,7 +67,7 @@ export class StarkLoggingServiceImpl implements StarkLoggingService {
 			// ensuring that the app config is valid before configuring the automatic logging flush
 			StarkValidationErrorsUtil.throwOnError(
 				validateSync(this.appConfig),
-				starkLoggingServiceName + ": " + starkAppConfigConstantName + " constant is not valid."
+				starkLoggingServiceName + ": " + STARK_APP_CONFIG.toString() + " constant is not valid."
 			);
 
 			this.backend = this.appConfig.getBackend("logging");

--- a/starter/package.json
+++ b/starter/package.json
@@ -116,7 +116,7 @@
     "@angular/platform-server": "5.2.9",
     "@angular/router": "5.2.9",
     "@nationalbankbelgium/angular-mdi-svg": "1.7.0",
-    "@nationalbankbelgium/stark-core": "file:../dist/packages-dist/stark-core/nationalbankbelgium-stark-core-10.0.0-alpha.0-f89b1b0.tgz",
+    "@nationalbankbelgium/stark-core": "file:../dist/packages-dist/stark-core/nationalbankbelgium-stark-core-10.0.0-alpha.0-abad17c.tgz",
     "@uirouter/angular": "1.0.1",
     "@uirouter/visualizer": "6.0.0",
     "core-js": "2.5.3",
@@ -129,8 +129,8 @@
     "zone.js": "0.8.20"
   },
   "devDependencies": {
-    "@nationalbankbelgium/stark-build": "file:../dist/packages-dist/stark-build/nationalbankbelgium-stark-build-10.0.0-alpha.0-f89b1b0.tgz",
-    "@nationalbankbelgium/stark-testing": "file:../dist/packages-dist/stark-testing/nationalbankbelgium-stark-testing-10.0.0-alpha.0-f89b1b0.tgz",
+    "@nationalbankbelgium/stark-build": "file:../dist/packages-dist/stark-build/nationalbankbelgium-stark-build-10.0.0-alpha.0-abad17c.tgz",
+    "@nationalbankbelgium/stark-testing": "file:../dist/packages-dist/stark-testing/nationalbankbelgium-stark-testing-10.0.0-alpha.0-abad17c.tgz",
     "@types/core-js": "0.9.46",
     "@types/hammerjs": "2.0.35",
     "@types/node": "6.0.102",

--- a/starter/src/app/+barrel/+child-barrel/child-barrel.component.ts
+++ b/starter/src/app/+barrel/+child-barrel/child-barrel.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
+import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
 /**
  * We're loading this component asynchronously
  * We are using some magic with es6-promise-loader that will wrap the module with a Promise
@@ -14,7 +15,9 @@ console.log("`ChildBarrel` component loaded asynchronously");
   `
 })
 export class ChildBarrelComponent implements OnInit {
+	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+
 	public ngOnInit(): void {
-		console.log("hello `ChildBarrel` component");
+		this.loggingService.debug("hello from `ChildBarrel` component");
 	}
 }

--- a/starter/src/app/+barrel/barrel.component.ts
+++ b/starter/src/app/+barrel/barrel.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
+import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
 /**
  * We're loading this component asynchronously
  * We are using some magic with es6-promise-loader that will wrap the module with a Promise
@@ -12,7 +13,9 @@ console.log("`Barrel` component loaded asynchronously");
 	templateUrl: "./barrel.component.html"
 })
 export class BarrelComponent implements OnInit {
+	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+
 	public ngOnInit(): void {
-		console.log("hello `Barrel` component");
+		this.loggingService.debug("hello from `Barrel` component");
 	}
 }

--- a/starter/src/app/+detail/+child-detail/child-detail.component.ts
+++ b/starter/src/app/+detail/+child-detail/child-detail.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
+import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
 /**
  * We're loading this component asynchronously
  * We are using some magic with es6-promise-loader that will wrap the module with a Promise
@@ -14,7 +15,9 @@ console.log("`ChildDetail` component loaded asynchronously");
   `
 })
 export class ChildDetailComponent implements OnInit {
+	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+
 	public ngOnInit(): void {
-		console.log("hello `ChildDetail` component");
+		this.loggingService.debug("hello from `ChildDetail` component");
 	}
 }

--- a/starter/src/app/+detail/detail.component.ts
+++ b/starter/src/app/+detail/detail.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
+import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
 /**
  * We're loading this component asynchronously
  * We are using some magic with es6-promise-loader that will wrap the module with a Promise
@@ -12,7 +13,9 @@ console.log("`Detail` component loaded asynchronously");
 	templateUrl: "./detail.component.html"
 })
 export class DetailComponent implements OnInit {
+	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+
 	public ngOnInit(): void {
-		console.log("hello `Detail` component");
+		this.loggingService.debug("hello from `Detail` component");
 	}
 }

--- a/starter/src/app/+dev-module/dev-module.component.ts
+++ b/starter/src/app/+dev-module/dev-module.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
+import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
 
 @Component({
 	selector: "dev-module",
@@ -7,7 +8,9 @@ import { Component, OnInit } from "@angular/core";
   `
 })
 export class DevModuleComponent implements OnInit {
+	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+
 	public ngOnInit(): void {
-		console.log("hello `DevModule` component");
+		this.loggingService.debug("hello from `DevModule` component");
 	}
 }

--- a/starter/src/app/about/about.component.spec.ts
+++ b/starter/src/app/about/about.component.spec.ts
@@ -5,13 +5,37 @@ import { inject, TestBed } from "@angular/core/testing";
  * Load the implementations that should be tested.
  */
 import { AboutComponent } from "./about.component";
+import {
+	StarkLoggingModule,
+	STARK_APP_CONFIG,
+	StarkBackend,
+	StarkApplicationConfig,
+	StarkBackendAuthenticationTypes,
+	StarkLoggingService,
+	starkLoggingServiceName
+} from "@nationalbankbelgium/stark-core";
 
 describe("About", () => {
 	/**
 	 * Provide our implementations or mocks to the dependency injector
 	 */
+	let logger: StarkLoggingService;
+
+	const mockBackend: Partial<StarkBackend> = {
+		authenticationType: StarkBackendAuthenticationTypes.PUBLIC,
+		name: "logging",
+		url: "dummy/url"
+	};
+
+	const mockStarkAppConfig: Partial<StarkApplicationConfig> = {
+		angularDebugInfoEnabled: true,
+		debugLoggingEnabled: true,
+		getBackend: jasmine.createSpy("getBackendSpy").and.returnValue(mockBackend)
+	};
+
 	beforeEach(() =>
 		TestBed.configureTestingModule({
+			imports: [StarkLoggingModule],
 			providers: [
 				/**
 				 * Provide a better mock.
@@ -27,7 +51,8 @@ describe("About", () => {
 						}
 					}
 				},
-				AboutComponent
+				AboutComponent,
+				{ provide: STARK_APP_CONFIG, useValue: mockStarkAppConfig }
 			]
 		})
 	);
@@ -35,11 +60,13 @@ describe("About", () => {
 	it(
 		"should log ngOnInit",
 		inject([AboutComponent], (about: AboutComponent) => {
-			spyOn(console, "log");
-			expect(console.log).not.toHaveBeenCalled();
+			logger = TestBed.get(starkLoggingServiceName);
+
+			spyOn(logger, "debug");
+			expect(logger.debug).not.toHaveBeenCalled();
 
 			about.ngOnInit();
-			expect(console.log).toHaveBeenCalled();
+			expect(logger.debug).toHaveBeenCalled();
 		})
 	);
 });

--- a/starter/src/app/about/about.component.ts
+++ b/starter/src/app/about/about.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, Inject, Input, OnInit } from "@angular/core";
 // import { Transition } from '@uirouter/angular';
 import { Observable } from "rxjs/Observable";
+import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
 
 @Component({
 	selector: "about",
@@ -27,10 +28,10 @@ export class AboutComponent implements OnInit {
 	@Input() public paramData: any;
 
 	public localState: any;
-	public constructor() // public transition: Transition   // the last transition could be injected if needed
-	{
-		/* empty */
-	}
+	public constructor(
+		// public transition: Transition   // the last transition could be injected if needed
+		@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService
+	) {}
 
 	public ngOnInit(): void {
 		/**
@@ -46,7 +47,7 @@ export class AboutComponent implements OnInit {
 		// if the resolve is an observable, we need to subscribe to it to get the value
 		if (this.resolvedData) {
 			this.resolvedData.subscribe((data: any) => {
-				console.warn("data resolved");
+				this.loggingService.warn("data resolved");
 				this.localState = { ...this.localState, ...data };
 			});
 		}
@@ -63,11 +64,12 @@ export class AboutComponent implements OnInit {
 		// let resolvePromise: Promise<any> = this.transition.injector().get('resolvedData');
 		// resolvePromise.then((data: any) => this.localState = {...this.localState, ...data});
 
-		console.log("hello `About` component");
+		this.loggingService.debug("hello from `About` component");
+
 		/**
 		 * static data that is bundled
 		 * var mockData = require('assets/mock-data/mock-data.json');
-		 * console.log('mockData', mockData);
+		 * this.loggingService.debug('mockData', mockData);
 		 * if you're working with mock data you can also use http.get('assets/mock-data/mock-data.json')
 		 */
 		this.asyncDataWithWebpack();
@@ -80,7 +82,7 @@ export class AboutComponent implements OnInit {
 		 */
 		// setTimeout(() => {
 		// 	System.import("../../assets/mock-data/mock-data.json").then(json => {
-		// 		console.log("async mockData", json);
+		// 		this.loggingService.debug("async mockData", json);
 		// 		this.localState = { ...this.localState, asyncData: json };
 		// 	});
 		// });

--- a/starter/src/app/app.module.ts
+++ b/starter/src/app/app.module.ts
@@ -3,8 +3,15 @@ import { BrowserModule } from "@angular/platform-browser";
 import { FormsModule } from "@angular/forms";
 import { UIRouterModule } from "@uirouter/angular";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { StarkHttpModule } from "@nationalbankbelgium/stark-core";
+import {
+	StarkHttpModule,
+	StarkLoggingModule,
+	STARK_APP_CONFIG,
+	StarkApplicationConfig,
+	StarkApplicationConfigImpl
+} from "@nationalbankbelgium/stark-core";
 import { routerConfigFn } from "./router.config";
+import { Deserialize } from "cerialize";
 
 /*
  * Platform and Environment providers/directives/pipes
@@ -28,6 +35,23 @@ import "../styles/headings.css";
 // Application wide providers
 const APP_PROVIDERS: any[] = [AppState];
 
+// TODO: where to put this factory function?
+export function starkAppConfigFactory(): StarkApplicationConfig {
+	const config: any = require("../stark-app-config.json");
+
+	const applicationConfig: StarkApplicationConfig = Deserialize(config, StarkApplicationConfigImpl);
+	// FIXME: Make sure the correct values are used below
+	applicationConfig.rootStateUrl = "home";
+	applicationConfig.rootStateName = "";
+	applicationConfig.homeStateName = "home";
+	applicationConfig.errorStateName = "";
+	applicationConfig.angularDebugInfoEnabled = true; //DEVELOPMENT;
+	applicationConfig.debugLoggingEnabled = true; //DEVELOPMENT;
+	applicationConfig.routerLoggingEnabled = true; //DEVELOPMENT;
+
+	return applicationConfig;
+}
+
 /**
  * `AppModule` is the main entry point into Angular2's bootstrapping process
  */
@@ -42,6 +66,7 @@ const APP_PROVIDERS: any[] = [AppState];
 		BrowserAnimationsModule,
 		FormsModule,
 		StarkHttpModule,
+		StarkLoggingModule,
 		UIRouterModule.forRoot({
 			states: APP_STATES,
 			useHash: Boolean(history.pushState) === false,
@@ -62,7 +87,8 @@ const APP_PROVIDERS: any[] = [AppState];
 	providers: [
 		environment.ENV_PROVIDERS,
 		APP_PROVIDERS,
-		{ provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader } // needed for ui-router
+		{ provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader }, // needed for ui-router
+		{ provide: STARK_APP_CONFIG, useFactory: starkAppConfigFactory }
 	]
 })
 export class AppModule {}

--- a/starter/src/app/home/home.component.spec.ts
+++ b/starter/src/app/home/home.component.spec.ts
@@ -8,11 +8,33 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { AppState } from "../app.service";
 import { HomeComponent } from "./home.component";
 import { Title } from "./title";
-import { StarkHttpModule } from "@nationalbankbelgium/stark-core";
+import {
+	StarkHttpModule,
+	StarkLoggingModule,
+	STARK_APP_CONFIG,
+	StarkApplicationConfig,
+	StarkBackend,
+	StarkBackendAuthenticationTypes,
+	StarkLoggingService,
+	starkLoggingServiceName
+} from "@nationalbankbelgium/stark-core";
 
 describe(`Home`, () => {
 	let comp: HomeComponent;
 	let fixture: ComponentFixture<HomeComponent>;
+	let logger: StarkLoggingService;
+
+	const mockBackend: Partial<StarkBackend> = {
+		authenticationType: StarkBackendAuthenticationTypes.PUBLIC,
+		name: "logging",
+		url: "dummy/url"
+	};
+
+	const mockStarkAppConfig: Partial<StarkApplicationConfig> = {
+		angularDebugInfoEnabled: true,
+		debugLoggingEnabled: true,
+		getBackend: jasmine.createSpy("getBackendSpy").and.returnValue(mockBackend)
+	};
 
 	/**
 	 * async beforeEach.
@@ -23,8 +45,8 @@ describe(`Home`, () => {
 				TestBed.configureTestingModule({
 					declarations: [HomeComponent],
 					schemas: [NO_ERRORS_SCHEMA],
-					imports: [HttpClientTestingModule, StarkHttpModule],
-					providers: [AppState, Title]
+					imports: [HttpClientTestingModule, StarkHttpModule, StarkLoggingModule],
+					providers: [AppState, Title, { provide: STARK_APP_CONFIG, useValue: mockStarkAppConfig }]
 				})
 
 					/**
@@ -39,6 +61,8 @@ describe(`Home`, () => {
 	 * Synchronous beforeEach.
 	 */
 	beforeEach(() => {
+		logger = TestBed.get(starkLoggingServiceName);
+
 		fixture = TestBed.createComponent(HomeComponent);
 		comp = fixture.componentInstance;
 
@@ -57,10 +81,10 @@ describe(`Home`, () => {
 	});
 
 	it("should log ngOnInit", () => {
-		spyOn(console, "log");
-		expect(console.log).not.toHaveBeenCalled();
+		spyOn(logger, "debug");
+		expect(logger.debug).not.toHaveBeenCalled();
 
 		comp.ngOnInit();
-		expect(console.log).toHaveBeenCalled();
+		expect(logger.debug).toHaveBeenCalled();
 	});
 });

--- a/starter/src/app/home/home.component.ts
+++ b/starter/src/app/home/home.component.ts
@@ -9,6 +9,8 @@ import {
 	StarkHttpSerializerImpl,
 	StarkHttpService,
 	starkHttpServiceName,
+	StarkLoggingService,
+	starkLoggingServiceName,
 	StarkSingleItemResponseWrapper
 } from "@nationalbankbelgium/stark-core";
 import { Observable } from "rxjs/Observable";
@@ -41,25 +43,27 @@ export class HomeComponent implements OnInit {
 	/**
 	 * Set our default values
 	 */
-	public localState: any = {value: " "};
+	public localState: any = { value: " " };
 
 	/**
 	 * TypeScript public modifiers
 	 */
-	public constructor(public appState: AppState,
-					   public title: Title,
-					   @Inject(starkHttpServiceName) public httpService: StarkHttpService<any>) {
-	}
+	public constructor(
+		public appState: AppState,
+		public title: Title,
+		@Inject(starkHttpServiceName) public httpService: StarkHttpService<any>,
+		@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService
+	) {}
 
 	public ngOnInit(): void {
-		console.log("hello `Home` component");
+		this.loggingService.debug("hello from `Home` component");
 		/**
 		 * this.title.getData().subscribe(data => this.data = data);
 		 */
 	}
 
 	public submitState(value: string): void {
-		console.log("submitState", value);
+		this.loggingService.debug("submitState", value);
 		this.appState.set("value", value);
 		this.localState.value = "";
 	}
@@ -77,33 +81,31 @@ export class HomeComponent implements OnInit {
 		let httpRequest$: Observable<StarkSingleItemResponseWrapper<Request> | StarkCollectionResponseWrapper<Request>>;
 
 		if (type === "singleItem") {
-			httpRequest$ = this.httpService
-				.executeSingleItemRequest({
-					backend: backend,
-					resourcePath: "requests/11",
-					headers: new Map<string, string>(),
-					queryParameters: new Map<string, string | string[] | undefined>(),
-					requestType: StarkHttpRequestType.GET,
-					serializer: serializer,
-					retryCount: 4
-				})
+			httpRequest$ = this.httpService.executeSingleItemRequest({
+				backend: backend,
+				resourcePath: "requests/11",
+				headers: new Map<string, string>(),
+				queryParameters: new Map<string, string | string[] | undefined>(),
+				requestType: StarkHttpRequestType.GET,
+				serializer: serializer,
+				retryCount: 4
+			});
 		} else {
-			httpRequest$ = this.httpService
-				.executeCollectionRequest({
-					backend: backend,
-					resourcePath: "requests",
-					headers: new Map<string, string>(),
-					queryParameters: new Map<string, string | string[] | undefined>(),
-					requestType: StarkHttpRequestType.GET_COLLECTION,
-					serializer: serializer,
-					retryCount: 4
-				})
+			httpRequest$ = this.httpService.executeCollectionRequest({
+				backend: backend,
+				resourcePath: "requests",
+				headers: new Map<string, string>(),
+				queryParameters: new Map<string, string | string[] | undefined>(),
+				requestType: StarkHttpRequestType.GET_COLLECTION,
+				serializer: serializer,
+				retryCount: 4
+			});
 		}
 
 		httpRequest$.subscribe(
 			(response: any) => console.log("---------- SUCCESS", response),
-			(error: StarkHttpErrorWrapper) => console.log("---------- ERROR", error),
-			() => console.log("---------- COMPLETE")
+			(error: StarkHttpErrorWrapper) => this.loggingService.error("---------- ERROR", <any>error),
+			() => this.loggingService.debug("---------- COMPLETE")
 		);
 	}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Logging service not yet available in the Starter app.

Issue Number: #91


## What is the new behavior?
Logging service implemented in the Starter app.
Created a "STARK_APP_CONFIG" token to provide the StarkConfig from the client app into Stark.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
"STARK_APP_CONFIG" token has to be used to inject the AppConfig in components and services.