### PR TITLE
ci(stark-build): downgrade npm back to 5.8.0 due to 'npm pack' failure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - AUTHOR_NAME="$(git log -1 $TRAVIS_COMMIT --pretty="%aN")"
   - echo $AUTHOR_NAME
   - export TZ=Europe/Brussels
-  - npm i -g npm@6.3.0
+  - npm i -g npm@5.8.0
   - npm i -g greenkeeper-lockfile
   # This ensures that we are authenticated without requiring to have an actual .npmrc file within the project
   - 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc'
@@ -63,4 +63,3 @@ script:
 after_success:
   - npm run test:ci:coveralls:combined
   - greenkeeper-lockfile-upload
-


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Travis builds fail due to the `npm pack` command triggered in our `build.sh` suddenly stops and executes the next command `adaptNpmPackageDependencies` which fails.


## What is the new behavior?
The `npm pack` is executed correctly and the command `adaptNpmPackageDependencies` is executed afterwards as soon as the `npm pack` finishes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information