### PR TITLE
fix(prettier) Add package-lock.json, coverage and reports folder to prettier ignored files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,8 @@
 .idea/
 .vscode/
 dist/
+coverage/
+reports/
 node_modules/
 package.json
+package-lock.json

--- a/starter/.prettierignore
+++ b/starter/.prettierignore
@@ -3,5 +3,8 @@
 .idea/
 .vscode/
 dist/
+coverage/
+reports/
 node_modules/
 package.json
+package-lock.json


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Prettier takes a useless long time on package-lock.json files and analyzes coverage and reports folder which are ignored by git.

Issue Number: N/A


## What is the new behavior?
Those files/folders are ignored by Prettier

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information