### PR TITLE
fix(build): Fix Import bracket rule for prettier and tslint

### DIFF
--- a/packages/stark-build/config/.prettierrc.js
+++ b/packages/stark-build/config/.prettierrc.js
@@ -3,6 +3,7 @@ module.exports = {
 	tabWidth: 4,
 	useTabs: true,
 	trailingComma: "none",
+	bracketSpacing: true,
 	overrides: [
 		{
 			files: "*.{pcss,scss,css,json}",

--- a/packages/stark-build/config/tslint.json
+++ b/packages/stark-build/config/tslint.json
@@ -29,7 +29,6 @@
     "use-pipe-decorator": true,
     "use-view-encapsulation": true,
     "trackBy-function": true,
-    "import-destructuring-spacing": true,
     "no-unused-css": true,
     "i18n": false,
     "template-cyclomatic-complexity": [true, 5],
@@ -297,4 +296,6 @@
   //	true,
   //	"as-needed"
   //	],
+//  "import-destructuring-spacing": true,
+
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Prettier now add a space between the import and the brackets.
Disable corresponding rule for Tslint.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information