### PR TITLE
chore(core): define InjectionTokens for every service and a forRoot() method for every module

### DIFF
--- a/packages/stark-build/config/tslint.json
+++ b/packages/stark-build/config/tslint.json
@@ -18,7 +18,7 @@
     "use-pipe-transform-interface": true,
     "no-output-named-after-standard-event": true,
     "max-inline-declarations": true,
-//    "no-life-cycle-call": true, // FIXME: throws an exception (Codelyzer v4.3.0). Enable this rule when solved
+    //    "no-life-cycle-call": true, // FIXME: throws an exception (Codelyzer v4.3.0). Enable this rule when solved
     "no-conflicting-life-cycle-hooks": true,
     "enforce-component-selector": true,
     "component-class-suffix": [true, "Component"],

--- a/packages/stark-core/src/common/routes/routes.ts
+++ b/packages/stark-core/src/common/routes/routes.ts
@@ -1,5 +1,5 @@
 import { Location } from "@angular/common";
-import { StarkRoutingService, starkRoutingServiceName, StarkStateConfigWithParams } from "../../routing/services";
+import { StarkRoutingService, STARK_ROUTING_SERVICE, StarkStateConfigWithParams } from "../../routing/services";
 import { StatesModule } from "@uirouter/angular";
 
 export const starkAppInitStateName: string = "starkAppInit";
