### PR TITLE
fix(release): fix wrong pushRepo option in release-it according to the latest version

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -20,7 +20,7 @@
 		"tagAnnotation": "%s",
 		"push": true,
 		"pushArgs": "",
-		"pushRepo": null,
+		"pushRepo": "origin",
 		"beforeStartCommand": false,
 		"afterReleaseCommand": false
 	},


### PR DESCRIPTION
ISSUES CLOSED: #669

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #669 


## What is the new behavior?
The `pushRepo` option of the release-it config is now set to `"origin"` as the default config according to the changes made in this commit https://github.com/webpro/release-it/commit/948fb1b8e8fc75e0a448d1e25106ef73b856c98e aimed to solve this issue https://github.com/webpro/release-it/issues/306

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->