### PR TITLE
build(testing): create 'testing' subpackage for stark-core and stark-ui to isolate testing resources

### DIFF
--- a/build-functions.sh
+++ b/build-functions.sh
@@ -273,7 +273,7 @@ N="
     BASE_DIR=$(basename "${DIR}")
     # Skip over directories that are not nested entry points
     [[ -e ${DIR}/tsconfig-build.json && "${BASE_DIR}" != "integrationtest" ]] || continue
-    compilePackage ${DIR} ${2}/${BASE_DIR} ${3} ${4}
+    compilePackage ${DIR} ${2}/${BASE_DIR} ${3} ${4:-}
   done
 }
 

--- a/packages/stark-core/src/modules/http.ts
+++ b/packages/stark-core/src/modules/http.ts
@@ -5,5 +5,4 @@ export * from "./http/enumerators";
 export * from "./http/repository";
 export * from "./http/serializer";
 export * from "./http/services";
-export * from "./http/testing";
 export * from "./http/http.module";

--- a/packages/stark-core/src/modules/http/repository/http-abstract-repository.spec.ts
+++ b/packages/stark-core/src/modules/http/repository/http-abstract-repository.spec.ts
@@ -12,7 +12,7 @@ import {
 import { StarkHttpService } from "../services/http.service.intf";
 import { MockStarkHttpService } from "../testing";
 import { MockStarkLoggingService } from "../../logging/testing";
-import { StarkLoggingService } from "../../logging";
+import { StarkLoggingService } from "../../logging/services";
 import { StarkHttpRequestBuilderImpl } from "../builder";
 import { StarkHttpSerializer, StarkHttpSerializerImpl } from "../serializer";
 import createSpyObj = jasmine.createSpyObj;

--- a/packages/stark-core/src/modules/http/repository/http-abstract-repository.ts
+++ b/packages/stark-core/src/modules/http/repository/http-abstract-repository.ts
@@ -12,7 +12,7 @@ import {
 	StarkHttpUpdateRequestParams
 } from "../builder";
 import { StarkHttpService } from "../services/http.service.intf";
-import { StarkLoggingService } from "../../logging";
+import { StarkLoggingService } from "../../logging/services";
 import { StarkSerializable } from "../../../serialization";
 import { StarkHttpSerializer, StarkHttpSerializerImpl } from "../serializer";
 

--- a/packages/stark-core/src/modules/http/services/http.service.spec.ts
+++ b/packages/stark-core/src/modules/http/services/http.service.spec.ts
@@ -31,11 +31,11 @@ import {
 
 import { StarkHttpHeaders, StarkSortOrder } from "../constants";
 import { StarkHttpStatusCodes } from "../enumerators";
-import { StarkLoggingService } from "../../logging";
+import { StarkLoggingService } from "../../logging/services";
+import { StarkSessionService } from "../../session/services";
 import { MockStarkLoggingService } from "../../logging/testing";
 import { MockStarkSessionService } from "../../session/testing";
 import { StarkHttpSerializer, StarkHttpSerializerImpl } from "../serializer";
-import { StarkSessionService } from "../../session";
 
 // FIXME: re-enable this TSLINT rule and refactor these tests to try to reduce the duplication of function as much as possible
 /* tslint:disable:no-identical-functions */

--- a/packages/stark-core/src/modules/http/services/http.service.ts
+++ b/packages/stark-core/src/modules/http/services/http.service.ts
@@ -21,8 +21,8 @@ import {
 	StarkSingleItemResponseWrapper,
 	StarkSingleItemResponseWrapperImpl
 } from "../entities";
-import { STARK_LOGGING_SERVICE, StarkLoggingService } from "../../logging";
-import { STARK_SESSION_SERVICE, StarkSessionService } from "../../session";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "../../logging/services";
+import { STARK_SESSION_SERVICE, StarkSessionService } from "../../session/services";
 
 /**
  * @ngdoc service

--- a/packages/stark-core/src/modules/logging.ts
+++ b/packages/stark-core/src/modules/logging.ts
@@ -2,5 +2,4 @@ export * from "./logging/actions";
 export * from "./logging/entities";
 export * from "./logging/reducers";
 export * from "./logging/services";
-export * from "./logging/testing";
 export * from "./logging/logging.module";

--- a/packages/stark-core/src/modules/routing.ts
+++ b/packages/stark-core/src/modules/routing.ts
@@ -1,4 +1,3 @@
 export * from "./routing/actions";
 export * from "./routing/services";
-export * from "./routing/testing";
 export * from "./routing/routing.module";

--- a/packages/stark-core/src/modules/session.ts
+++ b/packages/stark-core/src/modules/session.ts
@@ -2,5 +2,4 @@ export * from "./session/actions";
 export * from "./session/entities";
 export * from "./session/reducers";
 export * from "./session/services";
-export * from "./session/testing";
 export * from "./session/session.module";

--- a/packages/stark-core/src/modules/session/testing/session.mock.ts
+++ b/packages/stark-core/src/modules/session/testing/session.mock.ts
@@ -1,4 +1,4 @@
-import { StarkHttpHeaders } from "../../http";
+import { StarkHttpHeaders } from "../../http/constants";
 import { StarkSessionService } from "../services";
 import { Observable } from "rxjs";
 

--- a/packages/stark-core/src/modules/settings/services/settings.service.spec.ts
+++ b/packages/stark-core/src/modules/settings/services/settings.service.spec.ts
@@ -12,7 +12,7 @@ import {
 import { StarkCoreApplicationState } from "../../../common/store";
 import { StarkSettingsServiceImpl } from "./settings.service";
 import { SetPreferredLanguage } from "../actions";
-import { StarkUser } from "../../user";
+import { StarkUser } from "../../user/entities";
 import { of } from "rxjs";
 import Spy = jasmine.Spy;
 

--- a/packages/stark-core/src/modules/settings/services/settings.service.ts
+++ b/packages/stark-core/src/modules/settings/services/settings.service.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../configuration/entities";
 import { StarkUser } from "../../user/entities";
 import { StarkCoreApplicationState } from "../../../common/store";
-import { selectStarkUser } from "../../user";
+import { selectStarkUser } from "../../user/reducers";
 
 /**
  * @ngdoc service

--- a/packages/stark-core/src/modules/user/services/user.service.spec.ts
+++ b/packages/stark-core/src/modules/user/services/user.service.spec.ts
@@ -23,6 +23,7 @@ import { MockStarkSessionService } from "../../session/testing";
 import { StarkUserRepository } from "../repository";
 import {
 	StarkHttpError,
+	StarkHttpErrorImpl,
 	StarkHttpErrorWrapper,
 	StarkHttpErrorWrapperImpl,
 	StarkSingleItemResponseWrapper,
@@ -31,7 +32,6 @@ import {
 import { StarkHttpStatusCodes } from "../../http/enumerators";
 import { StarkSessionService } from "../../session/services";
 import { HttpErrorResponse } from "@angular/common/http";
-import { StarkHttpErrorImpl } from "../../http";
 import { StarkMockData } from "../../../configuration/entities/mock-data";
 import { StarkCoreApplicationState } from "../../../common/store";
 

--- a/packages/stark-core/testing.ts
+++ b/packages/stark-core/testing.ts
@@ -1,4 +1,0 @@
-export * from "./src/modules/http/testing";
-export * from "./src/modules/logging/testing";
-export * from "./src/modules/routing/testing";
-export * from "./src/modules/session/testing";

--- a/packages/stark-core/testing/index.ts
+++ b/packages/stark-core/testing/index.ts
@@ -1,0 +1,6 @@
+// This file is not used to build this module. It is only used during editing
+// by the TypeScript language service and during build for verification. `ngc`
+// replaces this file with production index.ts when it rewrites private symbol
+// names.
+
+export * from "./public_api";

--- a/packages/stark-core/testing/package.json
+++ b/packages/stark-core/testing/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@nationalbankbelgium/stark-core/testing",
+  "types": "testing.d.ts",
+  "main": "../bundles/stark-core-testing.umd.js",
+  "module": "../fesm5/testing.js",
+  "es2015": "../fesm2015/testing.js",
+  "esm5": "../esm5/testing/testing.js",
+  "esm2015": "../esm2015/testing/testing.js",
+  "fesm5": "../fesm5/testing.js",
+  "fesm2015": "../fesm2015/testing.js"
+}

--- a/packages/stark-core/testing/public_api.ts
+++ b/packages/stark-core/testing/public_api.ts
@@ -1,0 +1,11 @@
+/**
+ * @module
+ * @description
+ * Entry point for all public APIs of this package.
+ */
+export * from "../src/modules/http/testing";
+export * from "../src/modules/logging/testing";
+export * from "../src/modules/routing/testing";
+export * from "../src/modules/session/testing";
+
+// This file only reexports content of the `src/modules/**/testing` folders. Keep it that way.

--- a/packages/stark-core/testing/rollup.config.js
+++ b/packages/stark-core/testing/rollup.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const commonData = require("../../rollup.config.common-data.js"); // common configuration between environments
+
+module.exports = {
+	input: "../../../dist/packages-dist/stark-core/fesm5/testing.js",
+	external: commonData.external,
+	plugins: commonData.plugins,
+	output: [
+		{
+			file: "../../../dist/packages-dist/stark-core/bundles/stark-core-testing.umd.js",
+			globals: commonData.output.globals,
+			format: commonData.output.format,
+			exports: commonData.output.exports,
+			name: "stark.core.testing",
+			sourcemap: commonData.output.sourcemap,
+			amd: {
+				id: "@nationalbankbelgium/stark-core/testing"
+			}
+		}
+	]
+};

--- a/packages/stark-core/testing/tsconfig-build.json
+++ b/packages/stark-core/testing/tsconfig-build.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "../",
+    "typeRoots": ["../node_modules/@types", "../node_modules/@nationalbankbelgium/stark-testing/node_modules/@types"],
+    "outDir": "../../../dist/packages/stark-core"
+  },
+
+  "files": ["public_api.ts"],
+
+  // Unfortunately, all those options have to be written in every tsconfig file
+  "angularCompilerOptions": {
+    "generateCodeForLibraries": true,
+    "skipMetadataEmit": false,
+    "strictMetadataEmit": false,
+    "strictInjectionParameters": true,
+    "fullTemplateTypeCheck": true,
+    "annotationsAs": "static fields",
+    "enableLegacyTemplate": false,
+    "preserveWhitespaces": false,
+    "allowEmptyCodegenFiles": false,
+    "annotateForClosureCompiler": true,
+    "skipTemplateCodegen": true,
+    "flatModuleOutFile": "testing.js",
+    "flatModuleId": "@nationalbankbelgium/stark-core/testing"
+  }
+}

