### PR TITLE
fix(core): fix ngc issues and clean-up code in stark-core. Integrate AppMetadata in Starter

### DIFF
--- a/packages/stark-core/karma.conf.typescript.ci.js
+++ b/packages/stark-core/karma.conf.typescript.ci.js
@@ -22,12 +22,9 @@ defaultKarmaCIConfig(configExtractor);
 let starkCoreSpecificConfiguration = loadedConfiguration;
 
 // change the path of the report so that Coveralls takes the right path to the source files
-starkCoreSpecificConfiguration.coverageIstanbulReporter = Object.assign(
-	starkCoreSpecificConfiguration.coverageIstanbulReporter,
-	{
-		dir: helpers.root("reports/coverage/packages"),
-	}
-);
+starkCoreSpecificConfiguration.coverageIstanbulReporter = Object.assign(starkCoreSpecificConfiguration.coverageIstanbulReporter, {
+	dir: helpers.root("reports/coverage/packages")
+});
 
 // export the configuration function that karma expects and simply return the stark configuration
 module.exports = config => {

--- a/packages/stark-core/src/configuration/entities/application/app-config.entity.ts
+++ b/packages/stark-core/src/configuration/entities/application/app-config.entity.ts
@@ -6,8 +6,10 @@ import { StarkApplicationConfig } from "./app-config.entity.intf";
 import { StarkBackend, StarkBackendImpl } from "../../../http/entities/backend/index";
 import { stringMap } from "../../../serialization/index";
 import { StarkValidationErrorsUtil } from "../../../util/index";
-// FIXME Implement the following decorators as before
-// import {StarkMapIsValid, StarkMapNotEmpty} from "../../../validation/decorators";
+// FIXME: cannot import both validation decorators from the barrel due to an issue with angular-compiler
+// see: https://github.com/angular/angular/issues/20931
+import { StarkMapIsValid } from "../../../validation/decorators/map-is-valid/map-is-valid.validator.decorator";
+import { StarkMapNotEmpty } from "../../../validation/decorators/map-not-empty/map-not-empty.validator.decorator";
 
 export class StarkApplicationConfigImpl implements StarkApplicationConfig {
 	@IsDefined()
@@ -115,9 +117,8 @@ export class StarkApplicationConfigImpl implements StarkApplicationConfig {
 	@autoserialize
 	public publicApp: boolean;
 
-	//FIXME Import StarkMapIsValid & StarkMapNotEmpty  from validation/decorators
-	// @StarkMapNotEmpty()
-	// @StarkMapIsValid()
+	@StarkMapNotEmpty()
+	@StarkMapIsValid()
 	@autoserializeAs(stringMap(StarkBackendImpl)) // using custom serialization type (stringMap) to handle ES6 Maps
 	public backends: Map<string, StarkBackend> = new Map<string, StarkBackend>();
 

--- a/packages/stark-core/src/configuration/entities/language/language.entity.ts
+++ b/packages/stark-core/src/configuration/entities/language/language.entity.ts
@@ -3,14 +3,15 @@
 import { IsNotEmpty, IsString, Matches } from "class-validator";
 import { autoserialize } from "cerialize";
 import { StarkLanguage } from "./language.entity.intf";
-
-// import {StarkIsSupportedLanguage} from "../../validation/decorators/is-supported-language";
+// FIXME: cannot import both validation decorator from the barrel due to an issue with angular-compiler
+// see: https://github.com/angular/angular/issues/20931
+import { StarkIsSupportedLanguage } from "../../../validation/decorators/is-supported-language/is-supported-language.validator.decorator";
 
 export class StarkLanguageImpl implements StarkLanguage {
 	@IsNotEmpty()
 	@IsString()
 	@Matches(/^[a-z]{2}-[A-Z]{2}$/)
-	// @StarkIsSupportedLanguage()  // FIXME: add Stark validator decorators
+	@StarkIsSupportedLanguage()
 	@autoserialize
 	public isoCode: string;
 

--- a/packages/stark-core/src/http/services/http.service.spec.ts
+++ b/packages/stark-core/src/http/services/http.service.spec.ts
@@ -1192,9 +1192,9 @@ describe("Service: StarkHttpService", () => {
 					item: mockResourceWithoutEtag,
 					serializer: mockResourceSerializer
 				};
-				const result: Observable<any> = starkHttpService.executeSingleItemRequest(request);
+				const result: ErrorObservable = <ErrorObservable>starkHttpService.executeSingleItemRequest(request);
 				expect(result instanceof ErrorObservable).toBe(true);
-				expect((<ErrorObservable>result).error).toContain("Unknown request type");
+				expect(result.error).toContain("Unknown request type");
 			});
 		});
 	});
