### PR TITLE
fix(stark-demo): adapt ExampleViewer to fetch example files targeting the right url. Rename title input to prevent weird tooltip.

### DIFF
--- a/packages/stark-core/src/modules/http/testing/http.mock.ts
+++ b/packages/stark-core/src/modules/http/testing/http.mock.ts
@@ -6,6 +6,7 @@ import {
 } from "@nationalbankbelgium/stark-core";
 import { HttpClient } from "@angular/common/http";
 import { Observable } from "rxjs";
+
 /**
  * Mock class of the StarkHttpService interface.
  * @link StarkHttpService
@@ -15,7 +16,17 @@ export class MockStarkHttpService implements StarkHttpService<any> {
 	 * Gets the core Angular HTTP API (HttpClient)
 	 * @returns Angular Http client
 	 */
-	public readonly rawHttpClient: HttpClient;
+	public readonly rawHttpClient: HttpClient = jasmine.createSpyObj("rawHttpClient", [
+		"request",
+		"delete",
+		"get",
+		"head",
+		"jsonp",
+		"options",
+		"patch",
+		"post",
+		"put"
+	]);
 
 	/**
 	 * Executes requests to fetch a single resource

--- a/showcase/src/app/demo/action-bar/action-bar.component.html
+++ b/showcase/src/app/demo/action-bar/action-bar.component.html
@@ -1,12 +1,14 @@
-<example-viewer [extensions]="['HTML', 'TS']" filesPath="action-bar/classic-full" title="SHOWCASE.DEMO.ACTION-BAR.CLASSIC-FULL">
+<example-viewer [extensions]="['HTML', 'TS']" filesPath="action-bar/classic-full"
+				exampleTitle="SHOWCASE.DEMO.ACTION-BAR.CLASSIC-FULL">
 		<stark-action-bar actionBarId="classic-full" [actionBarConfig]="actionBarConfig" mode="full"></stark-action-bar>
 </example-viewer>
 
 
-<example-viewer [extensions]="['HTML', 'TS']" filesPath="action-bar/classic-compact" title="SHOWCASE.DEMO.ACTION-BAR.CLASSIC-COMPACT">
+<example-viewer [extensions]="['HTML', 'TS']" filesPath="action-bar/classic-compact"
+				exampleTitle="SHOWCASE.DEMO.ACTION-BAR.CLASSIC-COMPACT">
 		<stark-action-bar actionBarId="classic-compact" [actionBarConfig]="actionBarConfig" mode="compact"></stark-action-bar>
 </example-viewer>
 
-<example-viewer [extensions]="['HTML', 'TS']" filesPath="action-bar/alt" title="SHOWCASE.DEMO.ACTION-BAR.ALT">
+<example-viewer [extensions]="['HTML', 'TS']" filesPath="action-bar/alt" exampleTitle="SHOWCASE.DEMO.ACTION-BAR.ALT">
 	<stark-action-bar actionBarId="alt" [actionBarConfig]="actionBarConfig" [alternativeActions]="alternativeActions" mode="compact"></stark-action-bar>
 </example-viewer>

--- a/showcase/src/app/demo/button/button.component.html
+++ b/showcase/src/app/demo/button/button.component.html
@@ -1,4 +1,4 @@
-<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/basic" title="Basic buttons">
+<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/basic" exampleTitle="Basic buttons">
 	<div class="button-row">
 		<button mat-button>Basic</button>
 		<button mat-raised-button>Basic</button>
@@ -21,7 +21,7 @@
 	</div>
 </example-viewer>
 
-<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/primary" title="Primary buttons">
+<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/primary" exampleTitle="Primary buttons">
 	<div class="button-row">
 		<button color="primary" mat-button>Primary</button>
 		<button color="primary" mat-raised-button>Primary</button>
@@ -44,7 +44,7 @@
 	</div>
 </example-viewer>
 
-<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/accent" title="Accent buttons">
+<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/accent" exampleTitle="Accent buttons">
 	<div class="button-row">
 		<button color="accent" mat-button>Accent</button>
 		<button color="accent" mat-raised-button>Accent</button>
@@ -67,7 +67,7 @@
 	</div>
 </example-viewer>
 
-<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/warn" title="Warning buttons">
+<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/warn" exampleTitle="Warning buttons">
 	<div class="button-row">
 		<button color="warn" mat-button>Accent</button>
 		<button color="warn" mat-raised-button>Accent</button>
@@ -90,7 +90,7 @@
 	</div>
 </example-viewer>
 
-<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/success" title="Success buttons">
+<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/success" exampleTitle="Success buttons">
 	<div class="button-row">
 		<button color="success" mat-button>Success</button>
 		<button color="success" mat-raised-button>Success</button>
@@ -113,7 +113,7 @@
 	</div>
 </example-viewer>
 
-<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/alert" title="Alert buttons">
+<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/alert" exampleTitle="Alert buttons">
 	<div class="button-row">
 		<button color="alert" mat-button>Alert</button>
 		<button color="alert" mat-raised-button>Alert</button>
@@ -136,7 +136,7 @@
 	</div>
 </example-viewer>
 
-<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/alt" title="Alt buttons">
+<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/alt" exampleTitle="Alt buttons">
 	<div class="button-row">
 		<button color="alt" mat-button>Alt</button>
 		<button color="alt" mat-raised-button>Alt</button>
@@ -159,7 +159,7 @@
 	</div>
 </example-viewer>
 
-<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/neutral" title="Neutral buttons">
+<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/neutral" exampleTitle="Neutral buttons">
 	<div class="button-row">
 		<button color="neutral" mat-button>Neutral</button>
 		<button color="neutral" mat-raised-button>Neutral</button>
@@ -182,7 +182,7 @@
 	</div>
 </example-viewer>
 
-<example-viewer class="dark" [extensions]="['HTML', 'CSS']" filesPath="button/white" title="White buttons">
+<example-viewer class="dark" [extensions]="['HTML', 'CSS']" filesPath="button/white" exampleTitle="White buttons">
 	<div class="button-row">
 		<button color="white" mat-button>White</button>
 		<button color="white" mat-raised-button>White</button>
@@ -205,7 +205,7 @@
 	</div>
 </example-viewer>
 
-<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/disabled" title="Disabled buttons">
+<example-viewer [extensions]="['HTML', 'CSS']" filesPath="button/disabled" exampleTitle="Disabled buttons">
 	<div class="button-row">
 		<button disabled mat-button>Disabled</button>
 		<button disabled mat-raised-button>Disabled</button>

--- a/showcase/src/app/demo/example-viewer/example-viewer.component.html
+++ b/showcase/src/app/demo/example-viewer/example-viewer.component.html
@@ -1,4 +1,4 @@
-<example-viewer filesPath="test" title="Example Viewer">
+<example-viewer filesPath="test" exampleTitle="Example Viewer">
 	<h3>Raised Buttons</h3>
 	<div class="button-row">
 		<button mat-raised-button>Basic</button>

--- a/showcase/src/app/demo/keyboard-directives/keyboard-directives.component.html
+++ b/showcase/src/app/demo/keyboard-directives/keyboard-directives.component.html
@@ -1,5 +1,5 @@
 <example-viewer [extensions]="['HTML', 'TS']" filesPath="keyboard-directives/on-enter-key-directive"
-				title="SHOWCASE.DEMO.KEYBOARD_DIRECTIVES.ON_ENTER_KEY.TITLE">
+				exampleTitle="SHOWCASE.DEMO.KEYBOARD_DIRECTIVES.ON_ENTER_KEY.TITLE">
 	<form class="on-enter-key-directive-form">
 		<p translate>SHOWCASE.DEMO.KEYBOARD_DIRECTIVES.ON_ENTER_KEY.DESCRIPTION</p>
 		<mat-form-field>
@@ -30,7 +30,7 @@
 </example-viewer>
 
 <example-viewer [extensions]="['HTML', 'TS']" filesPath="keyboard-directives/restrict-input-directive"
-				title="SHOWCASE.DEMO.KEYBOARD_DIRECTIVES.RESTRICT_INPUT.TITLE">
+				exampleTitle="SHOWCASE.DEMO.KEYBOARD_DIRECTIVES.RESTRICT_INPUT.TITLE">
 	<form class="restrict-input-directive-form">
 		<p translate>SHOWCASE.DEMO.KEYBOARD_DIRECTIVES.RESTRICT_INPUT.DESCRIPTION</p>
 		<mat-form-field>

--- a/showcase/src/app/demo/pretty-print/pretty-print.component.html
+++ b/showcase/src/app/demo/pretty-print/pretty-print.component.html
@@ -1,7 +1,7 @@
 <example-viewer *ngFor="let fileType of fileTypes; trackBy: trackFileTypes"
 				[extensions]="['HTML', 'SCSS', 'TS']"
 				[filesPath]="fileType.path"
-				[title]="fileType.title">
+				[exampleTitle]="fileType.title">
 	<mat-tab-group>
 		<mat-tab label="{{ 'SHOWCASE.DEMO.PRETTY-PRINT.ORIGINAL_CODE'  | translate }}">
 			<div class="code-block">{{ fileType.rawData }}</div>

--- a/showcase/src/app/shared/example-viewer/example-viewer.component.html
+++ b/showcase/src/app/shared/example-viewer/example-viewer.component.html
@@ -1,6 +1,6 @@
 <div class="example-viewer-wrapper mat-elevation-z2">
 	<div class="example-viewer-title">
-		<div class="example-viewer-title-spacer"><h2 translate>{{ title }}</h2></div>
+		<div class="example-viewer-title-spacer"><h2 translate>{{ exampleTitle }}</h2></div>
 
 		<button color="white" mat-icon-button (click)="toggleSourceView()" matTooltip="View source">
 			<mat-icon svgIcon="code-tags"></mat-icon>
@@ -9,7 +9,7 @@
 
 	<div class="example-viewer-source" *ngIf="showSource">
 		<mat-tab-group>
-			<mat-tab *ngFor="let file of filesContent; trackBy: trackFilesContent" [label]="file.extension">
+			<mat-tab *ngFor="let file of exampleFiles; trackBy: trackExampleFile" [label]="file.extension">
 				<div class="example-source-wrapper">
 					<stark-pretty-print [data]="file.data"
 										[format]="file.format"

--- a/showcase/src/app/shared/example-viewer/example-viewer.component.spec.ts
+++ b/showcase/src/app/shared/example-viewer/example-viewer.component.spec.ts
@@ -1,31 +1,34 @@
-import { HttpClientModule } from "@angular/common/http";
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { async, ComponentFixtureAutoDetect, ComponentFixture, TestBed } from "@angular/core/testing";
-import { MatButtonModule, MatTabsModule, MatTooltipModule } from "@angular/material";
-
-import { ExampleViewerComponent } from "./example-viewer.component";
-import { FileService } from "./file.service";
-import { throwError, of } from "rxjs";
-import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
-import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
-import SpyObj = jasmine.SpyObj;
-import { StarkPrettyPrintModule } from "@nationalbankbelgium/stark-ui";
 import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatButtonModule, MatTabsModule, MatTooltipModule } from "@angular/material";
+import { throwError, of, Observable, Subject } from "rxjs";
+import { filter, delay } from "rxjs/operators";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
+import { StarkPrettyPrintModule } from "@nationalbankbelgium/stark-ui";
+
+import { ExampleFile, ExampleViewerComponent } from "./example-viewer.component";
+import { FileService } from "./file.service";
+import SpyObj = jasmine.SpyObj;
+import Spy = jasmine.Spy;
 
 describe("ExampleViewerComponent", () => {
 	let component: ExampleViewerComponent;
-	let fileService: FileService;
+	let fileService: SpyObj<FileService>;
 	let fixture: ComponentFixture<ExampleViewerComponent>;
 	let logger: SpyObj<StarkLoggingService>;
 
 	beforeEach(async(() => {
 		return TestBed.configureTestingModule({
 			declarations: [ExampleViewerComponent],
-			imports: [BrowserAnimationsModule, HttpClientModule, MatButtonModule, MatTabsModule, MatTooltipModule, StarkPrettyPrintModule],
+			imports: [NoopAnimationsModule, MatButtonModule, MatTabsModule, MatTooltipModule, StarkPrettyPrintModule],
 			providers: [
-				{ provide: ComponentFixtureAutoDetect, useValue: true },
 				{ provide: STARK_LOGGING_SERVICE, useValue: new MockStarkLoggingService() },
-				FileService
+				{
+					provide: FileService,
+					useValue: jasmine.createSpyObj("FileServiceSpy", ["fetchFile"])
+				}
 			],
 			schemas: [NO_ERRORS_SCHEMA] // tells the Angular compiler to ignore unrecognized elements and attributes: mat-icon
 		}).compileComponents();
@@ -33,48 +36,112 @@ describe("ExampleViewerComponent", () => {
 
 	beforeEach(() => {
 		logger = TestBed.get(STARK_LOGGING_SERVICE);
+		fileService = TestBed.get(FileService);
+		fileService.fetchFile.and.callFake(() => of("initial dummy file content"));
+
 		fixture = TestBed.createComponent(ExampleViewerComponent);
 		component = fixture.componentInstance;
-		fileService = fixture.debugElement.injector.get<FileService>(FileService as any);
+		fixture.detectChanges(); // trigger initial data binding
 	});
 
-	describe("@Input() title", () => {
-		it("should change the title according to the @Input", () => {
-			const h2: any = fixture.nativeElement.querySelector(".example-viewer-title-spacer h2");
-			component.title = "Test title";
+	describe("@Input() exampleTitle", () => {
+		it("should change the exampleTitle according to the @Input", () => {
+			const h2: HTMLHeadingElement = fixture.nativeElement.querySelector(".example-viewer-title-spacer h2");
+			component.exampleTitle = "Test title";
 			fixture.detectChanges();
-			expect(h2.textContent).toContain(component.title);
+			expect(h2.textContent).toContain(component.exampleTitle);
 		});
 	});
 
 	describe("@Input() extensions", () => {
-		it("should show the tabs when the file exist", () => {
-			spyOn(fileService, "fetchFile").and.returnValue(of("test"));
-			component.fetchFiles();
-			const button: any = fixture.nativeElement.querySelector(".example-viewer-title button");
+		it("should show the tabs when the file exist", (done: DoneFn) => {
+			component.exampleFiles = [];
+			component.extensions = ["CSS", "JS", "HTML", "SCSS", "TS"];
+			fixture.detectChanges();
+
+			let button: HTMLButtonElement = fixture.nativeElement.querySelector(".example-viewer-title button");
 			button.click();
-			const tabs: any = fixture.nativeElement.querySelectorAll(".mat-tab-labels .mat-tab-label");
-			expect(tabs.length).toBe(component.extensions.length);
+			let tabs: any[] = fixture.nativeElement.querySelectorAll(".mat-tab-labels .mat-tab-label");
+			expect(tabs.length).toBe(0);
+
+			fileService.fetchFile.and.callFake(() => {
+				fileFetched.next("file has been fetched");
+				return of("some file content");
+			});
+
+			const fileFetched: Subject<string> = new Subject();
+			const allFilesFetched: Observable<string> = fileFetched.asObservable().pipe(
+				filter((_value: string, index: number) => index === component.extensions.length - 1),
+				delay(10) // we need to give some time until the tabs are refreshed
+			);
+
+			allFilesFetched.subscribe(() => {
+				fixture.detectChanges();
+
+				button = fixture.nativeElement.querySelector(".example-viewer-title button");
+				button.click();
+				tabs = fixture.nativeElement.querySelectorAll(".mat-tab-labels .mat-tab-label");
+				expect(tabs.length).toBe(component.extensions.length);
+				done();
+			});
+
+			component.fetchExampleFiles();
 		});
 	});
 
-	describe("fetchFiles()", () => {
-		it("should not do anything when the file doesn't exist", () => {
-			logger.debug.calls.reset();
-			spyOn(component, "addFileContent");
-			spyOn(fileService, "fetchFile").and.returnValue(throwError("http failure"));
-			component.fetchFiles();
-			expect(component.addFileContent).not.toHaveBeenCalled();
-			expect(fileService.fetchFile).toHaveBeenCalledTimes(component.extensions.length);
-			expect(logger.error).toHaveBeenCalled();
+	describe("fetchExampleFiles()", () => {
+		beforeEach(() => {
+			spyOn(component, "addExampleFile");
+			fileService.fetchFile.calls.reset();
+			logger.error.calls.reset();
 		});
 
-		it("should call the callback when the file exists", () => {
-			spyOn(component, "addFileContent");
-			spyOn(fileService, "fetchFile").and.returnValue(of("test"));
-			component.fetchFiles();
-			expect(component.addFileContent).toHaveBeenCalledTimes(component.extensions.length);
+		it("should not do anything when the file doesn't exist", () => {
+			fileService.fetchFile.and.returnValue(throwError("file does not exist"));
+			expect(fileService.fetchFile).not.toHaveBeenCalled();
+			component.fetchExampleFiles();
 			expect(fileService.fetchFile).toHaveBeenCalledTimes(component.extensions.length);
+			expect(logger.error).toHaveBeenCalledTimes(component.extensions.length);
+			expect(component.addExampleFile).not.toHaveBeenCalled();
+		});
+
+		it("should call addExampleFiles() when the file exists passing the data of the file and its metadata", () => {
+			fileService.fetchFile.and.returnValue(of("dummy file content"));
+			component.fetchExampleFiles();
+			expect(fileService.fetchFile).toHaveBeenCalledTimes(component.extensions.length);
+			expect(component.addExampleFile).toHaveBeenCalledTimes(component.extensions.length);
+
+			component.extensions.forEach((extension: string, index: number) => {
+				const exampleFile: ExampleFile = (<Spy>component.addExampleFile).calls.argsFor(index)[0];
+				expect(exampleFile.data).toBeDefined();
+				expect(exampleFile.extension).toBe(extension);
+				expect(exampleFile.format).toBeDefined();
+			});
+		});
+
+		it("should call the FileService passing the right url of the file including the base URL if any", () => {
+			fileService.fetchFile.and.returnValue(of("dummy file content"));
+			component.filesPath = "dummy-example-file";
+			component.appBaseHref = "";
+			component.fetchExampleFiles();
+			expect(fileService.fetchFile).toHaveBeenCalledTimes(component.extensions.length);
+
+			component.extensions.forEach((extension: string, index: number) => {
+				const filePath: string = fileService.fetchFile.calls.argsFor(index)[0];
+				expect(filePath).toBe(component.examplesFolder + component.filesPath + "." + extension.toLowerCase());
+			});
+
+			fileService.fetchFile.calls.reset();
+			component.appBaseHref = "mock-bae-href/";
+			component.fetchExampleFiles();
+			expect(fileService.fetchFile).toHaveBeenCalledTimes(component.extensions.length);
+
+			component.extensions.forEach((extension: string, index: number) => {
+				const filePath: string = fileService.fetchFile.calls.argsFor(index)[0];
+				expect(filePath).toBe(
+					component.appBaseHref + component.examplesFolder + component.filesPath + "." + extension.toLowerCase()
+				);
+			});
 		});
 	});
 

--- a/showcase/src/app/shared/example-viewer/example-viewer.component.ts
+++ b/showcase/src/app/shared/example-viewer/example-viewer.component.ts
@@ -3,56 +3,92 @@ import { HttpErrorResponse } from "@angular/common/http";
 import { FileService } from "./file.service";
 import { STARK_LOGGING_SERVICE, StarkErrorImpl, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 
+export interface ExampleFile {
+	extension: string;
+	data: string;
+	format: string;
+}
+
 @Component({
 	selector: "example-viewer",
 	templateUrl: "./example-viewer.component.html",
-	styleUrls: ["./example-viewer.component.scss"],
-	providers: [FileService]
+	styleUrls: ["./example-viewer.component.scss"]
 })
 export class ExampleViewerComponent implements OnInit {
 	@Input()
-	public extensions: string[] = ["HTML", "TS", "CSS"];
+	public extensions: string[];
 	@Input()
 	public filesPath: string;
 	@Input()
-	public title: string;
+	public exampleTitle: string;
 
-	public filesContent: object[] = [];
-	public showSource: boolean = false;
+	public appBaseHref: string;
+	public examplesFolder: string;
+	public exampleFiles: ExampleFile[];
+	public showSource: boolean;
 
-	public constructor(private service: FileService, @Inject(STARK_LOGGING_SERVICE) public loggingService: StarkLoggingService) {}
+	public constructor(private fileService: FileService, @Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService) {
+		this.extensions = ["HTML", "TS", "CSS"];
+		this.exampleFiles = [];
+		this.showSource = false;
+		this.appBaseHref = this.getAppBaseHref();
+		this.examplesFolder = "assets/examples/";
+	}
 
 	public ngOnInit(): void {
-		this.fetchFiles();
+		this.fetchExampleFiles();
 	}
 
-	public fetchFiles(): void {
-		this.extensions.forEach((extension: string) => {
-			this.service.fetchFile("/assets/examples/" + this.filesPath + "." + extension.toLowerCase()).subscribe(
+	public fetchExampleFiles(): void {
+		for (const extension of this.extensions) {
+			this.fileService.fetchFile(this.appBaseHref + this.examplesFolder + this.filesPath + "." + extension.toLowerCase()).subscribe(
 				(data: string) =>
-					this.addFileContent({
+					this.addExampleFile({
 						extension: extension,
 						data: data,
-						format: this.translateExtentionToFormat(extension)
+						format: this.translateExtensionToFormat(extension)
 					}),
-				(error: HttpErrorResponse) => this.loggingService.error("Error while fetching files", new StarkErrorImpl(error))
+				(error: HttpErrorResponse) => this.logger.error("Error while fetching files", new StarkErrorImpl(error))
 			);
-		});
+		}
 	}
 
-	public addFileContent(fileContent: object): void {
-		this.filesContent.push(fileContent);
+	/**
+	 * Get the final baseHref based on the path location of the Showcase app. Useful when deployed on GitHub Pages
+	 */
+	public getAppBaseHref(): string {
+		// the final url in GitHub Pages will be something like "/showcase/latest/" or "/showcase/some-version/"
+		const finalUrlRegex: RegExp = /(\/showcase\/[\d\D][^\/]+(\/|\/$|$))/;
+		const trailingSlashRegex: RegExp = /\/$/;
+		const matches: RegExpExecArray | null = finalUrlRegex.exec(window.location.pathname);
+
+		let finalBaseHref: string = "";
+
+		if (matches && matches[1]) {
+			finalBaseHref = matches[1]; // match group 1 contains the base url (i.e. "/showcase/latest/")
+		}
+
+		// add a trailing slash to the url in case it doesn't have any
+		if (!finalBaseHref.match(trailingSlashRegex)) {
+			finalBaseHref = finalBaseHref + "/";
+		}
+
+		return finalBaseHref;
+	}
+
+	public addExampleFile(fileContent: ExampleFile): void {
+		this.exampleFiles.push(fileContent);
 	}
 
 	public toggleSourceView(): void {
 		this.showSource = !this.showSource;
 	}
 