--- a/packages/stark-core/tsconfig-build.json
+++ b/packages/stark-core/tsconfig-build.json
@@ -6,10 +6,10 @@
     "typeRoots": ["./node_modules/@types", "./node_modules/@nationalbankbelgium/stark-testing/node_modules/@types"],
     "lib": ["dom", "dom.iterable", "es2017"],
     "paths": {
-      "rxjs/*": ["../../node_modules/rxjs/*"],
       "@angular/common": ["../../node_modules/@angular/common"],
       "@angular/core": ["../../node_modules/@angular/core"],
       "@angular/router": ["../../node_modules/@angular/router"],
+      "rxjs/*": ["../../node_modules/rxjs/*"],
       "@nationalbankbelgium/stark-core": ["."]
     },
     "outDir": "../../dist/packages/stark-core"

--- a/packages/stark-core/tsconfig.spec.json
+++ b/packages/stark-core/tsconfig.spec.json
@@ -4,21 +4,5 @@
     "module": "commonjs"
   },
   "files": null,
-  "include": ["**/*.ts"],
-
-  // Unfortunately, all those options have to be written in every tsconfig file
-  "angularCompilerOptions": {
-    "generateCodeForLibraries": true,
-    "skipMetadataEmit": false,
-    "strictMetadataEmit": false,
-    "strictInjectionParameters": true,
-    "fullTemplateTypeCheck": true,
-    "annotationsAs": "static fields",
-    "enableLegacyTemplate": false,
-    "preserveWhitespaces": false,
-    "allowEmptyCodegenFiles": false,
-    "annotateForClosureCompiler": true,
-    "skipTemplateCodegen": true,
-    "enableResourceInlining": true
-  }
+  "include": ["**/*.ts"]
 }

