### PR TITLE
fix(release): add "package-lock.json" to the set of files to be updated by release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -3,7 +3,7 @@
 	"dry-run": false,
 	"verbose": false,
 	"force": false,
-	"pkgFiles": ["package.json"],
+	"pkgFiles": ["package.json", "package-lock.json"],
 	"increment": "conventional:angular",
 	"beforeChangelogCommand": "npm run generate:changelog",
 	"changelogCommand": "npm run generate:changelog-recent",


### PR DESCRIPTION
ISSUES CLOSED: #574

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #574 


## What is the new behavior?
The version of the Stark packages is automatically updated by release-it in both the `package.json` and `package-lock.json` files.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information