### PR TITLE
fix(stark-ui): include only "src" and "assets" folders in "lint-css" command

### DIFF
--- a/packages/stark-core/package.json
+++ b/packages/stark-core/package.json
@@ -67,7 +67,7 @@
     "ngc": "node ../../node_modules/@angular/compiler-cli/src/main.js -p ./tsconfig-build.json",
     "lint": "npm run lint-ts && npm run lint-css",
     "lint-ts": "node ../../node_modules/tslint/bin/tslint --config ./tslint.json --project ./tsconfig.spec.json --format codeFrame",
-    "lint-css": "node ../../node_modules/stylelint/bin/stylelint \"./**/*.?(pc|sc|c|sa)ss\" --formatter \"string\"",
+    "lint-css": "node ../../node_modules/stylelint/bin/stylelint \"./(src|assets)/**/*.?(pc|sc|c|sa)ss\" --formatter \"string\"",
     "test": "npm run lint && npm run test-fast",
     "test:ci": "npm run lint && npm run test-fast:ci",
     "test-fast": "node ./node_modules/@nationalbankbelgium/stark-testing/node_modules/karma/bin/karma start",

--- a/packages/stark-ui/package.json
+++ b/packages/stark-ui/package.json
@@ -61,7 +61,7 @@
     "ngc": "node ../../node_modules/@angular/compiler-cli/src/main.js -p ./tsconfig-build.json",
     "lint": "npm run lint-ts && npm run lint-css",
     "lint-ts": "node ../../node_modules/tslint/bin/tslint --config ./tslint.json --project ./tsconfig.spec.json --format codeFrame",
-    "lint-css": "node ../../node_modules/stylelint/bin/stylelint \"./**/*.?(pc|sc|c|sa)ss\" --formatter \"string\"",
+    "lint-css": "node ../../node_modules/stylelint/bin/stylelint \"./(src|assets)/**/*.?(pc|sc|c|sa)ss\" --formatter \"string\"",
     "test": "npm run lint && npm run test-fast",
     "test:ci": "npm run lint && npm run test-fast:ci",
     "test-fast": "node ./node_modules/@nationalbankbelgium/stark-testing/node_modules/karma/bin/karma start",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
As a result of the PR #516, the new `lint-css` command in stark-core and stark-ui also lints the CSS files in the "coverage" and "reports" folders which are created by the unit tests. This causes the `lint-css` command to fail due to many violations which should not be in the scope of the linting.


## What is the new behavior?
The `lint-css` command in stark-core and stark-ui only includes the files from the "src" and "assets" folders.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