--- a/packages/stark-ui/karma.conf.typescript.js
+++ b/packages/stark-ui/karma.conf.typescript.js
@@ -8,6 +8,7 @@ const karmaTypescriptBundlerAliasResolution = {
 		alias: {
 			// adapt the resolution of the stark-core module to the UMD module
 			"@nationalbankbelgium/stark-core": "../../dist/packages-dist/stark-core/bundles/stark-core.umd.js",
+			"@nationalbankbelgium/stark-core/testing": "../../dist/packages-dist/stark-core/bundles/stark-core-testing.umd.js",
 			// adapt the resolution of the 3rd party modules used in stark-core
 			"@ng-idle/core": "../stark-core/node_modules/@ng-idle/core/bundles/core.umd.js",
 			"@ng-idle/keepalive": "../stark-core/node_modules/@ng-idle/keepalive/bundles/keepalive.umd.js",

--- a/packages/stark-ui/src/modules/app-logo/components/app-logo.component.spec.ts
+++ b/packages/stark-ui/src/modules/app-logo/components/app-logo.component.spec.ts
@@ -1,11 +1,7 @@
 import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import {
-	MockStarkLoggingService,
-	MockStarkRoutingService,
-	STARK_LOGGING_SERVICE,
-	STARK_ROUTING_SERVICE
-} from "@nationalbankbelgium/stark-core";
+import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE } from "@nationalbankbelgium/stark-core";
+import { MockStarkLoggingService, MockStarkRoutingService } from "@nationalbankbelgium/stark-core/testing";
 import { StarkAppLogoComponent } from "./app-logo.component";
 import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;

--- a/packages/stark-ui/testing/index.ts
+++ b/packages/stark-ui/testing/index.ts
@@ -1,0 +1,6 @@
+// This file is not used to build this module. It is only used during editing
+// by the TypeScript language service and during build for verification. `ngc`
+// replaces this file with production index.ts when it rewrites private symbol
+// names.
+
+export * from "./public_api";

--- a/packages/stark-ui/testing/package.json
+++ b/packages/stark-ui/testing/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@nationalbankbelgium/stark-ui/testing",
+  "types": "testing.d.ts",
+  "main": "../bundles/stark-ui-testing.umd.js",
+  "module": "../fesm5/testing.js",
+  "es2015": "../fesm2015/testing.js",
+  "esm5": "../esm5/testing/testing.js",
+  "esm2015": "../esm2015/testing/testing.js",
+  "fesm5": "../fesm5/testing.js",
+  "fesm2015": "../fesm2015/testing.js"
+}

