### PR TITLE
fix(stark-demo): revert PR #471. Adapt baseHref/deployUrl via Node script to fix Showcase publication on GitHub pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   - npm run lint:all
   - npm run test:ci:all
   - npm run docs:coverage
-  - npm run build:showcase
+  - npm run build:showcase:ghpages
   - npm run docs:publish
   - npm run release:publish
   - bash ./scripts/ci/print-logs.sh

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "build:stark-testing": "npm run build -- --packages=stark-testing",
     "build:stark-ui": "npm run build -- --packages=stark-ui",
     "build:showcase": "cd showcase && npm run build:prod && cd ..",
+    "build:showcase:ghpages": "cd showcase && npm run build:prod:ghpages && cd ..",
     "clean": "npx rimraf ./dist",
     "clean:all": "npm run clean && npm run clean:stark-build && npm run clean:stark-core && npm run clean:stark-ui && npm run clean:stark-testing && npm run clean:starter && npm run clean:showcase",
     "clean:stark-build": "cd packages/stark-build && npm run clean && cd ../..",

--- a/showcase/ghpages-adapt-angular-json.js
+++ b/showcase/ghpages-adapt-angular-json.js
@@ -1,0 +1,34 @@
+let fs = require("fs");
+
+const deployUrlPlaceholder = "<stark-dummy-deploy-url>";
+const baseHrefPlaceholder = "<stark-dummy-base-href>";
+
+let replacements = [
+	{ searchValue: `"deployUrl": ""`, replaceValue: `"deployUrl": "${deployUrlPlaceholder}"` },
+	{ searchValue: `"baseHref": "/"`, replaceValue: `"baseHref": "${baseHrefPlaceholder}"` }
+];
+
+replaceValuesInFile("angular.json", replacements);
+
+function replaceValuesInFile(fileName, valueReplacements) {
+	fs.readFile(fileName, "utf8", function(err, data) {
+		if (err) {
+			return console.error("Error while reading file => " + err);
+		}
+
+		let result = data;
+
+		for (const replacement of valueReplacements) {
+			const searchValueRegex = new RegExp(replacement.searchValue, "g");
+			result = result.replace(searchValueRegex, replacement.replaceValue);
+		}
+
+		fs.writeFile(fileName, result, "utf8", function(err) {
+			if (err) {
+				return console.error(err);
+			} else {
+				return console.log(`${fileName} updated successfully`);
+			}
+		});
+	});
+}

--- a/showcase/ghpages-adapt-bundle-urls.js
+++ b/showcase/ghpages-adapt-bundle-urls.js
@@ -1,0 +1,81 @@
+let fs = require("fs");
+let path = require("path");
+
+const filesToChange = [
+	/index.html/,
+	/main.*\.css$/,
+	/runtime~main.*\.js$/,
+	/runtime~main.*\.js\.map$/,
+	/runtime~polyfills.*\.js$/,
+	/runtime~polyfills.*\.js\.map$/
+];
+
+if (process.argv.length <= 2) {
+	console.log("Usage: " + __filename + " deployDir oldDeployDir");
+	process.exit(-1);
+}
+
+let deployDir = "/showcase/" + process.argv[2];
+
+let baseHrefPlaceholder = "<stark-dummy-base-href>";
+let deployUrlPlaceholder = "<stark-dummy-deploy-url>";
+
+let urlWithTrailingSlash = deployDir.endsWith("/") ? deployDir : deployDir + "/";
+let urlWithoutTrailingSlash = deployDir.endsWith("/") ? deployDir.substring(0, deployDir.length - 1) : deployDir;
+
+let replacements = [
+	{ searchValue: `"${baseHrefPlaceholder}"`, replaceValue: `"${urlWithTrailingSlash}"` },
+	{ searchValue: `"${deployUrlPlaceholder}"`, replaceValue: `"${urlWithoutTrailingSlash}"` },
+	{ searchValue: `"${deployUrlPlaceholder}/`, replaceValue: `"${urlWithTrailingSlash}` },
+	{ searchValue: `/${baseHrefPlaceholder}/${deployUrlPlaceholder}/`, replaceValue: urlWithTrailingSlash }
+];
+
+// if the 3rd param is given (oldDeployDir) then it will be appended to the "showcase" folder and replaced by the new deployDir
+if (process.argv[3]) {
+	deployDir = "showcase/" + process.argv[2]; // no slashes at the beginning nor the end to cover all replacements at once
+	let oldDeployDir = "showcase/" + process.argv[3]; // no slashes at the beginning nor the end cover all replacements at once
+
+	replacements = [{ searchValue: oldDeployDir, replaceValue: deployDir }];
+}
+
+let outputDir = "showcase" + path.sep + "dist";
+
+fs.readdir(outputDir, function(err, items) {
+	if (err) {
+		return console.error("Error while reading directory => " + err);
+	}
+
+	for (const item of items) {
+		for (const fileRegex of filesToChange) {
+			if (item.match(fileRegex)) {
+				let fullFilePath = outputDir + path.sep + item;
+				replaceValuesInFile(fullFilePath, replacements);
+
+				break;
+			}
+		}
+	}
+});
+
+function replaceValuesInFile(fileName, valueReplacements) {
+	fs.readFile(fileName, "utf8", function(err, data) {
+		if (err) {
+			return console.error("Error while reading file => " + err);
+		}
+
+		let result = data;
+
+		for (const replacement of valueReplacements) {
+			const searchValueRegex = new RegExp(replacement.searchValue, "g");
+			result = result.replace(searchValueRegex, replacement.replaceValue);
+		}
+
+		fs.writeFile(fileName, result, "utf8", function(err) {
+			if (err) {
+				return console.error(err);
+			} else {
+				return console.log(`${fileName} updated successfully`);
+			}
+		});
+	});
+}

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -33,6 +33,7 @@
     "build:dev:monitor": "npx mkdirp reports && npm run build:dev -- --env.monitor",
     "build:docker": "npm run build:prod && docker build -t angular2-webpack-start:latest .",
     "build:prod": "npm run clean:dist && npm run build:aot:prod",
