### PR TITLE
fix(stark-demo): add baseHref dynamically via Angular provider to fix Showcase when published in GitHub pages

### DIFF
--- a/showcase/angular.json
+++ b/showcase/angular.json
@@ -36,7 +36,7 @@
             "styles": ["src/styles.css"],
             "scripts": [],
             "deployUrl": "",
-            "baseHref": "/"
+            "baseHref": ""
           },
           "configurations": {
             "hmr": {

--- a/showcase/src/environments/environment.e2e.prod.ts
+++ b/showcase/src/environments/environment.e2e.prod.ts
@@ -1,5 +1,6 @@
 import { enableProdMode, NgModuleRef } from "@angular/core";
 import { disableDebugTools } from "@angular/platform-browser";
+import { APP_BASE_HREF } from "@angular/common";
 import { StarkEnvironment } from "@nationalbankbelgium/stark-core";
 
 enableProdMode();
@@ -17,5 +18,7 @@ export const environment: StarkEnvironment = {
 		disableDebugTools();
 		return modRef;
 	},
-	ENV_PROVIDERS: []
+	ENV_PROVIDERS: [
+		{ provide: APP_BASE_HREF, useValue: "/" } // the baseHref is defined via the Angular provider instead of the angular.json file
+	]
 };

--- a/showcase/src/environments/environment.hmr.ts
+++ b/showcase/src/environments/environment.hmr.ts
@@ -1,5 +1,6 @@
 import { ApplicationRef, ComponentRef, NgModuleRef } from "@angular/core";
 import { enableDebugTools } from "@angular/platform-browser";
+import { APP_BASE_HREF } from "@angular/common";
 import { StarkEnvironment } from "@nationalbankbelgium/stark-core";
 
 // Ensure that we get detailed stack tracks during development (useful with node & Webpack)
@@ -26,5 +27,7 @@ export const environment: StarkEnvironment = {
 		(<any>window).ng.coreTokens = _ng.coreTokens;
 		return modRef;
 	},
-	ENV_PROVIDERS: []
+	ENV_PROVIDERS: [
+		{ provide: APP_BASE_HREF, useValue: "/" } // the baseHref is defined via the Angular provider instead of the angular.json file
+	]
 };

--- a/showcase/src/environments/environment.prod.ts
+++ b/showcase/src/environments/environment.prod.ts
@@ -1,8 +1,32 @@
 import { enableProdMode, NgModuleRef } from "@angular/core";
 import { disableDebugTools } from "@angular/platform-browser";
+import { APP_BASE_HREF } from "@angular/common";
 import { StarkEnvironment } from "@nationalbankbelgium/stark-core";
 
 enableProdMode();
+
+/**
+ * This factory constructs the final baseHref based on the path location of the Showcase app in GitHub Pages
+ */
+export function appBaseHrefFactory(): string {
+	// the final url in GitHub Pages will be something like "/showcase/latest/" or "/showcase/some-version/"
+	const finalUrlRegex: RegExp = /(\/showcase\/[\d\D][^\/]+(\/|\/$|$))/;
+	const trailingSlashRegex: RegExp = /\/$/;
+	const matches: RegExpExecArray | null = finalUrlRegex.exec(window.location.pathname);
+
+	let finalBaseHref: string = "";
+
+	if (matches && matches[1]) {
+		finalBaseHref = matches[1];
+	}
+
+	// add a trailing slash to the url in case it doesn't have any
+	if (!finalBaseHref.match(trailingSlashRegex)) {
+		finalBaseHref = finalBaseHref + "/";
+	}
+
+	return finalBaseHref;
+}
 
 export const environment: StarkEnvironment = {
 	production: true,
@@ -17,5 +41,7 @@ export const environment: StarkEnvironment = {
 		disableDebugTools();
 		return modRef;
 	},
-	ENV_PROVIDERS: []
+	ENV_PROVIDERS: [
+		{ provide: APP_BASE_HREF, useFactory: appBaseHrefFactory } // the baseHref is defined via the Angular provider instead of the angular.json file
+	]
 };

--- a/showcase/src/environments/environment.ts
+++ b/showcase/src/environments/environment.ts
@@ -1,5 +1,6 @@
 import { ApplicationRef, ComponentRef, NgModuleRef } from "@angular/core";
 import { enableDebugTools } from "@angular/platform-browser";
+import { APP_BASE_HREF } from "@angular/common";
 import { StarkEnvironment } from "@nationalbankbelgium/stark-core";
 
 // Ensure that we get detailed stack tracks during development (useful with node & Webpack)
@@ -26,5 +27,7 @@ export const environment: StarkEnvironment = {
 		(<any>window).ng.coreTokens = _ng.coreTokens;
 		return modRef;
 	},
-	ENV_PROVIDERS: []
+	ENV_PROVIDERS: [
+		{ provide: APP_BASE_HREF, useValue: "/" } // the baseHref is defined via the Angular provider instead of the angular.json file
+	]
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #466 


## What is the new behavior?
The base href of the showcase is set dynamically via the Angular [APP_BASE_HREF](https://angular.io/api/common/APP_BASE_HREF) provider as an environment provider instead of setting it in the `angular.json` file in order to handle the final location of the app in GitHub pages (defined in `environment.prod.ts`).

The handling of the environment files in Webpack is works correctly now due to some minor fixes in the `build-utils.js` file.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information