-	public trackFilesContent(_index: number, file: any): string {
+	public trackExampleFile(_index: number, file: ExampleFile): string {
 		return file.extension;
 	}
 
-	private translateExtentionToFormat(extension: string): string {
+	private translateExtensionToFormat(extension: string): string {
 		switch (extension.toLowerCase()) {
 			case "js":
 				return "javascript";

--- a/showcase/src/app/shared/example-viewer/file.service.ts
+++ b/showcase/src/app/shared/example-viewer/file.service.ts
@@ -1,12 +1,12 @@
-import { Injectable } from "@angular/core";
-import { HttpClient } from "@angular/common/http";
+import { Inject, Injectable } from "@angular/core";
 import { Observable } from "rxjs";
+import { STARK_HTTP_SERVICE, StarkHttpService } from "@nationalbankbelgium/stark-core";
 
 @Injectable()
 export class FileService {
-	public constructor(private http: HttpClient) {}
+	public constructor(@Inject(STARK_HTTP_SERVICE) private httpService: StarkHttpService<any>) {}
 
 	public fetchFile(path: string): Observable<string> {
-		return this.http.get(path, { responseType: "text" });
+		return this.httpService.rawHttpClient.get(path, { responseType: "text" });
 	}
 }


### PR DESCRIPTION
ISSUES CLOSED: #575 #580

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #575 #580 


## What is the new behavior?
- The ExampleViewer fetches the example files from the correct url taking into account the base URL of the app when deployed in GitHub Pages.
- The ExampleViewer does not show a tooltip anymore when hovering over the component.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->