### PR TITLE
fix(build): add quotes around the Prettier parameters to fix an issue on MacOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "install:travis:all": "npm run install:stark-build && npm run install:stark-testing && npm run install:stark-core && npm run install:stark-ui && npm run build:trace && npm run update:starter && npm run update:showcase",
     "ngc": "ngc",
     "precommit": "lint-staged && npm run docs:coverage",
-    "prettier-check": "prettier **/*.{css,js,json,md,pcss,scss,ts} --write",
+    "prettier-check": "prettier \"**/*.{css,js,json,md,pcss,scss,ts}\" --write",
     "preupdate:showcase": "npm run clean:showcase",
     "preupdate:starter": "npm run clean:starter",
     "release": "release-it",


### PR DESCRIPTION
When running the `npm run prettier-check` command on MacOs not all files are checked by Prettier.
The solution is to add double quotes around the globs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When running the `npm run prettier-check` command on MacOs not all files are checked by Prettier.

Issue Number: N/A


## What is the new behavior?
When running the `npm run prettier-check` command on MacOs  all files are checked by Prettier. The same command works correctly on Windows.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