@@ -2376,9 +2376,9 @@ describe("Service: StarkHttpService", () => {
 					item: undefined,
 					serializer: mockResourceSerializer
 				};
-				const result: Observable<any> = starkHttpService.executeCollectionRequest(request);
+				const result: ErrorObservable = <ErrorObservable>starkHttpService.executeCollectionRequest(request);
 				expect(result instanceof ErrorObservable).toBe(true);
-				expect((<ErrorObservable>result).error).toContain("Unknown request type");
+				expect(result.error).toContain("Unknown request type");
 			});
 		});
 	});

--- a/packages/stark-core/src/logging/services/logging.service.spec.ts
+++ b/packages/stark-core/src/logging/services/logging.service.spec.ts
@@ -19,7 +19,7 @@ import { StarkError, StarkErrorImpl } from "../../common/index";
 
 describe("Service: StarkLoggingService", () => {
 	let appConfig: StarkApplicationConfig;
-	let mockStore: Store<any>;
+	let mockStore: Store<StarkCoreApplicationState>;
 	// let mockXSRFService: StarkXSRFService;
 	let loggingService: LoggingServiceHelper;
 	const loggingBackend: StarkBackend = {
@@ -78,9 +78,7 @@ describe("Service: StarkLoggingService", () => {
 			appConfig.loggingFlushDisabled = false;
 			appConfig.backends.delete("logging");
 
-			expect(() => new LoggingServiceHelper(mockStore, appConfig /*, mockXSRFService*/)).toThrowError(
-				"Backend logging is undefined."
-			);
+			expect(() => new LoggingServiceHelper(mockStore, appConfig /*, mockXSRFService*/)).toThrowError(/backend/);
 		});
 
 		it("should throw an error in case the logging flushing is enabled but the loggingFlushPersistSize option is not greater than 0", () => {

--- a/packages/stark-core/src/routing/services/routing.service.spec.ts
+++ b/packages/stark-core/src/routing/services/routing.service.spec.ts
@@ -18,6 +18,7 @@ import CallInfo = jasmine.CallInfo;
 import { StarkRoutingActionTypes } from "../actions/index";
 import Spy = jasmine.Spy;
 import { MockStarkLoggingService } from "../../logging/testing/logging.mock";
+import { StarkCoreApplicationState } from "../../common/store/starkCoreApplicationState";
 
 @Component({ selector: "test-home", template: "HOME" })
 export class HomeComponent {}
@@ -31,7 +32,7 @@ describe("Service: StarkRoutingService", () => {
 
 	let routingService: StarkRoutingServiceImpl;
 	let mockLogger: StarkLoggingService;
-	const mockStore: Store<any> = jasmine.createSpyObj("storeSpy", ["dispatch"]);
+	const mockStore: Store<StarkCoreApplicationState> = jasmine.createSpyObj("storeSpy", ["dispatch"]);
 	const appConfig: Partial<StarkApplicationConfig> = {
 		sessionTimeout: 123,
 		sessionTimeoutWarningPeriod: 13,

--- a/packages/stark-core/src/session/services/session.service.spec.ts
+++ b/packages/stark-core/src/session/services/session.service.spec.ts
@@ -46,7 +46,7 @@ import { starkSessionExpiredStateName } from "../../common/routes/index";
 import { StarkCoreApplicationState } from "../../common/store/index";
 
 describe("Service: StarkSessionService", () => {
-	let mockStore: Store<any>;
+	let mockStore: Store<StarkCoreApplicationState>;
 	let appConfig: StarkApplicationConfig;
 	let mockSession: StarkSession;
 	let mockUser: Partial<StarkUser>;
@@ -336,7 +336,7 @@ describe("Service: StarkSessionService", () => {
 
 		it("should call the destroySession() method only when the logout HTTP request has returned a response (either success or error)", () => {
 			spyOn(sessionService, "destroySession");
-			const logoutHttpResponse$: Subject<any> = new Subject();
+			const logoutHttpResponse$: Subject<string> = new Subject();
 			const sendLogoutRequestSpy: Spy = spyOn(sessionService, "sendLogoutRequest").and.returnValue(logoutHttpResponse$);
 
 			sessionService.logout();

--- a/packages/stark-core/src/session/services/session.service.ts
+++ b/packages/stark-core/src/session/services/session.service.ts
@@ -310,8 +310,7 @@ export class StarkSessionServiceImpl implements StarkSessionService {
 		});
 		// }
 
-		// FIXME Should we create an interface instead of using any ?
-		const pingRequest: HttpRequest<any> = new HttpRequest("GET", <string>this.appConfig.keepAliveUrl, {
+		const pingRequest: HttpRequest<void> = new HttpRequest("GET", <string>this.appConfig.keepAliveUrl, {
 			headers: pingRequestHeaders
 		});
 

--- a/packages/stark-core/src/user/services/user.service.spec.ts
+++ b/packages/stark-core/src/user/services/user.service.spec.ts
@@ -36,6 +36,8 @@ import { StarkHttpStatusCodes } from "../../http/enumerators/index";
 import { StarkSessionService } from "../../session/services/index";
 import { HttpErrorResponse } from "@angular/common/http";
 import { StarkHttpErrorImpl } from "../../http";
+import { StarkMockData } from "../../configuration/entities/mock-data/index";
+import { StarkCoreApplicationState } from "../../common/store/starkCoreApplicationState";
 
 interface StarkUserWithCustomData extends Pick<StarkUser, "uuid" | "username" | "roles"> {
 	[prop: string]: any;
@@ -43,12 +45,12 @@ interface StarkUserWithCustomData extends Pick<StarkUser, "uuid" | "username" | 
 
 describe("Service: StarkUserService", () => {
 	let userService: StarkUserService;
-	let mockStore: Store<any>;
+	let mockStore: Store<StarkCoreApplicationState>;
 	let mockUserRepository: StarkUserRepository;
 	let mockLogger: StarkLoggingService;
 	let mockSessionService: StarkSessionService;
 
-	let mockData: any;
+	let mockData: StarkMockData;
 	let mockUsers: StarkUserWithCustomData[];
 	let mockUserCustomData: { [prop: string]: any };
 	let mockUserCustomData2: { [prop: string]: any };

--- a/packages/stark-core/src/validation/decorators/is-bban/is-bban.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-bban/is-bban.validator.decorator.ts
@@ -36,7 +36,6 @@ class StarkIsBBANConstraint implements ValidatorConstraintInterface {
  * @param property
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkIsBBAN(property: string, validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-bic/is-bic.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-bic/is-bic.validator.decorator.ts
@@ -26,7 +26,6 @@ class StarkIsBICConstraint implements ValidatorConstraintInterface {
  * Validator decorator that uses the StarkIsBIC validator constraint
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkIsBIC(validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-company-number/is-company-number.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-company-number/is-company-number.validator.decorator.ts
@@ -11,7 +11,7 @@ import { starkIsCompanyNumberValidatorName } from "../../validators/is-company-n
  * Validates that the Company Number number provided is valid
  */
 @ValidatorConstraint({ name: starkIsCompanyNumberValidatorName, async: false })
-export class StarkIsCompanyNumberConstraint implements ValidatorConstraintInterface {
+class StarkIsCompanyNumberConstraint implements ValidatorConstraintInterface {
 	public validate(companyNumber: string): boolean {
 		const validator: StarkValidator = getFromContainer<StarkValidatorImpl>(StarkValidatorImpl);
 		return validator.starkIsCompanyNumber(companyNumber);
@@ -26,7 +26,6 @@ export class StarkIsCompanyNumberConstraint implements ValidatorConstraintInterf
  * Validator decorator that uses the StarkIsCompanyNumber validator constraint
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkIsCompanyNumber(validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-establishment-unit-number/is-establishment-unit-number.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-establishment-unit-number/is-establishment-unit-number.validator.decorator.ts
@@ -27,7 +27,6 @@ class StarkIsEstablishmentUnitNumberConstraint implements ValidatorConstraintInt
  * Validator decorator that uses the StarkIsIsEstablishmentUnitNumber validator constraint
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkIsEstablishmentUnitNumber(validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-iban/is-iban.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-iban/is-iban.validator.decorator.ts
@@ -26,7 +26,6 @@ class StarkIsIBANConstraint implements ValidatorConstraintInterface {
  * Validator decorator that uses the StarkIsIBAN validator constraint
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkIsIBAN(validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-isin/is-isin.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-isin/is-isin.validator.decorator.ts
@@ -27,7 +27,6 @@ class StarkIsISINConstraint implements ValidatorConstraintInterface {
  * Validator decorator that uses the StarkIsISIN validator constraint
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkIsISIN(validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-kbo/is-kbo.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-kbo/is-kbo.validator.decorator.ts
@@ -27,7 +27,6 @@ class StarkIsKBOConstraint implements ValidatorConstraintInterface {
  * Validator decorator that uses the StarkIsKBO validator constraint
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkIsKBO(validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-nin/is-nin.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-nin/is-nin.validator.decorator.ts
@@ -36,7 +36,6 @@ class StarkIsNINConstraint implements ValidatorConstraintInterface {
  * @param property
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkIsNIN(property: string, validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/is-supported-language/is-supported-language.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/is-supported-language/is-supported-language.validator.decorator.ts
@@ -26,7 +26,6 @@ class StarkIsSupportedLanguageConstraint implements ValidatorConstraintInterface
  * Validator decorator that uses the StarkIsSupportedLanguage validator constraint
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkIsSupportedLanguage(validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/map-is-valid/map-is-valid.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/map-is-valid/map-is-valid.validator.decorator.ts
@@ -59,7 +59,6 @@ class StarkMapIsValidConstraint implements ValidatorConstraintInterface {
  * Validator decorator that uses the StarkMapIsValid validator constraint
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkMapIsValid(validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {

--- a/packages/stark-core/src/validation/decorators/map-not-empty/map-not-empty.validator.decorator.ts
+++ b/packages/stark-core/src/validation/decorators/map-not-empty/map-not-empty.validator.decorator.ts
@@ -4,7 +4,7 @@ import { ValidatorConstraint, ValidatorConstraintInterface, ValidationOptions, r
 
 import { StarkValidatorImpl } from "../../validator";
 import { StarkValidator } from "../../validator.intf";
-import { starkMapNotEmptyValidatorName } from "../../validators/map-not-empty";
+import { starkMapNotEmptyValidatorName } from "../../validators/map-not-empty/index";
 
 /**
  * StarkMapNotEmpty validator constraint
@@ -26,7 +26,6 @@ class StarkMapNotEmptyConstraint implements ValidatorConstraintInterface {
  * Validator decorator that uses the StarkMapNotEmpty validator constraint
  * @param validationOptions
  * @returns Function
- * @constructor
  */
 export function StarkMapNotEmpty(validationOptions?: ValidationOptions): Function {
 	return (object: object, propertyName: string): void => {


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Stark validator decorators not yet used where they used to be.
- NGC throws an exception due to an issue while handling re-exports (see angular/angular#20931)
- StarkAppMetadata not used in Starter

## What is the new behavior?
Stark validator decorators and StarkAppMetadata are now used. A workaround is implemented to avoid the NGC compilation error (until it is fixed)

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
