### PR TITLE
fix(stark-build): include postcss loader+plugins to the Webpack css and scss files processing

### DIFF
--- a/packages/stark-build/config/webpack.common.js
+++ b/packages/stark-build/config/webpack.common.js
@@ -208,7 +208,28 @@ module.exports = function(options) {
 				 */
 				{
 					test: /\.css$/,
-					use: ["to-string-loader", "css-loader"],
+					use: [
+						"to-string-loader",
+						{
+							loader: "css-loader",
+							options: {
+								//modules: true, // to check if needed
+								//minimize: true,
+								// even if disabled, sourceMaps gets generated
+								sourceMap: false, // true
+								autoprefixer: false,
+								// see https://github.com/webpack-contrib/css-loader#importloaders)
+								importLoaders: 1 // 1 => postcss-loader
+							}
+						},
+						{
+							loader: "postcss-loader",
+							options: {
+								sourceMap: true,
+								plugins: commonData.postcssPlugins
+							}
+						}
+					],
 					exclude: [helpers.root(buildUtils.ANGULAR_APP_CONFIG.sourceRoot, "styles")]
 				},
 
@@ -217,10 +238,31 @@ module.exports = function(options) {
 				 * Returns compiled css content as string
 				 *
 				 */
-				// TODO Check if this loader is needed for Angular Material components
 				{
 					test: /\.scss$/,
-					use: ["to-string-loader", "css-loader", "sass-loader"],
+					use: [
+						"to-string-loader",
+						{
+							loader: "css-loader",
+							options: {
+								//modules: true, // to check if needed
+								//minimize: true,
+								// even if disabled, sourceMaps gets generated
+								sourceMap: false, // true
+								autoprefixer: false,
+								// see https://github.com/webpack-contrib/css-loader#importloaders)
+								importLoaders: 2 // 2 => postcss-loader + sass-loader
+							}
+						},
+						{
+							loader: "postcss-loader",
+							options: {
+								sourceMap: true,
+								plugins: commonData.postcssPlugins
+							}
+						},
+						"sass-loader"
+					],
 					exclude: [helpers.root(buildUtils.ANGULAR_APP_CONFIG.sourceRoot, "styles")]
 				},
 

--- a/packages/stark-build/config/webpack.dev.js
+++ b/packages/stark-build/config/webpack.dev.js
@@ -139,7 +139,25 @@ module.exports = function(env) {
 							loader: "style-loader",
 							options: { attrs: { nonce: "cef324d21ec5483c8819cc7a5e33c4a2" } }
 						},
-						"css-loader"
+						{
+							loader: "css-loader",
+							options: {
+								//modules: true, // to check if needed
+								//minimize: true,
+								// even if disabled, sourceMaps gets generated
+								sourceMap: false, // true
+								autoprefixer: false,
+								// see https://github.com/webpack-contrib/css-loader#importloaders)
+								importLoaders: 1 // 1 => postcss-loader
+							}
+						},
+						{
+							loader: "postcss-loader",
+							options: {
+								sourceMap: true,
+								plugins: commonData.postcssPlugins
+							}
+						}
 					],
 					include: [helpers.root(buildUtils.ANGULAR_APP_CONFIG.sourceRoot, "styles")]
 				},
