### PR TITLE
chore(stark-all): remove obsolete and unnecessary NPM dependencies

### DIFF
--- a/packages/stark-build/package.json
+++ b/packages/stark-build/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@angular-devkit/build-angular": "0.6.8",
     "@angular-devkit/build-optimizer": "0.6.8",
-    "@types/source-map": "0.5.7",
     "@types/uglify-js": "3.0.2",
     "@types/webpack": "4.4.5",
     "add-asset-html-webpack-plugin": "2.1.3",

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -137,7 +137,6 @@
     "reflect-metadata": "0.1.12",
     "rxjs": "6.2.1",
     "rxjs-compat": "6.2.1",
-    "web-animations-js": "2.3.1",
     "zone.js": "0.8.26"
   },
   "devDependencies": {

--- a/showcase/src/polyfills.browser.ts
+++ b/showcase/src/polyfills.browser.ts
@@ -49,13 +49,14 @@ import "event-source-polyfill";
 import "eligrey-classlist-js-polyfill";
 
 /**
- * All but Chrome, Firefox and Opera require this to support Web Animations from
- * `@angular/animations` and `@angular/platform-browser/animations`.
- * See: http://caniuse.com/#feat=web-animation
+ * Web Animations polyfill is no longer needed for standard animation support as of Angular 6
+ * IMPORTANT: It is only needed in case you use the AnimationBuilder from '@angular/animations' in the application
  *
+ * See: https://angular.io/guide/browser-support#optional-browser-features-to-polyfill
+ * See: http://caniuse.com/#feat=web-animation
  * Polyfill: https://github.com/web-animations/web-animations-js
  */
-import "web-animations-js";
+// import "web-animations-js";
 
 /***************************************************************************************************
  * Zone JS is required by Angular itself.

--- a/starter/package.json
+++ b/starter/package.json
@@ -136,7 +136,6 @@
     "reflect-metadata": "0.1.12",
     "rxjs": "6.2.1",
     "rxjs-compat": "6.2.1",
-    "web-animations-js": "2.3.1",
     "zone.js": "0.8.26"
   },
   "devDependencies": {

--- a/starter/src/polyfills.browser.ts
+++ b/starter/src/polyfills.browser.ts
@@ -49,13 +49,14 @@ import "event-source-polyfill";
 import "eligrey-classlist-js-polyfill";
 
 /**
- * All but Chrome, Firefox and Opera require this to support Web Animations from
- * `@angular/animations` and `@angular/platform-browser/animations`.
- * See: http://caniuse.com/#feat=web-animation
+ * Web Animations polyfill is no longer needed for standard animation support as of Angular 6
+ * IMPORTANT: It is only needed in case you use the AnimationBuilder from '@angular/animations' in the application
  *
+ * See: https://angular.io/guide/browser-support#optional-browser-features-to-polyfill
+ * See: http://caniuse.com/#feat=web-animation
  * Polyfill: https://github.com/web-animations/web-animations-js
  */
-import "web-animations-js";
+// import "web-animations-js";
 
 /***************************************************************************************************
  * Zone JS is required by Angular itself.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently Stark has the following packages that are either obsolete or no longer necessary:

- **"@types/source-map"** is obsolete due to:
```npm WARN deprecated @types/source-map@0.5.7: This is a stub types definition for source-map (https://github.com/mozilla/source-map). source-map provides its own type definitions, so you don't need @types/source-map installed!```

- **"web-animations-js"** is no longer necessary as of Angular 6. See https://angular.io/guide/browser-support#optional-browser-features-to-polyfill

## What is the new behavior?
Packages "@types/source-map" and "web-animations-js" are removed from the NPM dependencies. The import of the "web-animations" module is removed from the `polyfills.browser.ts` file.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->