--- a/packages/stark-ui/testing/public_api.ts
+++ b/packages/stark-ui/testing/public_api.ts
@@ -1,0 +1,13 @@
+/**
+ * @module
+ * @description
+ * Entry point for all public APIs of this package.
+ */
+// FIXME: replace this dummy mock by the actual mocks once implemented => export * from "../src/modules/<module>/testing";
+export class MockStarkUIDummyService {
+	public readonly someProperty: string = "dummy property";
+
+	public someMethod: (someParam: any) => any = jasmine.createSpy("someMethod");
+}
+
+// This file only reexports content of the `src/modules/**/testing` folders. Keep it that way.

--- a/packages/stark-ui/testing/rollup.config.js
+++ b/packages/stark-ui/testing/rollup.config.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const commonData = require("../../rollup.config.common-data.js"); // common configuration between environments
+
+module.exports = {
+	input: "../../../dist/packages-dist/stark-ui/fesm5/testing.js",
+	external: commonData.external,
+	plugins: commonData.plugins,
+	output: [
+		{
+			file: "../../../dist/packages-dist/stark-ui/bundles/stark-ui-testing.umd.js",
+			globals: commonData.output.globals,
+			format: commonData.output.format,
+			exports: commonData.output.exports,
+			name: "stark.ui.testing",
+			sourcemap: commonData.output.sourcemap,
+			amd: {
+				id: "@nationalbankbelgium/stark-ui/testing"
+			}
+		}
+	]
+};

--- a/packages/stark-ui/testing/tsconfig-build.json
+++ b/packages/stark-ui/testing/tsconfig-build.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "../",
+    "typeRoots": ["../node_modules/@types", "../node_modules/@nationalbankbelgium/stark-testing/node_modules/@types"],
+    "outDir": "../../../dist/packages/stark-ui"
+  },
+
+  "files": ["public_api.ts"],
+
+  // Unfortunately, all those options have to be written in every tsconfig file
+  "angularCompilerOptions": {
+    "generateCodeForLibraries": true,
+    "skipMetadataEmit": false,
+    "strictMetadataEmit": false,
+    "strictInjectionParameters": true,
+    "fullTemplateTypeCheck": true,
+    "annotationsAs": "static fields",
+    "enableLegacyTemplate": false,
+    "preserveWhitespaces": false,
+    "allowEmptyCodegenFiles": false,
+    "annotateForClosureCompiler": true,
+    "skipTemplateCodegen": true,
+    "flatModuleOutFile": "testing.js",
+    "flatModuleId": "@nationalbankbelgium/stark-ui/testing"
+  }
+}