@@ -26,7 +26,7 @@ export const starkCoreRouteConfig: StatesModule = <any>{
 			resolve: {
 				targetRoute: [
 					"$location",
-					starkRoutingServiceName,
+					STARK_ROUTING_SERVICE,
 					($location: Location, routingService: StarkRoutingService) => {
 						// get the path of the current URL in the browser's navigation bar
 						const targetUrlPath: string = $location.path();

--- a/packages/stark-core/src/configuration.ts
+++ b/packages/stark-core/src/configuration.ts
@@ -1,1 +1,1 @@
-export * from "./configuration/entities"
+export * from "./configuration/entities";

--- a/packages/stark-core/src/http/builder/http-request-builder.spec.ts
+++ b/packages/stark-core/src/http/builder/http-request-builder.spec.ts
@@ -15,14 +15,7 @@ import { StarkHttpGetRequestBuilder } from "./http-get-request-builder.intf";
 import { StarkHttpGetCollectionRequestBuilder } from "./http-get-collection-request-builder.intf";
 import { StarkHttpSearchRequestBuilder } from "./http-search-request-builder.intf";
 import { StarkHttpUpdateRequestBuilder } from "./http-update-request-builder.intf";
-import {
-	StarkBackend,
-	StarkBackendImpl,
-	StarkHttpRequest,
-	StarkHttpRequestType,
-	StarkResource,
-	StarkSortItemImpl
-} from "../entities";
+import { StarkBackend, StarkBackendImpl, StarkHttpRequest, StarkHttpRequestType, StarkResource, StarkSortItemImpl } from "../entities";
 import { StarkLanguages } from "../../configuration/entities";
 import { stringMap } from "../../serialization";
 import { StarkHttpEchoType, StarkHttpHeaders, StarkHttpQueryParameters, StarkSortOrder } from "../constants";

--- a/packages/stark-core/src/http/services/http.service.intf.ts
+++ b/packages/stark-core/src/http/services/http.service.intf.ts
@@ -1,8 +1,10 @@
+import { InjectionToken } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
 import { StarkCollectionResponseWrapper, StarkHttpRequest, StarkResource, StarkSingleItemResponseWrapper } from "../entities";
 import { Observable } from "rxjs/Observable";
-import { HttpClient } from "@angular/common/http";
 
 export const starkHttpServiceName: string = "StarkHttpService";
+export const STARK_HTTP_SERVICE: InjectionToken<StarkHttpService<any>> = new InjectionToken<StarkHttpService<any>>(starkHttpServiceName);
 
 /**
  * Stark Http Service

--- a/packages/stark-core/src/http/services/http.service.ts
+++ b/packages/stark-core/src/http/services/http.service.ts
@@ -10,7 +10,7 @@ import { catchError } from "rxjs/operators/catchError";
 import { map } from "rxjs/operators/map";
 import { retryWhen } from "rxjs/operators/retryWhen";
 import { mergeMap } from "rxjs/operators/mergeMap";
-import { Injectable } from "@angular/core";
+import { Inject, Injectable } from "@angular/core";
 import { HttpClient, HttpHeaders, HttpResponse, HttpErrorResponse } from "@angular/common/http";
 
 import { StarkHttpService, starkHttpServiceName } from "./http.service.intf";
@@ -28,8 +28,8 @@ import {
 	StarkSingleItemResponseWrapper,
 	StarkSingleItemResponseWrapperImpl
 } from "../entities";
-import { StarkLoggingService } from "../../logging";
-import { StarkSessionService } from "../../session";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "../../logging";
+import { StarkSessionService, STARK_SESSION_SERVICE } from "../../session";
 
 /**
  * @ngdoc service
@@ -44,15 +44,11 @@ import { StarkSessionService } from "../../session";
 export class StarkHttpServiceImpl<P extends StarkResource> implements StarkHttpService<P> {
 	protected retryDelay: number = 1000;
 
-	private logger: StarkLoggingService;
-	private sessionService: StarkSessionService;
-	private httpClient: HttpClient;
-
 	// FIXME: uncomment these lines once LoggingService and SessionService are implemented
 	public constructor(
-		/*@Inject(starkLoggingServiceName)*/ logger: StarkLoggingService,
-		/*@Inject(starkSessionServiceName)*/ sessionService: StarkSessionService,
-		httpClient: HttpClient
+		@Inject(STARK_LOGGING_SERVICE) private logger: StarkLoggingService,
+		@Inject(STARK_SESSION_SERVICE) private sessionService: StarkSessionService,
+		private httpClient: HttpClient
 	) {
 		this.logger = logger;
 		this.sessionService = sessionService;

--- a/packages/stark-core/src/http/testing.ts
+++ b/packages/stark-core/src/http/testing.ts
@@ -1,1 +1,1 @@
-export * from "./testing/http.mock"
+export * from "./testing/http.mock";

--- a/packages/stark-core/src/logging/logging.module.ts
+++ b/packages/stark-core/src/logging/logging.module.ts
@@ -1,17 +1,37 @@
-import { NgModule } from "@angular/core";
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from "@angular/core";
 import { ActionReducerMap, StoreModule } from "@ngrx/store";
 
 import { loggingReducer, StarkLoggingState } from "./reducers";
 import { StarkLoggingActions } from "./actions";
-import { StarkLoggingServiceImpl, starkLoggingServiceName } from "./services";
+import { StarkLoggingServiceImpl, STARK_LOGGING_SERVICE } from "./services";
 
 const reducers: ActionReducerMap<StarkLoggingState, StarkLoggingActions> = {
 	logging: loggingReducer
 };
 
 @NgModule({
-	imports: [StoreModule.forFeature("StarkLogging", reducers)],
-	declarations: [],
-	providers: [{ provide: starkLoggingServiceName, useClass: StarkLoggingServiceImpl }]
+	imports: [StoreModule.forFeature("StarkLogging", reducers)]
 })
-export class StarkLoggingModule {}
+export class StarkLoggingModule {
+	// instantiate the services only once since they should be singletons
+	// so the forRoot() should be called only by the AppModule
+	// see https://angular.io/guide/singleton-services#forroot
+	public static forRoot(): ModuleWithProviders {
+		return {
+			ngModule: StarkLoggingModule,
+			providers: [{ provide: STARK_LOGGING_SERVICE, useClass: StarkLoggingServiceImpl }]
+		};
+	}
+
+	// prevent this module from being re-imported
+	// see https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
+	public constructor(
+		@Optional()
+		@SkipSelf()
+		parentModule: StarkLoggingModule
+	) {
+		if (parentModule) {
+			throw new Error("StarkLoggingModule is already loaded. Import it in the AppModule only");
+		}
+	}
+}

--- a/packages/stark-core/src/logging/services/logging.service.intf.ts
+++ b/packages/stark-core/src/logging/services/logging.service.intf.ts
@@ -1,6 +1,8 @@
+import { InjectionToken } from "@angular/core";
 import { StarkError } from "../../common";
 
 export const starkLoggingServiceName: string = "StarkLoggingService";
+export const STARK_LOGGING_SERVICE: InjectionToken<StarkLoggingService> = new InjectionToken<StarkLoggingService>(starkLoggingServiceName);
 
 /**
  * Stark Logging Service.

--- a/packages/stark-core/src/routing/routing.module.ts
+++ b/packages/stark-core/src/routing/routing.module.ts
@@ -1,9 +1,30 @@
-import { NgModule } from "@angular/core";
-import { StarkRoutingServiceImpl, starkRoutingServiceName } from "./services";
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from "@angular/core";
+import { UIRouterModule } from "@uirouter/angular";
+import { StarkRoutingServiceImpl, STARK_ROUTING_SERVICE } from "./services";
 
 @NgModule({
-	imports: [],
-	declarations: [],
-	providers: [{ provide: starkRoutingServiceName, useClass: StarkRoutingServiceImpl }]
+	imports: [UIRouterModule.forChild()]
 })
-export class StarkRoutingModule {}
+export class StarkRoutingModule {
+	// instantiate the services only once since they should be singletons
+	// so the forRoot() should be called only by the AppModule
+	// see https://angular.io/guide/singleton-services#forroot
+	public static forRoot(): ModuleWithProviders {
+		return {
+			ngModule: StarkRoutingModule,
+			providers: [{ provide: STARK_ROUTING_SERVICE, useClass: StarkRoutingServiceImpl }]
+		};
+	}
+
+	// prevent this module from being re-imported
+	// see https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
+	public constructor(
+		@Optional()
+		@SkipSelf()
+		parentModule: StarkRoutingModule
+	) {
+		if (parentModule) {
+			throw new Error("StarkRoutingModule is already loaded. Import it in the AppModule only");
+		}
+	}
+}

--- a/packages/stark-core/src/routing/services/routing.service.intf.ts
+++ b/packages/stark-core/src/routing/services/routing.service.intf.ts
@@ -2,8 +2,10 @@ import { Observable } from "rxjs/Observable";
 import { HookFn, HookMatchCriteria, HookRegOptions, RawParams, StateDeclaration, StateObject, TransitionOptions } from "@uirouter/core";
 
 import { StarkStateConfigWithParams } from "./state-config-with-params.intf";
+import { InjectionToken } from "@angular/core";
 
 export const starkRoutingServiceName: string = "StarkRoutingService";
+export const STARK_ROUTING_SERVICE: InjectionToken<StarkRoutingService> = new InjectionToken<StarkRoutingService>(starkRoutingServiceName);
 
 /**
  * Stark Routing Service.

--- a/packages/stark-core/src/routing/services/routing.service.ts
+++ b/packages/stark-core/src/routing/services/routing.service.ts
@@ -4,7 +4,7 @@ import { fromPromise } from "rxjs/observable/fromPromise";
 import { empty } from "rxjs/observable/empty";
 import { Inject, Injectable } from "@angular/core";
 
-import { StarkLoggingService, starkLoggingServiceName } from "../../logging/services";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "../../logging/services";
 import { StarkRoutingService, starkRoutingServiceName } from "./routing.service.intf";
 import {
 	Navigate,
@@ -71,11 +71,11 @@ export class StarkRoutingServiceImpl implements StarkRoutingService {
 	private _starkStateHistory: StarkState[];
 
 	public constructor(
-		@Inject(starkLoggingServiceName) private logger: StarkLoggingService,
+		@Inject(STARK_LOGGING_SERVICE) private logger: StarkLoggingService,
 		private store: Store<StarkCoreApplicationState>,
 		@Inject(STARK_APP_CONFIG) private appConfig: StarkApplicationConfig,
-		@Inject("$state") private $state: StateService,
-		@Inject("$transitions") private $transitions: TransitionService
+		private $state: StateService,
+		private $transitions: TransitionService
 	) {
 		this.appConfig = appConfig;
 

--- a/packages/stark-core/src/session/services/session.service.intf.ts
+++ b/packages/stark-core/src/session/services/session.service.intf.ts
@@ -1,7 +1,9 @@
+import { InjectionToken } from "@angular/core";
 import { Observable } from "rxjs/Observable";
 import { StarkUser } from "../../user/entities";
 
 export const starkSessionServiceName: string = "StarkSessionService";
+export const STARK_SESSION_SERVICE: InjectionToken<StarkSessionService> = new InjectionToken<StarkSessionService>(starkSessionServiceName);
 
 /**
  * Stark Session Service.

--- a/packages/stark-core/src/session/services/session.service.ts
+++ b/packages/stark-core/src/session/services/session.service.ts
@@ -12,9 +12,9 @@ import { map } from "rxjs/operators/map";
 import { defer } from "rxjs/observable/defer";
 import { validateSync } from "class-validator";
 
-import { StarkLoggingService, starkLoggingServiceName } from "../../logging/services";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "../../logging/services";
 import { StarkSessionService, starkSessionServiceName } from "./session.service.intf";
-import { StarkRoutingService, starkRoutingServiceName, StarkRoutingTransitionHook } from "../../routing/services";
+import { StarkRoutingService, STARK_ROUTING_SERVICE, StarkRoutingTransitionHook } from "../../routing/services";
 import { StarkApplicationConfig, STARK_APP_CONFIG } from "../../configuration/entities";
 import { StarkPreAuthentication, StarkSession } from "../entities";
 import { StarkUser } from "../../user/entities";
@@ -76,8 +76,8 @@ export class StarkSessionServiceImpl implements StarkSessionService {
 
 	public constructor(
 		public store: Store<StarkCoreApplicationState>,
-		@Inject(starkLoggingServiceName) public logger: StarkLoggingService,
-		@Inject(starkRoutingServiceName) public routingService: StarkRoutingService,
+		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
+		@Inject(STARK_ROUTING_SERVICE) public routingService: StarkRoutingService,
 		@Inject(STARK_APP_CONFIG) private appConfig: StarkApplicationConfig,
 		// FIXME Uncomment when XSRF Service is implemented
 		// @Inject(starkXSRFServiceName) public xsrfService: StarkXSRFService,

--- a/packages/stark-core/src/session/session.module.ts
+++ b/packages/stark-core/src/session/session.module.ts
@@ -1,17 +1,36 @@
-import { NgModule } from "@angular/core";
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from "@angular/core";
 import { ActionReducerMap, StoreModule } from "@ngrx/store";
-
 import { sessionReducer, StarkSessionState } from "./reducers";
 import { StarkSessionActions } from "./actions";
-import { StarkSessionServiceImpl, starkSessionServiceName } from "./services";
+import { StarkSessionServiceImpl, STARK_SESSION_SERVICE } from "./services";
 
 const reducers: ActionReducerMap<StarkSessionState, StarkSessionActions> = {
 	session: sessionReducer
 };
 
 @NgModule({
-	imports: [StoreModule.forFeature("StarkSession", reducers)],
-	declarations: [],
-	providers: [{ provide: starkSessionServiceName, useClass: StarkSessionServiceImpl }]
+	imports: [StoreModule.forFeature("StarkSession", reducers)]
 })
-export class StarkSessionModule {}
+export class StarkSessionModule {
+	// instantiate the services only once since they should be singletons
+	// so the forRoot() should be called only by the AppModule
+	// see https://angular.io/guide/singleton-services#forroot
+	public static forRoot(): ModuleWithProviders {
+		return {
+			ngModule: StarkSessionModule,
+			providers: [{ provide: STARK_SESSION_SERVICE, useClass: StarkSessionServiceImpl }]
+		};
+	}
+
+	// prevent this module from being re-imported
+	// see https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
+	public constructor(
+		@Optional()
+		@SkipSelf()
+		parentModule: StarkSessionModule
+	) {
+		if (parentModule) {
+			throw new Error("StarkSessionModule is already loaded. Import it in the AppModule only");
+		}
+	}
+}

--- a/packages/stark-core/src/user/repository/user.repository.ts
+++ b/packages/stark-core/src/user/repository/user.repository.ts
@@ -5,8 +5,8 @@ import { StarkUser } from "../entities";
 import { StarkHttpRequest, StarkSingleItemResponseWrapper } from "../../http/entities";
 import { StarkApplicationConfig, STARK_APP_CONFIG } from "../../configuration/entities/application";
 import { StarkUserRepository } from "./user.repository.intf";
-import { StarkLoggingService, starkLoggingServiceName } from "../../logging/services/logging.service.intf";
-import { StarkHttpService, starkHttpServiceName } from "../../http/services";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "../../logging/services/logging.service.intf";
+import { StarkHttpService, STARK_HTTP_SERVICE } from "../../http/services";
 import { AbstractStarkHttpRepository } from "../../http/repository";
 
 /**
@@ -21,8 +21,8 @@ import { AbstractStarkHttpRepository } from "../../http/repository";
 @Injectable()
 export class StarkUserRepositoryImpl extends AbstractStarkHttpRepository<StarkUser> implements StarkUserRepository {
 	public constructor(
-		@Inject(starkHttpServiceName) starkHttpService: StarkHttpService<StarkUser>,
-		@Inject(starkLoggingServiceName) logger: StarkLoggingService,
+		@Inject(STARK_HTTP_SERVICE) starkHttpService: StarkHttpService<StarkUser>,
+		@Inject(STARK_LOGGING_SERVICE) logger: StarkLoggingService,
 		@Inject(STARK_APP_CONFIG) appConfig: StarkApplicationConfig
 	) {
 		super(starkHttpService, logger, appConfig.getBackend("userProfile"), "security/userprofile");

--- a/packages/stark-core/src/user/services/user.service.intf.ts
+++ b/packages/stark-core/src/user/services/user.service.intf.ts
@@ -1,7 +1,9 @@
+import { InjectionToken } from "@angular/core";
 import { Observable } from "rxjs/Observable";
 import { StarkUser } from "../entities";
 
 export const starkUserServiceName: string = "StarkUserService";
+export const STARK_USER_SERVICE: InjectionToken<StarkUserService> = new InjectionToken<StarkUserService>(starkUserServiceName);
 
 /**
  * Stark User Service.

--- a/packages/stark-core/src/user/services/user.service.ts
+++ b/packages/stark-core/src/user/services/user.service.ts
@@ -17,8 +17,8 @@ import {
 	GetAllUsersSuccess,
 	GetAllUsersFailure
 } from "../actions";
-import { StarkLoggingService, starkLoggingServiceName } from "../../logging/services";
-import { StarkSessionService, starkSessionServiceName } from "../../session/services";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "../../logging/services";
+import { StarkSessionService, STARK_SESSION_SERVICE } from "../../session/services";
 import { StarkUserService, starkUserServiceName } from "./user.service.intf";
 import { StarkUserRepository, starkUserRepositoryName } from "../repository";
 import { STARK_MOCK_DATA, StarkMockData } from "../../configuration/entities/mock-data";
@@ -43,12 +43,11 @@ const userErrorMessagePrefix: string = starkUserServiceName + ": User defined is
 @Injectable()
 export class StarkUserServiceImpl implements StarkUserService {
 	public user$: Observable<StarkUser | undefined>;
-	private sessionService: StarkSessionService;
 	public userProfiles: StarkUser[];
 
 	public constructor(
-		@Inject(starkLoggingServiceName) public logger: StarkLoggingService,
-		@Inject(starkSessionServiceName) sessionService: StarkSessionService,
+		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
+		@Inject(STARK_SESSION_SERVICE) private sessionService: StarkSessionService,
 		public store: Store<StarkCoreApplicationState>,
 		@Inject(starkUserRepositoryName) public userRepository: StarkUserRepository,
 		// FIXME Use starkMockData

--- a/packages/stark-core/src/user/user.module.ts
+++ b/packages/stark-core/src/user/user.module.ts
@@ -1,9 +1,27 @@
-import { NgModule } from "@angular/core";
-import { StarkUserServiceImpl, starkUserServiceName } from "./services";
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from "@angular/core";
+import { StarkUserServiceImpl, STARK_USER_SERVICE } from "./services";
 
-@NgModule({
-	imports: [],
-	declarations: [],
-	providers: [{ provide: starkUserServiceName, useClass: StarkUserServiceImpl }]
-})
-export class StarkUserModule {}
+@NgModule({})
+export class StarkUserModule {
+	// instantiate the services only once since they should be singletons
+	// so the forRoot() should be called only by the AppModule
+	// see https://angular.io/guide/singleton-services#forroot
+	public static forRoot(): ModuleWithProviders {
+		return {
+			ngModule: StarkUserModule,
+			providers: [{ provide: STARK_USER_SERVICE, useClass: StarkUserServiceImpl }]
+		};
+	}
+
+	// prevent this module from being re-imported
+	// see https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
+	public constructor(
+		@Optional()
+		@SkipSelf()
+		parentModule: StarkUserModule
+	) {
+		if (parentModule) {
+			throw new Error("StarkUserModule is already loaded. Import it in the AppModule only");
+		}
+	}
+}

--- a/starter/src/app/+barrel/+child-barrel/child-barrel.component.ts
+++ b/starter/src/app/+barrel/+child-barrel/child-barrel.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from "@angular/core";
-import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "@nationalbankbelgium/stark-core";
 /**
  * We're loading this component asynchronously
  * We are using some magic with es6-promise-loader that will wrap the module with a Promise
@@ -15,7 +15,7 @@ console.log("`ChildBarrel` component loaded asynchronously");
   `
 })
 export class ChildBarrelComponent implements OnInit {
-	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+	public constructor(@Inject(STARK_LOGGING_SERVICE) public loggingService: StarkLoggingService) {}
 
 	public ngOnInit(): void {
 		this.loggingService.debug("hello from `ChildBarrel` component");

--- a/starter/src/app/+barrel/barrel.component.ts
+++ b/starter/src/app/+barrel/barrel.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from "@angular/core";
-import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "@nationalbankbelgium/stark-core";
 /**
  * We're loading this component asynchronously
  * We are using some magic with es6-promise-loader that will wrap the module with a Promise
@@ -13,7 +13,7 @@ console.log("`Barrel` component loaded asynchronously");
 	templateUrl: "./barrel.component.html"
 })
 export class BarrelComponent implements OnInit {
-	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+	public constructor(@Inject(STARK_LOGGING_SERVICE) public loggingService: StarkLoggingService) {}
 
 	public ngOnInit(): void {
 		this.loggingService.debug("hello from `Barrel` component");

--- a/starter/src/app/+detail/+child-detail/child-detail.component.ts
+++ b/starter/src/app/+detail/+child-detail/child-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from "@angular/core";
-import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "@nationalbankbelgium/stark-core";
 /**
  * We're loading this component asynchronously
  * We are using some magic with es6-promise-loader that will wrap the module with a Promise
@@ -15,7 +15,7 @@ console.log("`ChildDetail` component loaded asynchronously");
   `
 })
 export class ChildDetailComponent implements OnInit {
-	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+	public constructor(@Inject(STARK_LOGGING_SERVICE) public loggingService: StarkLoggingService) {}
 
 	public ngOnInit(): void {
 		this.loggingService.debug("hello from `ChildDetail` component");

--- a/starter/src/app/+detail/detail.component.ts
+++ b/starter/src/app/+detail/detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from "@angular/core";
-import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "@nationalbankbelgium/stark-core";
 /**
  * We're loading this component asynchronously
  * We are using some magic with es6-promise-loader that will wrap the module with a Promise
@@ -13,7 +13,7 @@ console.log("`Detail` component loaded asynchronously");
 	templateUrl: "./detail.component.html"
 })
 export class DetailComponent implements OnInit {
-	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+	public constructor(@Inject(STARK_LOGGING_SERVICE) public loggingService: StarkLoggingService) {}
 
 	public ngOnInit(): void {
 		this.loggingService.debug("hello from `Detail` component");

--- a/starter/src/app/+dev-module/dev-module.component.ts
+++ b/starter/src/app/+dev-module/dev-module.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject, OnInit } from "@angular/core";
-import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "@nationalbankbelgium/stark-core";
 
 @Component({
 	selector: "dev-module",
@@ -8,7 +8,7 @@ import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgi
   `
 })
 export class DevModuleComponent implements OnInit {
-	public constructor(@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService) {}
+	public constructor(@Inject(STARK_LOGGING_SERVICE) public loggingService: StarkLoggingService) {}
 
 	public ngOnInit(): void {
 		this.loggingService.debug("hello from `DevModule` component");

--- a/starter/src/app/about/about.component.spec.ts
+++ b/starter/src/app/about/about.component.spec.ts
@@ -6,9 +6,8 @@ import {
 	StarkApplicationConfig,
 	StarkBackend,
 	StarkBackendAuthenticationTypes,
-	StarkLoggingModule,
 	StarkLoggingService,
-	starkLoggingServiceName
+	STARK_LOGGING_SERVICE
 } from "@nationalbankbelgium/stark-core";
 
 /**
@@ -36,7 +35,7 @@ describe("About", () => {
 
 	beforeEach(() =>
 		TestBed.configureTestingModule({
-			imports: [StoreModule.forRoot({}), StarkLoggingModule],
+			imports: [StoreModule.forRoot({})],
 			providers: [
 				/**
 				 * Provide a better mock.
@@ -53,17 +52,16 @@ describe("About", () => {
 					}
 				},
 				AboutComponent,
-				{ provide: STARK_APP_CONFIG, useValue: mockStarkAppConfig }
+				{ provide: STARK_APP_CONFIG, useValue: mockStarkAppConfig },
+				{ provide: STARK_LOGGING_SERVICE, useValue: jasmine.createSpyObj("StarkLoggingService", ["debug", "warn"]) }
 			]
-		})
-	);
+		}));
 
 	it(
 		"should log ngOnInit",
 		inject([AboutComponent], (about: AboutComponent) => {
-			logger = TestBed.get(starkLoggingServiceName);
+			logger = TestBed.get(STARK_LOGGING_SERVICE);
 
-			spyOn(logger, "debug");
 			expect(logger.debug).not.toHaveBeenCalled();
 
 			about.ngOnInit();

--- a/starter/src/app/about/about.component.ts
+++ b/starter/src/app/about/about.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, Input, OnInit } from "@angular/core";
 // import { Transition } from '@uirouter/angular';
 import { Observable } from "rxjs/Observable";
-import { StarkLoggingService, starkLoggingServiceName } from "@nationalbankbelgium/stark-core";
+import { StarkLoggingService, STARK_LOGGING_SERVICE } from "@nationalbankbelgium/stark-core";
 
 @Component({
 	selector: "about",
@@ -15,7 +15,7 @@ export class AboutComponent implements OnInit {
 	public localState: any;
 	public constructor(
 		// public transition: Transition   // the last transition could be injected if needed
-		@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService
+		@Inject(STARK_LOGGING_SERVICE) public loggingService: StarkLoggingService
 	) {}
 
 	public ngOnInit(): void {

--- a/starter/src/app/app.component.spec.ts
+++ b/starter/src/app/app.component.spec.ts
@@ -14,19 +14,17 @@ describe(`App`, () => {
 	/**
 	 * async beforeEach
 	 */
-	beforeEach(
-		async(() => {
-			TestBed.configureTestingModule({
-				declarations: [AppComponent],
-				schemas: [NO_ERRORS_SCHEMA],
-				providers: [AppState]
-			})
-				/**
-				 * Compile template and css
-				 */
-				.compileComponents();
+	beforeEach(async(() => {
+		TestBed.configureTestingModule({
+			declarations: [AppComponent],
+			schemas: [NO_ERRORS_SCHEMA],
+			providers: [AppState]
 		})
-	);
+			/**
+			 * Compile template and css
+			 */
+			.compileComponents();
+	}));
 
 	/**
 	 * Synchronous beforeEach

--- a/starter/src/app/app.module.ts
+++ b/starter/src/app/app.module.ts
@@ -2,6 +2,8 @@ import { NgModule, NgModuleFactoryLoader, SystemJsNgModuleLoader } from "@angula
 import { BrowserModule } from "@angular/platform-browser";
 import { FormsModule } from "@angular/forms";
 import { UIRouterModule } from "@uirouter/angular";
+import { NgIdleModule } from "@ng-idle/core";
+import { TranslateModule } from "@ngx-translate/core";
 import { validateSync } from "class-validator";
 import { ActionReducer, ActionReducerMap, MetaReducer, StoreModule } from "@ngrx/store";
 import { storeFreeze } from "ngrx-store-freeze";
@@ -17,11 +19,12 @@ import {
 	StarkApplicationMetadataImpl,
 	StarkHttpModule,
 	StarkLoggingModule,
+	StarkRoutingModule,
+	StarkSessionModule,
 	StarkValidationErrorsUtil
 } from "@nationalbankbelgium/stark-core";
 import { routerConfigFn } from "./router.config";
 import { Deserialize } from "cerialize";
-
 /*
  * Platform and Environment providers/directives/pipes
  */
@@ -35,7 +38,6 @@ import { AboutComponent } from "./about";
 import { NoContentComponent } from "./no-content";
 import { XLargeDirective } from "./home/x-large";
 import { DevModuleModule } from "./+dev-module";
-
 /* tslint:disable:no-import-side-effect */
 import "../styles/styles.scss";
 /* tslint:enable */
@@ -103,8 +105,6 @@ export const metaReducers: MetaReducer<State>[] = !environment.production ? [log
 		BrowserModule,
 		BrowserAnimationsModule,
 		FormsModule,
-		StarkHttpModule,
-		StarkLoggingModule,
 		StoreModule.forRoot(reducers, {
 			metaReducers
 		}),
@@ -114,6 +114,12 @@ export const metaReducers: MetaReducer<State>[] = !environment.production ? [log
 			otherwise: { state: "otherwise" },
 			config: routerConfigFn
 		}),
+		TranslateModule.forRoot(),
+		NgIdleModule.forRoot(),
+		StarkHttpModule.forRoot(),
+		StarkLoggingModule.forRoot(),
+		StarkSessionModule.forRoot(),
+		StarkRoutingModule.forRoot(),
 
 		/**
 		 * This section will import the `DevModuleModule` only in certain build types.

--- a/starter/src/app/home/home.component.ts
+++ b/starter/src/app/home/home.component.ts
@@ -1,18 +1,21 @@
 import { Component, Inject, OnInit } from "@angular/core";
 import {
+	STARK_HTTP_SERVICE,
+	STARK_LOGGING_SERVICE,
+	STARK_SESSION_SERVICE,
 	StarkBackend,
 	StarkBackendAuthenticationTypes,
 	StarkCollectionResponseWrapper,
+	StarkErrorImpl,
 	StarkHttpErrorWrapper,
 	StarkHttpRequestType,
 	StarkHttpSerializer,
 	StarkHttpSerializerImpl,
 	StarkHttpService,
-	starkHttpServiceName,
 	StarkLoggingService,
-	starkLoggingServiceName,
+	StarkSessionService,
 	StarkSingleItemResponseWrapper,
-	StarkErrorImpl
+	StarkUser
 } from "@nationalbankbelgium/stark-core";
 import { Observable } from "rxjs/Observable";
 
@@ -52,8 +55,9 @@ export class HomeComponent implements OnInit {
 	public constructor(
 		public appState: AppState,
 		public title: Title,
-		@Inject(starkHttpServiceName) public httpService: StarkHttpService<any>,
-		@Inject(starkLoggingServiceName) public loggingService: StarkLoggingService
+		@Inject(STARK_HTTP_SERVICE) public httpService: StarkHttpService<any>,
+		@Inject(STARK_LOGGING_SERVICE) public loggingService: StarkLoggingService,
+		@Inject(STARK_SESSION_SERVICE) public sessionService: StarkSessionService
 	) {}
 
 	public ngOnInit(): void {
@@ -61,6 +65,18 @@ export class HomeComponent implements OnInit {
 		/**
 		 * this.title.getData().subscribe(data => this.data = data);
 		 */
+		this.loginUser();
+	}
+
+	public loginUser(): void {
+		const user: StarkUser = {
+			uuid: "abc123",
+			username: "John",
+			firstName: "Doe",
+			lastName: "Smith",
+			roles: ["dummy role"]
+		};
+		this.sessionService.login(user);
 	}
 
 	public submitState(value: string): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- The Stark modules define all their providers every time they are imported from another module, this makes Angular create a new instance of such modules every time.
- Due to the injection tokens of the Stark services being just a string, there is no type checking provided when injecting those services.

Issue Number: N/A


## What is the new behavior?
- The Stark core modules should be imported from the AppModule calling the forRoot() method to prevent Angular from creating a nbew instante the Stark services. In case the forRoot() method is called by more than one module, then an error is thrown.
- Now all Stark services have an injection token which provides full type checking support which will be useful when the developer wants to provide his own implementation of the Stark services.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
