### PR TITLE
feat(build) Trigger an error during build when rollup fails.

### DIFF
--- a/build-functions.sh
+++ b/build-functions.sh
@@ -109,6 +109,14 @@ runRollup() {
     cd ${1}
     logTrace "${FUNCNAME[0]}: Rollup command: $ROLLUP -c $ROLLUP_CONFIG_PATH" 2
     local ROLLUP_RESULTS=`$ROLLUP -c $ROLLUP_CONFIG_PATH 2>&1`
+    if [[ $ROLLUP_RESULTS =~ ^.*\(\!\).* ]]; then
+      if [[ $ROLLUP_RESULTS =~ "^.*\(\!\) Unresolved dependencies.*" ]]; then
+        logInfo "${FUNCNAME[0]}: Rollup - Unresolved dependencies detected." 2
+      else
+        logInfo "${FUNCNAME[0]}: Error happened during rollup execution. Rollup execution output: $ROLLUP_RESULTS"
+        exit 1
+      fi
+    fi
     cd - > /dev/null
 	logTrace "${FUNCNAME[0]}: Rollup execution output: $ROLLUP_RESULTS" 2
 	logTrace "${FUNCNAME[0]}: Rollup completed" 2
@@ -172,6 +180,14 @@ rollupIndex() {
     # Note that this execution of rollup MUST NOT include globals/external libs like rxjs, angular, ...
     # For this usage scenario, the client app is supposed to import those dependencies on their own (e.g., script tag above on the page)
     local ROLLUP_RESULTS=`$ROLLUP -c ${ROLLUP_CONFIG_PATH} -i ${in_file} -o ${out_file} --banner "$BANNER_TEXT" 2>&1`
+    if [[ $ROLLUP_RESULTS =~ ^.*\(\!\).* ]]; then
+      if [[ $ROLLUP_RESULTS =~ ^.*\(\!\)\ Unresolved\ dependencies.* ]]; then
+        logInfo "${FUNCNAME[0]}: Rollup - Unresolved dependencies detected." 2
+      else
+        logInfo "${FUNCNAME[0]}: Error happened during rollup execution. Rollup execution output: $ROLLUP_RESULTS"
+        exit 1
+      fi
+    fi
     logTrace "${FUNCNAME[0]}: Rollup execution output (do not mind the unresolved dependencies!): $ROLLUP_RESULTS" 2
   fi
 

--- a/build-functions.sh
+++ b/build-functions.sh
@@ -109,15 +109,21 @@ runRollup() {
     cd ${1}
     logTrace "${FUNCNAME[0]}: Rollup command: $ROLLUP -c $ROLLUP_CONFIG_PATH" 2
     local ROLLUP_RESULTS=`$ROLLUP -c $ROLLUP_CONFIG_PATH 2>&1`
-    if [[ $ROLLUP_RESULTS =~ ^.*\(\!\).* ]]; then
+    
+    if [[ $ROLLUP_RESULTS =~ ^.*\[\!\].* ]]; then
+      logInfo "${FUNCNAME[0]}: Error happened during rollup execution. Rollup execution output: $ROLLUP_RESULTS"
+      exit 1
+    elif [[ $ROLLUP_RESULTS =~ ^.*\(\!\).* ]]; then
       if [[ $ROLLUP_RESULTS =~ "^.*\(\!\) Unresolved dependencies.*" ]]; then
-        logInfo "${FUNCNAME[0]}: Rollup - Unresolved dependencies detected." 2
+        logInfo "${FUNCNAME[0]}: Rollup - (!) Unresolved dependencies detected." 2
+      elif [[ $ROLLUP_RESULTS =~ "^.*\(\!\) Missing global variable name.*" ]]; then
+        logInfo "${FUNCNAME[0]}: Rollup - (!) Missing global variable name." 2
       else
-        logInfo "${FUNCNAME[0]}: Error happened during rollup execution. Rollup execution output: $ROLLUP_RESULTS"
-        exit 1
+        logInfo "${FUNCNAME[0]}: Warning appeared during rollup execution. Rollup execution output: $ROLLUP_RESULTS"
       fi
     fi
     cd - > /dev/null
+
 	logTrace "${FUNCNAME[0]}: Rollup execution output: $ROLLUP_RESULTS" 2
 	logTrace "${FUNCNAME[0]}: Rollup completed" 2
 	
@@ -180,14 +186,20 @@ rollupIndex() {
     # Note that this execution of rollup MUST NOT include globals/external libs like rxjs, angular, ...
     # For this usage scenario, the client app is supposed to import those dependencies on their own (e.g., script tag above on the page)
     local ROLLUP_RESULTS=`$ROLLUP -c ${ROLLUP_CONFIG_PATH} -i ${in_file} -o ${out_file} --banner "$BANNER_TEXT" 2>&1`
-    if [[ $ROLLUP_RESULTS =~ ^.*\(\!\).* ]]; then
-      if [[ $ROLLUP_RESULTS =~ ^.*\(\!\)\ Unresolved\ dependencies.* ]]; then
-        logInfo "${FUNCNAME[0]}: Rollup - Unresolved dependencies detected." 2
+    
+    if [[ $ROLLUP_RESULTS =~ ^.*\[\!\].* ]]; then
+      logInfo "${FUNCNAME[0]}: Error happened during rollup execution. Rollup execution output: $ROLLUP_RESULTS"
+      exit 1
+    elif [[ $ROLLUP_RESULTS =~ ^.*\(\!\).* ]]; then
+      if [[ $ROLLUP_RESULTS =~ "^.*\(\!\) Unresolved dependencies.*" ]]; then
+        logInfo "${FUNCNAME[0]}: Rollup - (!) Unresolved dependencies detected." 2
+      elif [[ $ROLLUP_RESULTS =~ "^.*\(\!\) Missing global variable name.*" ]]; then
+        logInfo "${FUNCNAME[0]}: Rollup - (!) Missing global variable name." 2
       else
-        logInfo "${FUNCNAME[0]}: Error happened during rollup execution. Rollup execution output: $ROLLUP_RESULTS"
-        exit 1
+        logInfo "${FUNCNAME[0]}: Warning appeared during rollup execution. Rollup execution output: $ROLLUP_RESULTS"
       fi
     fi
+
     logTrace "${FUNCNAME[0]}: Rollup execution output (do not mind the unresolved dependencies!): $ROLLUP_RESULTS" 2
   fi
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

The build script displays now warning messages everytime a warning message is showed by Rollup, even when --trace argument is not passed.
Also, the build is now stopped when there is an error in during Rollup process.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #278 


## What is the new behavior?
Throw an error when there is an error during rollup process.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information