### PR TITLE
feat(stark-starter): add NgIdleKeepAlive module in app module

### DIFF
--- a/starter/src/app/app.module.ts
+++ b/starter/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserModule } from "@angular/platform-browser";
 import { FormsModule } from "@angular/forms";
 import { UIRouterModule } from "@uirouter/angular";
 import { NgIdleModule } from "@ng-idle/core";
+import { NgIdleKeepaliveModule } from "@ng-idle/keepalive";
 import { validateSync } from "class-validator";
 import { ActionReducer, ActionReducerMap, MetaReducer, StoreModule } from "@ngrx/store";
 import { storeFreeze } from "ngrx-store-freeze";
@@ -132,6 +133,7 @@ export const metaReducers: MetaReducer<State>[] = !environment.production ? [log
 		}),
 		TranslateModule.forRoot(),
 		NgIdleModule.forRoot(),
+		NgIdleKeepaliveModule.forRoot(), // FIXME: disabled in stark-app-config.json for now until json-server is integrated
 		StarkHttpModule.forRoot(),
 		StarkLoggingModule.forRoot(),
 		StarkSessionModule.forRoot(),

--- a/starter/src/stark-app-config.json
+++ b/starter/src/stark-app-config.json
@@ -10,6 +10,7 @@
   "sessionTimeoutWarningPeriod": 20,
   "keepAliveUrl": "http://localhost:5000/keepalive",
   "keepAliveInterval": 20,
+  "keepAliveDisabled": true,
   "angularDebugInfoEnabled": null,
   "debugLoggingEnabled": null,
   "loggingFlushPersistSize": 50,


### PR DESCRIPTION
ISSUES CLOSED: #261 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
NgIdleKeepAlive not imported in the App module of the Starter.

Issue Number: #261 


## What is the new behavior?
NgIdleAlive is imported now in the App module although it is not enabled by the moment (keepAliveDisabled: true) until `json-server` is integrated in the Starter

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