+    "build:prod:ghpages": "npm run clean:dist && node ./ghpages-adapt-angular-json.js && npm run build:aot:prod",
     "build": "npm run build:dev",
     "check-deps": "npx npm-check-u",
     "ci:aot": "cross-env BUILD_E2E=1 npm run lint && npm run test && npm run build:aot && npm run e2e",

--- a/showcase/src/environments/environment.e2e.prod.ts
+++ b/showcase/src/environments/environment.e2e.prod.ts
@@ -1,6 +1,5 @@
 import { enableProdMode, NgModuleRef } from "@angular/core";
 import { disableDebugTools } from "@angular/platform-browser";
-import { APP_BASE_HREF } from "@angular/common";
 import { StarkEnvironment } from "@nationalbankbelgium/stark-core";
 
 enableProdMode();
@@ -18,7 +17,5 @@ export const environment: StarkEnvironment = {
 		disableDebugTools();
 		return modRef;
 	},
-	ENV_PROVIDERS: [
-		{ provide: APP_BASE_HREF, useValue: "/" } // the baseHref is defined via the Angular provider instead of the angular.json file
-	]
+	ENV_PROVIDERS: []
 };

--- a/showcase/src/environments/environment.hmr.ts
+++ b/showcase/src/environments/environment.hmr.ts
@@ -1,6 +1,5 @@
 import { ApplicationRef, ComponentRef, NgModuleRef } from "@angular/core";
 import { enableDebugTools } from "@angular/platform-browser";
-import { APP_BASE_HREF } from "@angular/common";
 import { StarkEnvironment } from "@nationalbankbelgium/stark-core";
 
 // Ensure that we get detailed stack tracks during development (useful with node & Webpack)
@@ -27,7 +26,5 @@ export const environment: StarkEnvironment = {
 		(<any>window).ng.coreTokens = _ng.coreTokens;
 		return modRef;
 	},
-	ENV_PROVIDERS: [
-		{ provide: APP_BASE_HREF, useValue: "/" } // the baseHref is defined via the Angular provider instead of the angular.json file
-	]
+	ENV_PROVIDERS: []
 };

--- a/showcase/src/environments/environment.prod.ts
+++ b/showcase/src/environments/environment.prod.ts
@@ -1,32 +1,8 @@
 import { enableProdMode, NgModuleRef } from "@angular/core";
 import { disableDebugTools } from "@angular/platform-browser";
-import { APP_BASE_HREF } from "@angular/common";
 import { StarkEnvironment } from "@nationalbankbelgium/stark-core";
 
 enableProdMode();
-
-/**
- * This factory constructs the final baseHref based on the path location of the Showcase app in GitHub Pages
- */
-export function appBaseHrefFactory(): string {
-	// the final url in GitHub Pages will be something like "/showcase/latest/" or "/showcase/some-version/"
-	const finalUrlRegex: RegExp = /(\/showcase\/[\d\D][^\/]+(\/|\/$|$))/;
-	const trailingSlashRegex: RegExp = /\/$/;
-	const matches: RegExpExecArray | null = finalUrlRegex.exec(window.location.pathname);
-
-	let finalBaseHref: string = "";
-
-	if (matches && matches[1]) {
-		finalBaseHref = matches[1];
-	}
-
-	// add a trailing slash to the url in case it doesn't have any
-	if (!finalBaseHref.match(trailingSlashRegex)) {
-		finalBaseHref = finalBaseHref + "/";
-	}
-
-	return finalBaseHref;
-}
 
 export const environment: StarkEnvironment = {
 	production: true,
@@ -41,7 +17,5 @@ export const environment: StarkEnvironment = {
 		disableDebugTools();
 		return modRef;
 	},
-	ENV_PROVIDERS: [
-		{ provide: APP_BASE_HREF, useFactory: appBaseHrefFactory } // the baseHref is defined via the Angular provider instead of the angular.json file
-	]
+	ENV_PROVIDERS: []
 };

--- a/showcase/src/environments/environment.ts
+++ b/showcase/src/environments/environment.ts
@@ -1,6 +1,5 @@
 import { ApplicationRef, ComponentRef, NgModuleRef } from "@angular/core";
 import { enableDebugTools } from "@angular/platform-browser";
-import { APP_BASE_HREF } from "@angular/common";
 import { StarkEnvironment } from "@nationalbankbelgium/stark-core";
 
 // Ensure that we get detailed stack tracks during development (useful with node & Webpack)
@@ -27,7 +26,5 @@ export const environment: StarkEnvironment = {
 		(<any>window).ng.coreTokens = _ng.coreTokens;
 		return modRef;
 	},
-	ENV_PROVIDERS: [
-		{ provide: APP_BASE_HREF, useValue: "/" } // the baseHref is defined via the Angular provider instead of the angular.json file
-	]
+	ENV_PROVIDERS: []
 };


### PR DESCRIPTION
ISSUES CLOSED: 466

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Although the baseHref can be dynamically changed via the Angular APP_BASE_HREF provider, the CSS and other assets are imported from the wrong folder since the deployUrl is used during the bundle building by Wepack to generate such imports. The issue is that the deployUrl cannot be defined dynamically.

Issue Number: #466 


## What is the new behavior?
Reverted the changes made in #471 related to the definiton of the APP_BASE_HREF as an environment provider.

The final baseHref and deploy URL are adapted via a Node script before the showcase is copied to the GH-Pages branch.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