--- a/packages/stark-ui/tsconfig-build.json
+++ b/packages/stark-ui/tsconfig-build.json
@@ -7,12 +7,8 @@
     "lib": ["dom", "dom.iterable", "es2017"],
     "paths": {
       "@angular/common": ["../../node_modules/@angular/common"],
-      "@angular/compiler": ["../../node_modules/@angular/compiler"],
-      "@angular/compiler-cli": ["../../node_modules/@angular/compiler-cli"],
       "@angular/core": ["../../node_modules/@angular/core"],
       "@angular/material": ["../../node_modules/@angular/material"],
-      "@angular/platform-browser": ["../../node_modules/@angular/platform-browser"],
-      "@angular/platform-browser-dynamic": ["../../node_modules/@angular/platform-browser-dynamic"],
       "@angular/router": ["../../node_modules/@angular/router"],
       "@ng-idle/*": ["../stark-core/node_modules/@ng-idle/*"],
       "@ngrx/*": ["../stark-core/node_modules/@ngrx/*"],

--- a/packages/stark-ui/tsconfig.spec.json
+++ b/packages/stark-ui/tsconfig.spec.json
@@ -1,24 +1,12 @@
 {
   "extends": "./tsconfig-build.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "paths": {
+      "@nationalbankbelgium/stark-core/testing": ["../../dist/packages/stark-core/testing"],
+      "@nationalbankbelgium/stark-core": ["../../dist/packages/stark-core"]
+    }
   },
   "files": null,
-  "include": ["**/*.ts"],
-
-  // Unfortunately, all those options have to be written in every tsconfig file
-  "angularCompilerOptions": {
-    "generateCodeForLibraries": true,
-    "skipMetadataEmit": false,
-    "strictMetadataEmit": false,
-    "strictInjectionParameters": true,
-    "fullTemplateTypeCheck": true,
-    "annotationsAs": "static fields",
-    "enableLegacyTemplate": false,
-    "preserveWhitespaces": false,
-    "allowEmptyCodegenFiles": false,
-    "annotateForClosureCompiler": true,
-    "skipTemplateCodegen": true,
-    "enableResourceInlining": true
-  }
+  "include": ["**/*.ts"]
 }

--- a/starter/src/app/about/about.component.spec.ts
+++ b/starter/src/app/about/about.component.spec.ts
@@ -2,7 +2,6 @@ import { ActivatedRoute, Data } from "@angular/router";
 import { inject, TestBed } from "@angular/core/testing";
 import { StoreModule } from "@ngrx/store";
 import {
-	MockStarkLoggingService,
 	STARK_APP_CONFIG,
 	StarkApplicationConfig,
 	StarkBackend,
@@ -10,6 +9,7 @@ import {
 	StarkLoggingService,
 	STARK_LOGGING_SERVICE
 } from "@nationalbankbelgium/stark-core";
+import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
 
 /**
  * Load the implementations that should be tested.

--- a/starter/src/app/home/home.component.spec.ts
+++ b/starter/src/app/home/home.component.spec.ts
@@ -3,8 +3,6 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { StoreModule } from "@ngrx/store";
 import {
-	MockStarkHttpService,
-	MockStarkLoggingService,
 	STARK_APP_CONFIG,
 	StarkApplicationConfig,
 	StarkBackend,
@@ -13,6 +11,7 @@ import {
 	STARK_LOGGING_SERVICE,
 	STARK_HTTP_SERVICE
 } from "@nationalbankbelgium/stark-core";
+import { MockStarkHttpService, MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
 /**
  * Load the implementations that should be tested.
  */

--- a/starter/tsconfig.spec.json
+++ b/starter/tsconfig.spec.json
@@ -2,11 +2,5 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs"
-  },
-
-  "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
-    "strictMetadataEmit": false,
-    "skipTemplateCodegen": true
   }
 }


### PR DESCRIPTION
ISSUES CLOSED: #367

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The testing mocks inside every module in Stark-Core and Stark-UI are re-exported in the barrel of such modules. This means that the mocks are always included.

Issue Number: #367 


## What is the new behavior?
The testing mocks are not included in the re-exports but in a different entry point ("testing" subpackage) which is already supported by the current build.sh we use.

## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Mocks and testing resources from different modules of stark-core and stark-ui are now under "testing" subpackage for example: "`@nationalbankbelgium/stark-core/testing`"