### PR TITLE
docs(docs): add solution for the 'sed: illegal option -- r' error when building a subset of stark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,6 +308,7 @@ If you only want to build a subset of stark then you can
 -   execute one of the `build:stark-<name>` npm scripts; for example: `npm run build:stark-core` or `npm run build:stark-build`
 -   execute the `build` script through npm with the list of packages to build: `npm run build -- --packages=stark-core`
 -   execute the build script from the command line: `bash ./build.sh --packages=stark-core`
+-   **IMPORTANT: on MAC OS you may get the error: `sed: illegal option -- r`. The solution is to install `gnu-sed` (see https://www.gnu.org/software/sed/) with the command `brew install gnu-sed --with-default-names` (see https://stackoverflow.com/a/34815955)**
 
 ## Executing test suites
 


### PR DESCRIPTION
When building a subset of stark (ie: npm run build:stark-ui) on MacOS you might get the error:
```
sed: illegal option -- r
```

This is due to a difference in sed script on Windows OS and MacOS. On Windows the command is `sed -r ...` on MacOS this it is `sed -E ...` .

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We have no solution for the `sed: illegal option -- r` error.


## What is the new behavior?
A solution is added to the 'contributing' document under 'if you only want to build a subset of stark'.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
