### PR TITLE
chore(stark-all): remove "testing" subpackages from greenkeeper config file since they have no dependencies

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -5,10 +5,8 @@
         "package.json",
         "packages/stark-build/package.json",
         "packages/stark-core/package.json",
-        "packages/stark-core/testing/package.json",
         "packages/stark-testing/package.json",
         "packages/stark-ui/package.json",
-        "packages/stark-ui/testing/package.json",
         "showcase/package.json",
         "starter/package.json"
       ]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `package.json` files of the "testing" subpackages are included in the `greenkeeper.json` file. This seems to break greenkeeper which does not any create new PRs for updating deps in our repo.


## What is the new behavior?
The `greenkeeper.json` file contains only those `package.json` files from the packages that do have dependencies.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->