### PR TITLE
chore(docs): re-generate changelog after fixing tag 10.0.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,55 @@
 
 ### Bug Fixes
 
-* **build:** adapted the perl command to specify the backup file extension. This was necessary for some perl versions ([ec4afc6](https://github.com/nationalbankbelgium/stark/commit/ec4afc6))
 * **build:** adding quotes arround the Prettier parameters to fix an issue on MacOS. ([ff1188b](https://github.com/nationalbankbelgium/stark/commit/ff1188b))
+* **stark-core:** fix circular dependencies detected by Rollup ([0620d7b](https://github.com/nationalbankbelgium/stark/commit/0620d7b)), closes [#530](https://github.com/nationalbankbelgium/stark/issues/530)
+* **stark-core:** refactor AbstractStarkMain to enable Angular prod mode before bootstraping the app ([bb319fa](https://github.com/nationalbankbelgium/stark/commit/bb319fa))
+* **stark-demo:** add baseHref dynamically via Angular provider to fix Showcase when published in GitHub pages ([cfc8592](https://github.com/nationalbankbelgium/stark/commit/cfc8592)), closes [#466](https://github.com/nationalbankbelgium/stark/issues/466)
+* **stark-demo:** adding StarkLoggingService to the ExampleViewer tests ([380a60d](https://github.com/nationalbankbelgium/stark/commit/380a60d)), closes [#484](https://github.com/nationalbankbelgium/stark/issues/484)
+* **stark-demo:** fix baseHref in angular.json file ([2a36276](https://github.com/nationalbankbelgium/stark/commit/2a36276))
+* **stark-demo:** fix pretty-print demo translations ([3999ff9](https://github.com/nationalbankbelgium/stark/commit/3999ff9))
+* **stark-demo:** revert PR [#471](https://github.com/nationalbankbelgium/stark/issues/471). Adapt baseHref/deployUrl automatically via Node script to fix Showcase when published in GitHub pages ([f9dadfd](https://github.com/nationalbankbelgium/stark/commit/f9dadfd))
+* **stark-ui:** fix unresolved dependencies detected by Rollup ([a1d9487](https://github.com/nationalbankbelgium/stark/commit/a1d9487)), closes [#532](https://github.com/nationalbankbelgium/stark/issues/532)
+* **stark-ui:** include only "src" and "assets" folders in "lint-css" command on stark-ui and stark-core ([a1c3a4f](https://github.com/nationalbankbelgium/stark/commit/a1c3a4f))
+* **stark-ui:** tooltip translation + table translation ([12dd3b3](https://github.com/nationalbankbelgium/stark/commit/12dd3b3)), closes [#502](https://github.com/nationalbankbelgium/stark/issues/502)
+
+
+### Features
+
+* **core:** integrated bootstrap ([97ca29e](https://github.com/nationalbankbelgium/stark/commit/97ca29e)), closes [#112](https://github.com/nationalbankbelgium/stark/issues/112) [#412](https://github.com/nationalbankbelgium/stark/issues/412)
+* **stark-all:** enable npm ci for travis + add package-lock.json + force registry.npmjs.org as registry ([f47d610](https://github.com/nationalbankbelgium/stark/commit/f47d610)), closes [#43](https://github.com/nationalbankbelgium/stark/issues/43)
+* **stark-build:** add support for environment variables at runtime (importing environment.ts file) and at compilation time (using webpack Define plugin) ([c29e36b](https://github.com/nationalbankbelgium/stark/commit/c29e36b)), closes [#50](https://github.com/nationalbankbelgium/stark/issues/50)
+* **stark-build:** added html-element-webpack-plugin to handle head section in index.html ([ce089c8](https://github.com/nationalbankbelgium/stark/commit/ce089c8)), closes [#60](https://github.com/nationalbankbelgium/stark/issues/60)
+* **stark-core:** add [@ngrx-store-devtools](https://github.com/ngrx-store-devtools) package. Integrate store dev tools in showcase and starter ([b9c9179](https://github.com/nationalbankbelgium/stark/commit/b9c9179)), closes [#81](https://github.com/nationalbankbelgium/stark/issues/81) [#117](https://github.com/nationalbankbelgium/stark/issues/117)
+* **stark-core:** http-service: isolate NBB specifics ([e58afa7](https://github.com/nationalbankbelgium/stark/commit/e58afa7)), closes [#257](https://github.com/nationalbankbelgium/stark/issues/257)
+* **stark-demo:** add pretty-print component to Showcase Demo ([93557cb](https://github.com/nationalbankbelgium/stark/commit/93557cb)), closes [#496](https://github.com/nationalbankbelgium/stark/issues/496)
+* **stark-ui:** action Bar Component ([d1dd733](https://github.com/nationalbankbelgium/stark/commit/d1dd733)), closes [#481](https://github.com/nationalbankbelgium/stark/issues/481)
+* **stark-ui:** add Prettier and use it for all the supported types of data ([5b06aef](https://github.com/nationalbankbelgium/stark/commit/5b06aef)), closes [#500](https://github.com/nationalbankbelgium/stark/issues/500)
+* **stark-ui:** add stark-action-bar into stark-table ([d3a2c6d](https://github.com/nationalbankbelgium/stark/commit/d3a2c6d)), closes [#512](https://github.com/nationalbankbelgium/stark/issues/512)
+* **stark-ui:** example Viewer + basic showcase layout ([ff675c8](https://github.com/nationalbankbelgium/stark/commit/ff675c8)), closes [#458](https://github.com/nationalbankbelgium/stark/issues/458) [#459](https://github.com/nationalbankbelgium/stark/issues/459)
+* **stark-ui:** implement OnEnterKey directive. Create KeyboardDirectives module ([0696959](https://github.com/nationalbankbelgium/stark/commit/0696959)), closes [#538](https://github.com/nationalbankbelgium/stark/issues/538)
+* **stark-ui:** implement RestrictInput directive and module ([b8bd5be](https://github.com/nationalbankbelgium/stark/commit/b8bd5be)), closes [#546](https://github.com/nationalbankbelgium/stark/issues/546) [#550](https://github.com/nationalbankbelgium/stark/issues/550)
+* **stark-ui:** implement the Stark-Pretty-Print component ([22f84b6](https://github.com/nationalbankbelgium/stark/commit/22f84b6)), closes [#494](https://github.com/nationalbankbelgium/stark/issues/494) [#496](https://github.com/nationalbankbelgium/stark/issues/496)
+* **stark-ui:** implement the Stark-Slider component ([fd6d03d](https://github.com/nationalbankbelgium/stark/commit/fd6d03d)), closes [#448](https://github.com/nationalbankbelgium/stark/issues/448)
+* **stark-ui:** implementation of the button's theme ([c49b6ef](https://github.com/nationalbankbelgium/stark/commit/c49b6ef)), closes [#476](https://github.com/nationalbankbelgium/stark/issues/476)
+* **stark-ui:** import old stark ui global theming ([9ac8dde](https://github.com/nationalbankbelgium/stark/commit/9ac8dde)), closes [#456](https://github.com/nationalbankbelgium/stark/issues/456) [#472](https://github.com/nationalbankbelgium/stark/issues/472)
+* **stark-ui:** improve example viewer styling ([bad3746](https://github.com/nationalbankbelgium/stark/commit/bad3746)), closes [#515](https://github.com/nationalbankbelgium/stark/issues/515)
+* **stark-ui:** initial implementation of Stark Table component (supporting nested data, sorting and filtering) ([80e86c3](https://github.com/nationalbankbelgium/stark/commit/80e86c3))
+
+
+### Performance Improvements
+
+* **build-main:** adapt "npm install" commands to prevent optional dependencies from being installed. Enable parallelization in webpack prod config. ([020a5f4](https://github.com/nationalbankbelgium/stark/commit/020a5f4))
+
+
+
+<a name="10.0.0-alpha.3"></a>
+# [10.0.0-alpha.3](https://github.com/nationalbankbelgium/stark/compare/10.0.0-alpha.2...10.0.0-alpha.3) (2018-06-26)
+
+
+### Bug Fixes
+
+* **build:** adapted the perl command to specify the backup file extension. This was necessary for some perl versions ([ec4afc6](https://github.com/nationalbankbelgium/stark/commit/ec4afc6))
 * **build:** fix issue in build-utils with environment. Environment file was not replaced as it should. ([d21a837](https://github.com/nationalbankbelgium/stark/commit/d21a837)), closes [#439](https://github.com/nationalbankbelgium/stark/issues/439)
 * **build:** fix sourcemaps in PROD and in DEV ([c8c5696](https://github.com/nationalbankbelgium/stark/commit/c8c5696)), closes [#401](https://github.com/nationalbankbelgium/stark/issues/401)
 * **build:** fixed webpack config and circular-dependency-plugin config. Closes [#397](https://github.com/nationalbankbelgium/stark/issues/397), [#315](https://github.com/nationalbankbelgium/stark/issues/315) ([ea9c264](https://github.com/nationalbankbelgium/stark/commit/ea9c264))
@@ -19,17 +66,7 @@
 * **stark-build:** include postcss loader+plugins to the Webpack css and scss files processing ([ffd60e7](https://github.com/nationalbankbelgium/stark/commit/ffd60e7))
 * **stark-build) fix(stark-starter:** fix webpack monitor issues with reports folder and HMR ([78c799f](https://github.com/nationalbankbelgium/stark/commit/78c799f))
 * **stark-core:** add missing barrel for common folder. Fix stark-core translations utils imports. ([febb69b](https://github.com/nationalbankbelgium/stark/commit/febb69b))
-* **stark-core:** fix circular dependencies detected by Rollup ([0620d7b](https://github.com/nationalbankbelgium/stark/commit/0620d7b)), closes [#530](https://github.com/nationalbankbelgium/stark/issues/530)
-* **stark-core:** refactor AbstractStarkMain to enable Angular prod mode before bootstraping the app ([bb319fa](https://github.com/nationalbankbelgium/stark/commit/bb319fa))
-* **stark-demo:** add baseHref dynamically via Angular provider to fix Showcase when published in GitHub pages ([cfc8592](https://github.com/nationalbankbelgium/stark/commit/cfc8592)), closes [#466](https://github.com/nationalbankbelgium/stark/issues/466)
-* **stark-demo:** adding StarkLoggingService to the ExampleViewer tests ([380a60d](https://github.com/nationalbankbelgium/stark/commit/380a60d)), closes [#484](https://github.com/nationalbankbelgium/stark/issues/484)
-* **stark-demo:** fix baseHref in angular.json file ([2a36276](https://github.com/nationalbankbelgium/stark/commit/2a36276))
-* **stark-demo:** fix pretty-print demo translations ([3999ff9](https://github.com/nationalbankbelgium/stark/commit/3999ff9))
-* **stark-demo:** revert PR [#471](https://github.com/nationalbankbelgium/stark/issues/471). Adapt baseHref/deployUrl automatically via Node script to fix Showcase when published in GitHub pages ([f9dadfd](https://github.com/nationalbankbelgium/stark/commit/f9dadfd))
 * **stark-starter:** fix blocking issue for reports folder ([1b7d492](https://github.com/nationalbankbelgium/stark/commit/1b7d492)), closes [#356](https://github.com/nationalbankbelgium/stark/issues/356)
-* **stark-ui:** fix unresolved dependencies detected by Rollup ([a1d9487](https://github.com/nationalbankbelgium/stark/commit/a1d9487)), closes [#532](https://github.com/nationalbankbelgium/stark/issues/532)
-* **stark-ui:** include only "src" and "assets" folders in "lint-css" command on stark-ui and stark-core ([a1c3a4f](https://github.com/nationalbankbelgium/stark/commit/a1c3a4f))
-* **stark-ui:** tooltip translation + table translation ([12dd3b3](https://github.com/nationalbankbelgium/stark/commit/12dd3b3)), closes [#502](https://github.com/nationalbankbelgium/stark/issues/502)
 * **stark-ui) fix(stark-testing:** add stark-ui package to the npm install:all script. Simplify customization of default Karma config. ([4f77730](https://github.com/nationalbankbelgium/stark/commit/4f77730))
 
 
@@ -39,47 +76,23 @@
 * **build:** add support for publishing api docs and showcase using Travis. Closes [#282](https://github.com/nationalbankbelgium/stark/issues/282) ([f38ff86](https://github.com/nationalbankbelgium/stark/commit/f38ff86))
 * **build:** add webpackMonitor ([ee46bef](https://github.com/nationalbankbelgium/stark/commit/ee46bef)), closes [#322](https://github.com/nationalbankbelgium/stark/issues/322)
 * **build:** added changelog generation. Closes [#335](https://github.com/nationalbankbelgium/stark/issues/335) ([e06ba53](https://github.com/nationalbankbelgium/stark/commit/e06ba53))
-* **core:** integrated bootstrap ([97ca29e](https://github.com/nationalbankbelgium/stark/commit/97ca29e)), closes [#112](https://github.com/nationalbankbelgium/stark/issues/112) [#412](https://github.com/nationalbankbelgium/stark/issues/412)
 * **core:** validate the AppConfig in every service where it is injected ([dd41aa5](https://github.com/nationalbankbelgium/stark/commit/dd41aa5)), closes [#382](https://github.com/nationalbankbelgium/stark/issues/382)
 * **docs:** added API docs generation to packages and starter. Closes [#127](https://github.com/nationalbankbelgium/stark/issues/127) ([50c610f](https://github.com/nationalbankbelgium/stark/commit/50c610f))
 * **docs:** added TSlint rules and adapted documentation for the project ([14cb90f](https://github.com/nationalbankbelgium/stark/commit/14cb90f)), closes [#424](https://github.com/nationalbankbelgium/stark/issues/424) [#389](https://github.com/nationalbankbelgium/stark/issues/389)
 * **docs:** improved API docs generation with watch mode and coverage checks ([60701c8](https://github.com/nationalbankbelgium/stark/commit/60701c8))
 * **showcase:** added showcase, cleaned up start and got rid of old testing cfg. Closes [#395](https://github.com/nationalbankbelgium/stark/issues/395) [#353](https://github.com/nationalbankbelgium/stark/issues/353). Contributes to [#130](https://github.com/nationalbankbelgium/stark/issues/130) and [#63](https://github.com/nationalbankbelgium/stark/issues/63) ([abeefe7](https://github.com/nationalbankbelgium/stark/commit/abeefe7))
 * **stark-all:** add commitizen + commitlint with scripts, config & dependencies ([1cb59c2](https://github.com/nationalbankbelgium/stark/commit/1cb59c2)), closes [#290](https://github.com/nationalbankbelgium/stark/issues/290)
-* **stark-all:** enable npm ci for travis + add package-lock.json + force registry.npmjs.org as registry ([f47d610](https://github.com/nationalbankbelgium/stark/commit/f47d610)), closes [#43](https://github.com/nationalbankbelgium/stark/issues/43)
 * **stark-all:** enable resourcesInlining once we have Angular 6 for inlining template in components ([9b33ccd](https://github.com/nationalbankbelgium/stark/commit/9b33ccd)), closes [#376](https://github.com/nationalbankbelgium/stark/issues/376)
 * **stark-all:** integrate SonarTS to current TSLint checks. Refactor code to fix TSLint violations. ([8627ab4](https://github.com/nationalbankbelgium/stark/commit/8627ab4)), closes [#331](https://github.com/nationalbankbelgium/stark/issues/331)
 * **stark-all:** move dev dependencies from packages to ROOT of project + Fix source-map-loader issue ([98d2bc0](https://github.com/nationalbankbelgium/stark/commit/98d2bc0)), closes [#371](https://github.com/nationalbankbelgium/stark/issues/371)
 * **stark-all:** update to Angular 6, Rxjs 6, Webpack 4, TypeScript 2.7.2 ([862d10a](https://github.com/nationalbankbelgium/stark/commit/862d10a)), closes [#359](https://github.com/nationalbankbelgium/stark/issues/359) [#258](https://github.com/nationalbankbelgium/stark/issues/258) [#19](https://github.com/nationalbankbelgium/stark/issues/19)
-* **stark-build:** add support for environment variables at runtime (importing environment.ts file) and at compilation time (using webpack Define plugin) ([c29e36b](https://github.com/nationalbankbelgium/stark/commit/c29e36b)), closes [#50](https://github.com/nationalbankbelgium/stark/issues/50)
-* **stark-build:** added html-element-webpack-plugin to handle head section in index.html ([ce089c8](https://github.com/nationalbankbelgium/stark/commit/ce089c8)), closes [#60](https://github.com/nationalbankbelgium/stark/issues/60)
-* **stark-core:** add [@ngrx-store-devtools](https://github.com/ngrx-store-devtools) package. Integrate store dev tools in showcase and starter ([b9c9179](https://github.com/nationalbankbelgium/stark/commit/b9c9179)), closes [#81](https://github.com/nationalbankbelgium/stark/issues/81) [#117](https://github.com/nationalbankbelgium/stark/issues/117)
-* **stark-core:** http-service: isolate NBB specifics ([e58afa7](https://github.com/nationalbankbelgium/stark/commit/e58afa7)), closes [#257](https://github.com/nationalbankbelgium/stark/issues/257)
-* **stark-demo:** add pretty-print component to Showcase Demo ([93557cb](https://github.com/nationalbankbelgium/stark/commit/93557cb)), closes [#496](https://github.com/nationalbankbelgium/stark/issues/496)
 * **stark-demo:** cleanup of Stark Showcase application ([c0a0163](https://github.com/nationalbankbelgium/stark/commit/c0a0163)), closes [#422](https://github.com/nationalbankbelgium/stark/issues/422)
 * **stark-starter:** add NgIdleKeepAlive module in app module ([305989b](https://github.com/nationalbankbelgium/stark/commit/305989b)), closes [#261](https://github.com/nationalbankbelgium/stark/issues/261)
-* **stark-ui:** action Bar Component ([d1dd733](https://github.com/nationalbankbelgium/stark/commit/d1dd733)), closes [#481](https://github.com/nationalbankbelgium/stark/issues/481)
-* **stark-ui:** add Prettier and use it for all the supported types of data ([5b06aef](https://github.com/nationalbankbelgium/stark/commit/5b06aef)), closes [#500](https://github.com/nationalbankbelgium/stark/issues/500)
-* **stark-ui:** add stark-action-bar into stark-table ([d3a2c6d](https://github.com/nationalbankbelgium/stark/commit/d3a2c6d)), closes [#512](https://github.com/nationalbankbelgium/stark/issues/512)
-* **stark-ui:** example Viewer + basic showcase layout ([ff675c8](https://github.com/nationalbankbelgium/stark/commit/ff675c8)), closes [#458](https://github.com/nationalbankbelgium/stark/issues/458) [#459](https://github.com/nationalbankbelgium/stark/issues/459)
-* **stark-ui:** implement OnEnterKey directive. Create KeyboardDirectives module ([0696959](https://github.com/nationalbankbelgium/stark/commit/0696959)), closes [#538](https://github.com/nationalbankbelgium/stark/issues/538)
-* **stark-ui:** implement RestrictInput directive and module ([b8bd5be](https://github.com/nationalbankbelgium/stark/commit/b8bd5be)), closes [#546](https://github.com/nationalbankbelgium/stark/issues/546) [#550](https://github.com/nationalbankbelgium/stark/issues/550)
 * **stark-ui:** implement SvgViewBox directive to enable resizing of Angular Material's mat-icon directive ([b4dc8ec](https://github.com/nationalbankbelgium/stark/commit/b4dc8ec)), closes [#455](https://github.com/nationalbankbelgium/stark/issues/455)
-* **stark-ui:** implement the Stark-Pretty-Print component ([22f84b6](https://github.com/nationalbankbelgium/stark/commit/22f84b6)), closes [#494](https://github.com/nationalbankbelgium/stark/issues/494) [#496](https://github.com/nationalbankbelgium/stark/issues/496)
-* **stark-ui:** implement the Stark-Slider component ([fd6d03d](https://github.com/nationalbankbelgium/stark/commit/fd6d03d)), closes [#448](https://github.com/nationalbankbelgium/stark/issues/448)
-* **stark-ui:** implementation of the button's theme ([c49b6ef](https://github.com/nationalbankbelgium/stark/commit/c49b6ef)), closes [#476](https://github.com/nationalbankbelgium/stark/issues/476)
-* **stark-ui:** import old stark ui global theming ([9ac8dde](https://github.com/nationalbankbelgium/stark/commit/9ac8dde)), closes [#456](https://github.com/nationalbankbelgium/stark/issues/456) [#472](https://github.com/nationalbankbelgium/stark/issues/472)
-* **stark-ui:** improve example viewer styling ([bad3746](https://github.com/nationalbankbelgium/stark/commit/bad3746)), closes [#515](https://github.com/nationalbankbelgium/stark/issues/515)
-* **stark-ui:** initial implementation of Stark Table component (supporting nested data, sorting and filtering) ([80e86c3](https://github.com/nationalbankbelgium/stark/commit/80e86c3))
 * **translation:** add functionality to enable the use of translations in Stark modules ([fbdfc25](https://github.com/nationalbankbelgium/stark/commit/fbdfc25))
 * **ui:** add material theming ([9b03c06](https://github.com/nationalbankbelgium/stark/commit/9b03c06))
 * **ui:** create stark-ui package. Implement AppLogo module in Stark. ([ffaeacd](https://github.com/nationalbankbelgium/stark/commit/ffaeacd)), closes [#101](https://github.com/nationalbankbelgium/stark/issues/101)
 * **ui:** integrate [@mdi](https://github.com/mdi)/angular-material icons ([1e30ab7](https://github.com/nationalbankbelgium/stark/commit/1e30ab7)), closes [#123](https://github.com/nationalbankbelgium/stark/issues/123)
-
-
-### Performance Improvements
-
-* **build-main:** adapt "npm install" commands to prevent optional dependencies from being installed. Enable parallelization in webpack prod config. ([020a5f4](https://github.com/nationalbankbelgium/stark/commit/020a5f4))
 
 
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The Changelog generated during the latest release is wrong: all the changes from the `10.0.0-alpha.4` version are merged with the ones from the `10.0.0-alpha.3` version.

The cause of the issue is that the tag `10.0.0-alpha.3` is set in the wrong commit instead of being set in the "release" commit.


## What is the new behavior?
- The tag has been fixed and it is now set in the "release" commit of version `10.0.0-alpha.3`
- The auto-generated log contains now the `10.0.0-alpha.3` and `10.0.0-alpha.4` versions with their corresponding changes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The tag `10.0.0-alpha.3` has been re-created preserving the original date. 
Reference: https://github.com/openmelody/melody/wiki/devbest-tagging#tagging-your-way-through-history