### PR TITLE
ci(build-main): adapt travis config to remove all package-lock.json before installing all packages on PRs from GreenKeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   # cfr scripts/_travis-fold.sh
   - mkdir -p $LOGS_DIR
   - touch $LOGS_DIR/build-perf.log
+  - if [[ ${TRAVIS_BRANCH} =~ ^greenkeeper.*$ || ${AUTHOR_NAME} == "greenkeeper[bot]" ]]; then npm run clean:modules:all; fi
   - if [[ ${TRAVIS_BRANCH} =~ ^greenkeeper.*$ || ${AUTHOR_NAME} == "greenkeeper[bot]" ]]; then npm i --no-optional; else npm ci; fi
   - if [[ ${TRAVIS_BRANCH} =~ ^greenkeeper.*$ || ${AUTHOR_NAME} == "greenkeeper[bot]" ]]; then npm run install:travis:all; else npm run install:ci:all; fi
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
PRs submitted by GreenKeeper fail due to an NPM error:

```
npm ERR! enoent ENOENT: no such file or directory, rename '/home/travis/build/NationalBankBelgium/stark/packages/stark-core/node_modules/.staging/@nationalbankbelgium/stark-testing-c8dfe007/node_modules/@types/jasmine' -> '/home/travis/build/NationalBankBelgium/stark/packages/stark-core/node_modules/.staging/@types/jasmine-efe0cc22'
```

The issue seems to be related to the fact that the `package-lock.json` is present containing the previous versions but the `package.json` has the newer versions upgraded by GreenKeeper.

## What is the new behavior?
The `package-lock.json` of all packages is removed before the installation starts so that such files are re-created with the upgrades done by GreenKeeper.

**This behavior is enabled only for PRs from GreenKeeper.**

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->