### PR TITLE
refactor(stark-starter): enable UI-Router visualizer only in development. Disable visualizer in showcase

### DIFF
--- a/showcase/src/app/router.config.ts
+++ b/showcase/src/app/router.config.ts
@@ -1,10 +1,9 @@
 import { UIRouter, Category, StateDeclaration } from "@uirouter/core";
-import { Visualizer } from "@uirouter/visualizer";
 
-function logRegisteredStates(registeredstates: StateDeclaration[]): void {
+function logRegisteredStates(registeredStates: StateDeclaration[]): void {
 	let message: string = "=============  Registered Ui-Router states: ==============\n";
 
-	for (const state of registeredstates) {
+	for (const state of registeredStates) {
 		message += "State : " + state.name;
 		message += " [";
 		message += "parent: " + state.parent;
@@ -18,8 +17,10 @@ function logRegisteredStates(registeredstates: StateDeclaration[]): void {
 
 export function routerConfigFn(router: UIRouter): void {
 	router.trace.enable(Category.TRANSITION);
-	router.plugin(Visualizer);
-
+	// Enable UI-Router visualizer here if needed (for development purposes only)
+	// if (ENV === "development") {
+	// 	router.plugin(Visualizer);  // Visualizer should be imported from "@uirouter/visualizer"
+	// }
 	logRegisteredStates(router.stateService.get());
 }
 

--- a/starter/src/app/router.config.ts
+++ b/starter/src/app/router.config.ts
@@ -3,12 +3,12 @@ import { Visualizer } from "@uirouter/visualizer";
 
 /**
  * This method will log all registered states of the application
- * @param registeredstates: a set of registered states
+ * @param registeredStates - The set of states registered in the UI-Router instance
  */
-function logRegisteredStates(registeredstates: StateDeclaration[]): void {
+function logRegisteredStates(registeredStates: StateDeclaration[]): void {
 	let message: string = "=============  Registered Ui-Router states: ==============\n";
 
-	for (const state of registeredstates) {
+	for (const state of registeredStates) {
 		message += "State : " + state.name;
 		message += " [";
 		message += "parent: " + state.parent;
@@ -21,20 +21,23 @@ function logRegisteredStates(registeredstates: StateDeclaration[]): void {
 }
 
 /**
- * @ignore
- * @param router - the router to configure
+ * Function called by the UI-Router root module (forRoot()) to set some imperative configuration
+ * @param router - The UI-Router instance to configure
  */
 export function routerConfigFn(router: UIRouter): void {
 	router.trace.enable(Category.TRANSITION);
 
-	// TODO switch on/off depending on environment (DEVELOPMENT = ON)
-	router.plugin(Visualizer);
+	// Enable UI-Router visualizer here if needed (for development purposes only)
+	if (ENV === "development") {
+		router.plugin(Visualizer);
+	}
 
 	logRegisteredStates(router.stateService.get());
 }
 
 /**
- * @ignore
+ * Function called by the UI-Router child module (forChild()) to set some imperative configuration
+ * @param router - The UI-Router instance to configure
  */
 export function routerChildConfigFn(router: UIRouter): void {
 	logRegisteredStates(router.stateService.get());


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
UI-Router visualizer is always enabled in the Starter and in the Showcase.


## What is the new behavior?
- In the Starter, the UI-Router visualizer is enabled only in DEV.
- In the Showcase, the visualizer is always disabled since it is not needed for the moment. It can be enabled again if needed for development purposes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
