### PR TITLE
fix(release): adapt release-it.json and commitlint scopes to fix "release" command failure

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -9,7 +9,6 @@
 	"changelogCommand": "npm run generate:changelog-recent",
 	"buildCommand": false,
 	"safeBump": false,
-	"beforeChangelogCommand": false,
 	"requireCleanWorkingDir": true,
 	"requireUpstream": true,
 	"src": {

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,23 +8,21 @@ module.exports = {
 			2,
 			"always",
 			[
-				"core",
-				"ui",
-				"test",
-				"build",
 				"accessibility",
+				"build",
 				"build-main",
 				"developer-guide",
 				"docs",
 				"qa",
+				"release",
 				"stark-all",
 				"stark-build",
 				"stark-core",
 				"stark-demo",
-				"stark-starter",
 				"stark-rbac",
-				"stark-ui",
-				"testing"
+				"stark-starter",
+				"stark-testing",
+				"stark-ui"
 			]
 		],
 		"scope-case": [2, "always", "lowerCase"]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `npm run release` command fails due to missing scope "release" used in the release commit message.


## What is the new behavior?
The "release" scope is added to the `commitlint` scopes  Cleaned-up some duplicated and confusing scopes. Clean-up `release-it` config file.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->