@@ -152,8 +170,29 @@ module.exports = function(env) {
 				{
 					test: /\.scss$/,
 					use: [
-						{ loader: "style-loader", options: { attrs: { nonce: "cef324d21ec5483c8819cc7a5e33c4a2" } } },
-						"css-loader",
+						{
+							loader: "style-loader",
+							options: { attrs: { nonce: "cef324d21ec5483c8819cc7a5e33c4a2" } }
+						},
+						{
+							loader: "css-loader",
+							options: {
+								//modules: true, // to check if needed
+								//minimize: true,
+								// even if disabled, sourceMaps gets generated
+								sourceMap: false, // true
+								autoprefixer: false,
+								// see https://github.com/webpack-contrib/css-loader#importloaders)
+								importLoaders: 2 // 2 => postcss-loader + sass-loader
+							}
+						},
+						{
+							loader: "postcss-loader",
+							options: {
+								sourceMap: true,
+								plugins: commonData.postcssPlugins
+							}
+						},
 						"sass-loader"
 					],
 					include: [helpers.root(buildUtils.ANGULAR_APP_CONFIG.sourceRoot, "styles")]

--- a/packages/stark-build/config/webpack.prod.js
+++ b/packages/stark-build/config/webpack.prod.js
@@ -154,7 +154,28 @@ module.exports = function() {
 				 */
 				{
 					test: /\.css$/,
-					use: [MiniCssExtractPlugin.loader, "css-loader"],
+					use: [
+						MiniCssExtractPlugin.loader,
+						{
+							loader: "css-loader",
+							options: {
+								//modules: true, // to check if needed
+								//minimize: true,
+								// even if disabled, sourceMaps gets generated
+								sourceMap: false, // true
+								autoprefixer: false,
+								// see https://github.com/webpack-contrib/css-loader#importloaders)
+								importLoaders: 1 // 1 => postcss-loader
+							}
+						},
+						{
+							loader: "postcss-loader",
+							options: {
+								sourceMap: true,
+								plugins: commonData.postcssPlugins
+							}
+						}
+					],
 					include: [helpers.root(buildUtils.ANGULAR_APP_CONFIG.sourceRoot, "styles")]
 				},
 
@@ -163,7 +184,29 @@ module.exports = function() {
 				 */
 				{
 					test: /\.scss$/,
-					use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
+					use: [
+						MiniCssExtractPlugin.loader,
+						{
+							loader: "css-loader",
+							options: {
+								//modules: true, // to check if needed
+								//minimize: true,
+								// even if disabled, sourceMaps gets generated
+								sourceMap: false, // true
+								autoprefixer: false,
+								// see https://github.com/webpack-contrib/css-loader#importloaders)
+								importLoaders: 2 // 2 => postcss-loader + sass-loader
+							}
+						},
+						{
+							loader: "postcss-loader",
+							options: {
+								sourceMap: true,
+								plugins: commonData.postcssPlugins
+							}
+						},
+						"sass-loader"
+					],
 					include: [helpers.root(buildUtils.ANGULAR_APP_CONFIG.sourceRoot, "styles")]
 				},
 

--- a/packages/stark-build/config/webpack.test.js
+++ b/packages/stark-build/config/webpack.test.js
@@ -112,7 +112,28 @@ module.exports = function() {
 				 */
 				{
 					test: /\.css$/,
-					loader: ["to-string-loader", "css-loader"],
+					loader: [
+						"to-string-loader",
+						{
+							loader: "css-loader",
+							options: {
+								//modules: true, // to check if needed
+								//minimize: true,
+								// even if disabled, sourceMaps gets generated
+								sourceMap: false, // true
+								autoprefixer: false,
+								// see https://github.com/webpack-contrib/css-loader#importloaders)
+								importLoaders: 1 // 1 => postcss-loader
+							}
+						},
+						{
+							loader: "postcss-loader",
+							options: {
+								sourceMap: true,
+								plugins: commonData.postcssPlugins
+							}
+						}
+					],
 					exclude: [helpers.root("src/index.html")]
 				},
 
@@ -123,7 +144,29 @@ module.exports = function() {
 				 */
 				{
 					test: /\.scss$/,
-					loader: ["raw-loader", "sass-loader"],
+					loader: [
+						"raw-loader",
+						{
+							loader: "css-loader",
+							options: {
+								//modules: true, // to check if needed
+								//minimize: true,
+								// even if disabled, sourceMaps gets generated
+								sourceMap: false, // true
+								autoprefixer: false,
+								// see https://github.com/webpack-contrib/css-loader#importloaders)
+								importLoaders: 2 // 2 => postcss-loader + sass-loader
+							}
+						},
+						{
+							loader: "postcss-loader",
+							options: {
+								sourceMap: true,
+								plugins: commonData.postcssPlugins
+							}
+						},
+						"sass-loader"
+					],
 					exclude: [helpers.root("src/index.html")]
 				},
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
SASS and SCSS files are not correctly processed by Webpack causing the custom styles for Angular Material components and themes to be broken.

Issue Number: #104


## What is the new behavior?
Custom styles for Angular Material components and themes working properly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
