### PR TITLE
refactor(stark-ui): make all UI components to extend from the AbstrackStarkUiComponent class. Replace HostBinding property decorator by 'host' component metadata property.

### DIFF
--- a/packages/stark-ui/src/common/classes/abstract-component.ts
+++ b/packages/stark-ui/src/common/classes/abstract-component.ts
@@ -10,6 +10,11 @@ export abstract class AbstractStarkUiComponent implements OnInit {
 	@Input()
 	public color?: string; // Needs to be public for Angular to be able to read this property inside the template.
 
+	/**
+	 * Abstract class constructor
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
+	 */
 	protected constructor(protected renderer: Renderer2, protected elementRef: ElementRef) {}
 
 	/**

--- a/packages/stark-ui/src/modules/action-bar/components/action-bar.component.ts
+++ b/packages/stark-ui/src/modules/action-bar/components/action-bar.component.ts
@@ -1,7 +1,8 @@
-import { Component, Inject, Input, HostBinding, OnInit, ViewEncapsulation } from "@angular/core";
+import { Component, Inject, Input, OnInit, ViewEncapsulation, Renderer2, ElementRef } from "@angular/core";
 import { StarkActionBarConfig } from "./action-bar-config.intf";
 import { StarkAction } from "./action.intf";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 export type StarkActionBarComponentMode = "full" | "compact";
 
@@ -16,15 +17,13 @@ const componentName: string = "stark-action-bar";
 @Component({
 	selector: "stark-action-bar",
 	templateUrl: "./action-bar.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkActionBarComponent implements OnInit {
-	/**
-	 * Adds class="stark-action-bar" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkActionBarComponent extends AbstractStarkUiComponent implements OnInit {
 	/**
 	 * HTML id of action bar component.
 	 */
@@ -72,8 +71,16 @@ export class StarkActionBarComponent implements OnInit {
 	/**
 	 * Class constructor
 	 * @param logger - The logger of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
-	public constructor(@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService) {}
+	public constructor(
+		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
+	) {
+		super(renderer, elementRef);
+	}
 
 	/**
 	 * Component lifecycle hook

--- a/packages/stark-ui/src/modules/app-logo/components/app-logo.component.ts
+++ b/packages/stark-ui/src/modules/app-logo/components/app-logo.component.ts
@@ -1,5 +1,6 @@
-import { Component, HostBinding, Inject, Input, OnInit, ViewEncapsulation } from "@angular/core";
+import { Component, ElementRef, Inject, Input, OnInit, Renderer2, ViewEncapsulation } from "@angular/core";
 import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE, StarkLoggingService, StarkRoutingService } from "@nationalbankbelgium/stark-core";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
  * Name of the component
@@ -12,15 +13,13 @@ const componentName: string = "stark-app-logo";
 @Component({
 	selector: "stark-app-logo",
 	templateUrl: "./app-logo.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkAppLogoComponent implements OnInit {
-	/**
-	 * Adds class="stark-app-logo" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkAppLogoComponent extends AbstractStarkUiComponent implements OnInit {
 	/**
 	 * Params object to be passed to the UI router state defined as homeState.
 	 */
@@ -31,12 +30,16 @@ export class StarkAppLogoComponent implements OnInit {
 	 * Class constructor
 	 * @param logger - The logger of the application
 	 * @param routingService - The routing service of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
-		@Inject(STARK_ROUTING_SERVICE) public routingService: StarkRoutingService
+		@Inject(STARK_ROUTING_SERVICE) public routingService: StarkRoutingService,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
 	) {
-		// empty constructor
+		super(renderer, elementRef);
 	}
 
 	/**

--- a/packages/stark-ui/src/modules/app-logout/components/app-logout.component.ts
+++ b/packages/stark-ui/src/modules/app-logout/components/app-logout.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, Inject, Input, OnInit, ViewEncapsulation } from "@angular/core";
+import { Component, ElementRef, Inject, Input, OnInit, Renderer2, ViewEncapsulation } from "@angular/core";
 
 import {
 	STARK_LOGGING_SERVICE,
@@ -10,6 +10,7 @@ import {
 	STARK_SESSION_SERVICE,
 	StarkSessionService
 } from "@nationalbankbelgium/stark-core";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
  * Name of the component
@@ -22,15 +23,13 @@ const componentName: string = "stark-app-logout";
 @Component({
 	selector: "stark-app-logout",
 	templateUrl: "./app-logout.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkAppLogoutComponent implements OnInit {
-	/**
-	 * Adds class="stark-app-logout" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkAppLogoutComponent extends AbstractStarkUiComponent implements OnInit {
 	/**
 	 * Desired icon of the logout button
 	 */
@@ -43,14 +42,18 @@ export class StarkAppLogoutComponent implements OnInit {
 	 * @param routingService - The routing service of the application
 	 * @param sessionService - The session service of the application
 	 * @param appConfig - The configuration of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
 		@Inject(STARK_ROUTING_SERVICE) public routingService: StarkRoutingService,
 		@Inject(STARK_SESSION_SERVICE) public sessionService: StarkSessionService,
-		@Inject(STARK_APP_CONFIG) public appConfig: StarkApplicationConfig
+		@Inject(STARK_APP_CONFIG) public appConfig: StarkApplicationConfig,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
 	) {
-		// empty constructor
+		super(renderer, elementRef);
 	}
 
 	/**

--- a/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.ts
+++ b/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.ts
@@ -1,8 +1,9 @@
-import { Component, HostBinding, Inject, Input, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from "@angular/core";
+import { Component, ElementRef, Inject, Input, OnDestroy, OnInit, Renderer2, ViewChild, ViewEncapsulation } from "@angular/core";
 import { from, Subscription } from "rxjs";
 import { MatSidenav, MatSidenavContainer, MatDrawerToggleResult } from "@angular/material/sidenav";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkAppSidebarOpenEvent, StarkAppSidebarService, STARK_APP_SIDEBAR_SERVICE } from "../services";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 export type StarkAppSidebarLeftMode = "regular" | "menu";
 
@@ -18,15 +19,13 @@ const componentName: string = "stark-app-sidebar";
 @Component({
 	selector: "stark-app-sidebar",
 	templateUrl: "./app-sidebar.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkAppSidebarComponent implements OnDestroy, OnInit {
-	/**
-	 * Adds class="stark-app-sidebar" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkAppSidebarComponent extends AbstractStarkUiComponent implements OnDestroy, OnInit {
 	/**
 	 * Mode for the left sidebar: either the menu is shown or the regular sidebar
 	 */
@@ -63,12 +62,19 @@ export class StarkAppSidebarComponent implements OnDestroy, OnInit {
 
 	/**
 	 * Class constructor
+	 * @param logger - The logger of the application
 	 * @param sidebarService - The sidebar service of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
-		@Inject(STARK_APP_SIDEBAR_SERVICE) public sidebarService: StarkAppSidebarService
-	) {}
+		@Inject(STARK_APP_SIDEBAR_SERVICE) public sidebarService: StarkAppSidebarService,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
+	) {
+		super(renderer, elementRef);
+	}
 
 	/**
 	 * Component lifecycle OnInit hook

--- a/packages/stark-ui/src/modules/app-sidebar/services/app-sidebar-open-event.intf.ts
+++ b/packages/stark-ui/src/modules/app-sidebar/services/app-sidebar-open-event.intf.ts
@@ -1,7 +1,14 @@
 /**
- * StarkAppSidebarOpenEvent interface
+ * Event to be emitted by the Stark App Sidebar service interface when it opens a sidebar
  */
 export interface StarkAppSidebarOpenEvent {
+	/**
+	 * Mode of the open sidebar
+	 */
 	mode?: "regular" | "menu";
+
+	/**
+	 * Type of the open sidebar
+	 */
 	sidebar: "left" | "right";
 }

--- a/packages/stark-ui/src/modules/app-sidebar/services/app-sidebar.service.intf.ts
+++ b/packages/stark-ui/src/modules/app-sidebar/services/app-sidebar.service.intf.ts
@@ -28,22 +28,22 @@ export interface StarkAppSidebarService {
 	closeSidebar$: Observable<void>;
 
 	/**
-	 * open sidebar's menu
+	 * Open sidebar's menu
 	 */
 	openMenu(): void;
 
 	/**
-	 * open the left sidebar
+	 * Open the left sidebar
 	 */
 	openLeft(): void;
 
 	/**
-	 * open the right sidebar
+	 * Open the right sidebar
 	 */
 	openRight(): void;
 
 	/**
-	 * close all sidebars
+	 * Close all sidebars
 	 */
 	close(): void;
 }

--- a/packages/stark-ui/src/modules/app-sidebar/services/app-sidebar.service.ts
+++ b/packages/stark-ui/src/modules/app-sidebar/services/app-sidebar.service.ts
@@ -1,15 +1,11 @@
 import { Injectable, Inject } from "@angular/core";
 import { Observable, Subject } from "rxjs";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
-import { StarkAppSidebarService } from "./app-sidebar.service.intf";
+import { StarkAppSidebarService, starkAppSidebarServiceName } from "./app-sidebar.service.intf";
 import { StarkAppSidebarOpenEvent } from "./app-sidebar-open-event.intf";
 
 /**
- * Name of the service
- */
-const serviceName: string = "StarkAppSidebarService";
-
-/**
+ * @ignore
  * StarkAppSidebarService service
  */
 @Injectable()
@@ -29,7 +25,7 @@ export class StarkAppSidebarServiceImpl implements StarkAppSidebarService {
 	public closeSidebar$: Observable<void> = this.closeSidebarSource.asObservable();
 
 	public constructor(@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService) {
-		this.logger.debug(serviceName + " loaded");
+		this.logger.debug(starkAppSidebarServiceName + " loaded");
 	}
 
 	public openMenu(): void {

--- a/packages/stark-ui/src/modules/app-sidebar/testing/app-sidebar.mock.ts
+++ b/packages/stark-ui/src/modules/app-sidebar/testing/app-sidebar.mock.ts
@@ -1,24 +1,63 @@
-/**
- * Mock class of the StarkAppSidebarService interface.
- * @link StarkAppSidebarService
- */
-import { Observable, Subject } from "rxjs";
+import { Subject } from "rxjs";
 import { StarkAppSidebarOpenEvent, StarkAppSidebarService } from "@nationalbankbelgium/stark-ui";
 
+/**
+ * Mock class of the {@link StarkAppSidebarService|StarkAppSidebarService}.
+ *
+ * * `IMPORTANT:` This class just provides mocks (jasmine Spies) for all the methods of the actual service.
+ * Therefore, it is up to you to define the return values of such spies according to your needs.
+ *
+ * You can use it in your unit tests by providing it while configuring the testing module in the TestBed. For example:
+ * ```typescript
+ * import { STARK_APP_SIDEBAR_SERVICE } from "@nationalbankbelgium/stark-ui";
+ * import { MockAppSidebarService } from "@nationalbankbelgium/stark-ui/testing";
+ *
+ * describe("Some test", () => {
+ *
+ *     beforeEach(async(() => {
+ *         return TestBed.configureTestingModule({
+ *             imports: [...],
+ *             declarations: [...],
+ *             providers: [
+ *                 // provide is as a value
+ *                 { provide: STARK_APP_SIDEBAR_SERVICE, useValue: new MockAppSidebarService() },
+ *                 // or as a class
+ *                 { provide: STARK_APP_SIDEBAR_SERVICE, useClass: MockAppSidebarService }
+ *             ]
+ *         }).compileComponents();
+ *     }));
+ *
+ * }
+ * ```
+ */
 export class MockAppSidebarService implements StarkAppSidebarService {
-	private openSidebarSource: Subject<StarkAppSidebarOpenEvent> = new Subject<StarkAppSidebarOpenEvent>();
+	/**
+	 * Observable subscribed by components to catch open events
+	 */
+	public openSidebar$: Subject<StarkAppSidebarOpenEvent> = new Subject<StarkAppSidebarOpenEvent>();
 
-	public openSidebar$: Observable<StarkAppSidebarOpenEvent> = this.openSidebarSource.asObservable();
+	/**
+	 * Observable subscribed by components to catch close events
+	 */
+	public closeSidebar$: Subject<void> = new Subject<void>();
 
-	private closeSidebarSource: Subject<void> = new Subject<void>();
-
-	public closeSidebar$: Observable<void> = this.closeSidebarSource.asObservable();
-
+	/**
+	 * Open sidebar's menu
+	 */
 	public openMenu: () => void = jasmine.createSpy("openMenu");
 
+	/**
+	 * Open the left sidebar
+	 */
 	public openLeft: () => void = jasmine.createSpy("openLeft");
 
+	/**
+	 * Open the right sidebar
+	 */
 	public openRight: () => void = jasmine.createSpy("openRight");
 
+	/**
+	 * Close all sidebars
+	 */
 	public close: () => void = jasmine.createSpy("close");
 }

--- a/packages/stark-ui/src/modules/breadcrumb/components/breadcrumb-config.intf.ts
+++ b/packages/stark-ui/src/modules/breadcrumb/components/breadcrumb-config.intf.ts
@@ -4,5 +4,8 @@ import { StarkBreadcrumbPath } from "./breadcrumb-path.intf";
  * Interface that will define all paths to be displayed by the breadcrumb component
  */
 export interface StarkBreadcrumbConfig {
+	/**
+	 * Array of {@link StarkBreadcrumbPath|StarkBreadcrumbPath} objects
+	 */
 	breadcrumbPaths: StarkBreadcrumbPath[];
 }

--- a/packages/stark-ui/src/modules/breadcrumb/components/breadcrumb-path.intf.ts
+++ b/packages/stark-ui/src/modules/breadcrumb/components/breadcrumb-path.intf.ts
@@ -1,9 +1,24 @@
 /**
- * Interface that will define a path used in the breadcrumn ocmponent
+ * Interface that will define a path used in the breadcrumb component
  */
 export interface StarkBreadcrumbPath {
+	/**
+	 * The unique id to be given to the link of this breadcrumb path
+	 */
 	id: string;
+
+	/**
+	 * The name of the state that will be navigated to
+	 */
 	state: string;
+
+	/**
+	 * The params needed for the state
+	 */
 	stateParams: { [param: string]: any };
+
+	/**
+	 * The key used to translate the label of the specific path. If empty, the path will be taken instead
+	 */
 	translationKey: string;
 }

--- a/packages/stark-ui/src/modules/collapsible/components/collapsible.component.ts
+++ b/packages/stark-ui/src/modules/collapsible/components/collapsible.component.ts
@@ -1,5 +1,6 @@
-import { Component, EventEmitter, HostBinding, Inject, Input, OnInit, Output } from "@angular/core";
+import { Component, ElementRef, EventEmitter, Inject, Input, OnInit, Output, Renderer2, ViewEncapsulation } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
  * Name of the component
@@ -11,15 +12,14 @@ const componentName: string = "stark-collapsible";
  */
 @Component({
 	selector: "stark-collapsible",
-	templateUrl: "./collapsible.component.html"
+	templateUrl: "./collapsible.component.html",
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkCollapsibleComponent implements OnInit {
-	/**
-	 * Adds class="stark-app-logo" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkCollapsibleComponent extends AbstractStarkUiComponent implements OnInit {
 	/**
 	 * ID to set to the collapsible
 	 */
@@ -61,9 +61,15 @@ export class StarkCollapsibleComponent implements OnInit {
 	/**
 	 * Class constructor
 	 * @param logger - The logger of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
-	public constructor(@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService) {
-		// empty constructor
+	public constructor(
+		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
+	) {
+		super(renderer, elementRef);
 	}
 
 	/**

--- a/packages/stark-ui/src/modules/date-picker/components/date-picker.component.ts
+++ b/packages/stark-ui/src/modules/date-picker/components/date-picker.component.ts
@@ -1,7 +1,8 @@
-import { Component, EventEmitter, HostBinding, Inject, Input, OnInit, Output, ViewChild, ViewEncapsulation } from "@angular/core";
+import { Component, ElementRef, EventEmitter, Inject, Input, OnInit, Output, Renderer2, ViewChild, ViewEncapsulation } from "@angular/core";
 import { MatDatepicker, MatDatepickerInput, MatDatepickerInputEvent } from "@angular/material";
 import moment from "moment";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 export type StarkDatePickerFilter = "OnlyWeekends" | "OnlyWeekdays" | ((date: Date) => boolean) | undefined;
 
@@ -16,15 +17,13 @@ const componentName: string = "stark-date-picker";
 @Component({
 	selector: "stark-date-picker",
 	templateUrl: "./date-picker.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkDatePickerComponent implements OnInit {
-	/**
-	 * Adds class="stark-date-picker" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkDatePickerComponent extends AbstractStarkUiComponent implements OnInit {
 	/**
 	 * Source Date to be bound to the datepicker model
 	 */
@@ -49,6 +48,10 @@ export class StarkDatePickerComponent implements OnInit {
 		}
 	}
 
+	/**
+	 * @ignore
+	 * @internal
+	 */
 	private _dateFilter?: StarkDatePickerFilter;
 
 	/**
@@ -110,8 +113,16 @@ export class StarkDatePickerComponent implements OnInit {
 	/**
 	 * Class constructor
 	 * @param logger - The logger of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
-	public constructor(@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService) {}
+	public constructor(
+		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
+	) {
+		super(renderer, elementRef);
+	}
 
 	/**
 	 * Component lifecycle hook
@@ -156,7 +167,7 @@ export class StarkDatePickerComponent implements OnInit {
 
 	/**
 	 * Handle the date changed on mat-datepicker and emit the dateChanged event
-	 * @param MatDatepickerInputEvent<Date> - the mat-datepicker event
+	 * @param event - The MatDatepickerInputEvent to re-emit
 	 */
 	public onDateChange(event: MatDatepickerInputEvent<moment.Moment>): void {
 		if (event.value) {

--- a/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker-event.intf.ts
+++ b/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker-event.intf.ts
@@ -1,0 +1,14 @@
+/**
+ * Event to be emitted by the Stark Date Range Picker component when the date range changes
+ */
+export interface StarkDateRangePickerEvent {
+	/**
+	 * Selected start date
+	 */
+	startDate?: Date;
+
+	/**
+	 * Selected end date
+	 */
+	endDate?: Date;
+}

--- a/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker.component.spec.ts
+++ b/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker.component.spec.ts
@@ -1,11 +1,12 @@
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { StarkDatePickerModule } from "./../../date-picker";
-import { StarkDateRangePickerComponent, StarkDateRangePickerEvent } from "./date-range-picker.component";
+import { EventEmitter } from "@angular/core";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE } from "@nationalbankbelgium/stark-core";
 import { MockStarkLoggingService, MockStarkRoutingService } from "@nationalbankbelgium/stark-core/testing";
-import { TranslateModule, TranslateService } from "@ngx-translate/core";
-import { EventEmitter } from "@angular/core";
+import { StarkDatePickerModule } from "./../../date-picker";
+import { StarkDateRangePickerComponent } from "./date-range-picker.component";
+import { StarkDateRangePickerEvent } from "./date-range-picker-event.intf";
 
 describe("DateRangePickerComponent", () => {
 	let fixture: ComponentFixture<StarkDateRangePickerComponent>;

--- a/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker.component.ts
+++ b/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker.component.ts
@@ -1,15 +1,9 @@
-import { Component, EventEmitter, HostBinding, Inject, Input, OnInit, Output, ViewChild, ViewEncapsulation } from "@angular/core";
+import { Component, ElementRef, EventEmitter, Inject, Input, OnInit, Output, Renderer2, ViewChild, ViewEncapsulation } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
-import { StarkDatePickerFilter, StarkDatePickerComponent } from "./../../date-picker/components/date-picker.component";
 import moment from "moment";
-
-/**
- * StarkDateRangePickerEvent interface
- */
-export interface StarkDateRangePickerEvent {
-	startDate?: Date;
-	endDate?: Date;
-}
+import { StarkDatePickerFilter, StarkDatePickerComponent } from "./../../date-picker/components/date-picker.component";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
+import { StarkDateRangePickerEvent } from "./date-range-picker-event.intf";
 
 /**
  * Name of the component
@@ -22,15 +16,13 @@ const componentName: string = "stark-date-range-picker";
 @Component({
 	selector: "stark-date-range-picker",
 	templateUrl: "./date-range-picker.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkDateRangePickerComponent implements OnInit {
-	/**
-	 * Adds class="stark-date-range-picker" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkDateRangePickerComponent extends AbstractStarkUiComponent implements OnInit {
 	/**
 	 * Filter function or a string
 	 * Will be applied to both date-picker
@@ -126,8 +118,16 @@ export class StarkDateRangePickerComponent implements OnInit {
 	/**
 	 * Class constructor
 	 * @param logger - The logger of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
-	public constructor(@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService) {}
+	public constructor(
+		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
+	) {
+		super(renderer, elementRef);
+	}
 
 	/**
 	 * Component lifecycle hook

--- a/packages/stark-ui/src/modules/dropdown/components/dropdown.component.ts
+++ b/packages/stark-ui/src/modules/dropdown/components/dropdown.component.ts
@@ -12,7 +12,7 @@ import {
 	Renderer2
 } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
-import { AbstractStarkUiComponent } from "./../../../common/classes/abstract-component";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
  * Name of the component
@@ -125,8 +125,18 @@ export class StarkDropdownComponent extends AbstractStarkUiComponent implements 
 	@Output()
 	public dropdownSelectionChanged: EventEmitter<any> = new EventEmitter<any>();
 
+	/**
+	 * @ignore
+	 * @internal
+	 */
 	public optionsAreSimpleTypes: boolean;
 
+	/**
+	 * Class constructor
+	 * @param logger - The logger of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
+	 */
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
 		protected renderer: Renderer2,

--- a/packages/stark-ui/src/modules/language-selector/components/language-selector.component.ts
+++ b/packages/stark-ui/src/modules/language-selector/components/language-selector.component.ts
@@ -27,6 +27,7 @@ export type StarkLanguageSelectorMode = "dropdown" | "toolbar";
 	selector: "stark-language-selector",
 	templateUrl: "./language-selector.component.html",
 	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
 	host: {
 		class: componentName
 	}
@@ -61,6 +62,8 @@ export class StarkLanguageSelectorComponent extends AbstractStarkUiComponent imp
 	 * @param logger - The logger of the application
 	 * @param sessionService - The session service of the application
 	 * @param dateAdapter - Needed to change the locale of the DateAdapter
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
 	public constructor(
 		@Inject(STARK_APP_METADATA) public appMetadata: StarkApplicationMetadata,

--- a/packages/stark-ui/src/modules/pretty-print/components/pretty-print.component.ts
+++ b/packages/stark-ui/src/modules/pretty-print/components/pretty-print.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostBinding, Inject, Input, OnChanges, OnInit, SimpleChanges, ViewEncapsulation } from "@angular/core";
+import { Component, ElementRef, Inject, Input, OnChanges, OnInit, Renderer2, SimpleChanges, ViewEncapsulation } from "@angular/core";
 
 /* tslint:disable:no-duplicate-imports no-import-side-effect */
 import * as Prism from "prismjs";
@@ -12,6 +12,7 @@ import "prismjs/components/prism-scss.min.js";
 /* tslint:enable */
 
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
  * Name of the component
@@ -65,15 +66,13 @@ export type StarkPrettyPrintFormat = "css" | "scss" | "html" | "xml" | "json" | 
 @Component({
 	selector: "stark-pretty-print",
 	templateUrl: "./pretty-print.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkPrettyPrintComponent implements OnChanges, OnInit {
-	/**
-	 * Adds class="stark-pretty-print" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkPrettyPrintComponent extends AbstractStarkUiComponent implements OnChanges, OnInit {
 	/**
 	 * The text to be pretty printed
 	 */
@@ -92,14 +91,29 @@ export class StarkPrettyPrintComponent implements OnChanges, OnInit {
 	@Input()
 	public enableHighlighting?: boolean;
 
+	/**
+	 * The final prettified string
+	 */
 	public prettyString: string;
+
+	/**
+	 * Whether the prettified string should be highlighted as well
+	 */
 	public highlightingEnabled: boolean;
 
 	/**
 	 * Class constructor
 	 * @param logger - The logger of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
-	public constructor(@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService) {}
+	public constructor(
+		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
+	) {
+		super(renderer, elementRef);
+	}
 
 	/**
 	 * Component lifecycle hook

--- a/packages/stark-ui/src/modules/slider/components/slider.component.ts
+++ b/packages/stark-ui/src/modules/slider/components/slider.component.ts
@@ -3,12 +3,12 @@ import {
 	Component,
 	ElementRef,
 	EventEmitter,
-	HostBinding,
 	Inject,
 	Input,
 	OnChanges,
 	OnInit,
 	Output,
+	Renderer2,
 	SimpleChanges,
 	ViewEncapsulation
 } from "@angular/core";
@@ -19,6 +19,7 @@ import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE, StarkLoggingService, Star
 
 import { StarkDOMUtil } from "../../../util/dom.util";
 import { StarkSliderConfig } from "./slider-config.intf";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
  * @ignore
@@ -36,15 +37,13 @@ const componentName: string = "stark-slider";
 @Component({
 	selector: "stark-slider",
 	templateUrl: "./slider.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkSliderComponent implements AfterViewInit, OnChanges, OnInit {
-	/**
-	 * Adds class="stark-slider" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkSliderComponent extends AbstractStarkUiComponent implements AfterViewInit, OnChanges, OnInit {
 	/**
 	 * Whether the slider is disabled. Default: false
 	 */
@@ -99,15 +98,18 @@ export class StarkSliderComponent implements AfterViewInit, OnChanges, OnInit {
 
 	/**
 	 * Class constructor
-	 * @param logger : the logger of the application
-	 * @param routingService : the routing service of the application
-	 * @param elementRef: provides direct access to the DOM
+	 * @param logger - The logger of the application
+	 * @param routingService - The routing service of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
 		@Inject(STARK_ROUTING_SERVICE) public routingService: StarkRoutingService,
-		private elementRef: ElementRef
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
 	) {
+		super(renderer, elementRef);
 		this.noUiSliderLibrary = noUiSliderLibrary;
 	}
 

--- a/packages/stark-ui/src/modules/table/components/column.component.ts
+++ b/packages/stark-ui/src/modules/table/components/column.component.ts
@@ -1,15 +1,17 @@
 import {
 	Component,
 	ContentChild,
+	ElementRef,
 	EventEmitter,
-	HostBinding,
 	Input,
 	Output,
+	Renderer2,
 	TemplateRef,
 	ViewChild,
 	ViewEncapsulation
 } from "@angular/core";
 import { MatColumnDef } from "@angular/material/table";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
  * @ignore
@@ -27,15 +29,13 @@ export type StarkTableColumnSortingDirection = "asc" | "desc" | "";
 @Component({
 	selector: "stark-table-column",
 	templateUrl: "./column.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: "stark-table-column"
+	}
 })
-export class StarkTableColumnComponent {
-	/**
-	 * Adds class="stark-table-column" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = "stark-table-column";
-
+export class StarkTableColumnComponent extends AbstractStarkUiComponent {
 	/**
 	 * Name of the property that will be the source of the column.
 	 */
@@ -47,6 +47,11 @@ export class StarkTableColumnComponent {
 		this._name = name;
 		this.columnDef.name = name;
 	}
+
+	/**
+	 * @ignore
+	 * @internal
+	 */
 	private _name: string;
 
 	/**
@@ -138,6 +143,15 @@ export class StarkTableColumnComponent {
 	 */
 	@ContentChild(TemplateRef)
 	public columnTemplate: TemplateRef<any>;
+
+	/**
+	 * Class constructor
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
+	 */
+	public constructor(protected renderer: Renderer2, protected elementRef: ElementRef) {
+		super(renderer, elementRef);
+	}
 
 	/**
 	 * Returns the header label of the column if it's specified. If not, simply returns the name of the column

--- a/packages/stark-ui/src/modules/table/components/dialogs/multisort.component.ts
+++ b/packages/stark-ui/src/modules/table/components/dialogs/multisort.component.ts
@@ -1,6 +1,7 @@
-import { Component, Inject, OnInit, ViewEncapsulation, HostBinding } from "@angular/core";
+import { Component, Inject, OnInit, ViewEncapsulation, Renderer2, ElementRef } from "@angular/core";
 import { MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { StarkTableColumnComponent, StarkTableColumnSortingDirection } from "../column.component";
+import { AbstractStarkUiComponent } from "../../../../common/classes/abstract-component";
 
 /**
  * Content of the data to be passed to the StarkTableMultisortDialogComponent
@@ -36,15 +37,13 @@ export interface StarkSortingRule {
 @Component({
 	selector: "stark-table-dialog-multisort",
 	templateUrl: "multisort.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: "stark-table-dialog-multisort"
+	}
 })
-export class StarkTableMultisortDialogComponent implements OnInit {
-	/**
-	 * Adds class="stark-table-dialog-multisort" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = "stark-table-dialog-multisort";
-
+export class StarkTableMultisortDialogComponent extends AbstractStarkUiComponent implements OnInit {
 	/**
 	 * Array of sorting rules currently applied
 	 */
@@ -63,11 +62,17 @@ export class StarkTableMultisortDialogComponent implements OnInit {
 	 * Class constructor
 	 * @param dialogRef - Reference to this dialog opened via the MatDialog service
 	 * @param data - The data to be passed to this dialog component
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
 	public constructor(
 		public dialogRef: MatDialogRef<StarkTableMultisortDialogComponent>,
-		@Inject(MAT_DIALOG_DATA) public data: StarkTableMultisortDialogData
-	) {}
+		@Inject(MAT_DIALOG_DATA) public data: StarkTableMultisortDialogData,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
+	) {
+		super(renderer, elementRef);
+	}
 
 	/**
 	 * Component lifecycle hook

--- a/packages/stark-ui/src/modules/table/components/table.component.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.ts
@@ -4,14 +4,15 @@ import {
 	ChangeDetectorRef,
 	Component,
 	ContentChildren,
+	ElementRef,
 	EventEmitter,
-	HostBinding,
 	Inject,
 	Input,
 	OnChanges,
 	OnInit,
 	Output,
 	QueryList,
+	Renderer2,
 	SimpleChanges,
 	ViewChild,
 	ViewChildren,
@@ -21,6 +22,7 @@ import { MatDialog, MatDialogRef } from "@angular/material/dialog";
 import { MatPaginator } from "@angular/material/paginator";
 import { MatColumnDef, MatTable, MatTableDataSource } from "@angular/material/table";
 import { SelectionModel } from "@angular/cdk/collections";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 
 import { StarkTableColumnComponent, StarkTableColumnSortingDirection } from "./column.component";
 import { StarkSortingRule, StarkTableMultisortDialogComponent, StarkTableMultisortDialogData } from "./dialogs/multisort.component";
@@ -28,7 +30,7 @@ import { StarkActionBarConfig } from "../../action-bar/components/action-bar-con
 import { StarkAction } from "../../action-bar/components/action.intf";
 import { StarkTableColumnProperties } from "./column-properties.intf";
 import { StarkTableFilter } from "./table-filter.intf";
-import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
  * Name of the component
@@ -36,19 +38,20 @@ import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium
 const componentName: string = "stark-table";
 
 /* tslint:disable:enforce-component-selector */
+/**
+ * Component to display array data in a table layout.
+ */
 @Component({
 	selector: componentName,
 	templateUrl: "./table.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
 /* tslint:enable */
-export class StarkTableComponent implements OnInit, AfterContentInit, AfterViewInit, OnChanges {
-	/**
-	 * Adds class="stark-table" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = "stark-table";
-
+export class StarkTableComponent extends AbstractStarkUiComponent implements OnInit, AfterContentInit, AfterViewInit, OnChanges {
 	/**
 	 * Data that will be display inside your table.
 	 */
@@ -187,15 +190,21 @@ export class StarkTableComponent implements OnInit, AfterContentInit, AfterViewI
 
 	/**
 	 * Class constructor
+	 * @param logger - The logging service of the application
 	 * @param dialogService - Angular Material service to open Material Design modal dialogs.
 	 * @param cdRef - Reference to the change detector attached to this component
-	 * @param logger - The logging service of the application
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
 	public constructor(
+		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
 		public dialogService: MatDialog,
 		private cdRef: ChangeDetectorRef,
-		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService
-	) {}
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
+	) {
+		super(renderer, elementRef);
+	}
 
 	/**
 	 * Component lifecycle hook

--- a/packages/stark-ui/src/modules/toast-notification/components/toast-notification.component.ts
+++ b/packages/stark-ui/src/modules/toast-notification/components/toast-notification.component.ts
@@ -1,8 +1,9 @@
-import { Component, HostBinding, Inject, OnInit, ViewEncapsulation } from "@angular/core";
+import { Component, ElementRef, Inject, OnInit, Renderer2, ViewEncapsulation } from "@angular/core";
 import { MAT_SNACK_BAR_DATA, MatSnackBar } from "@angular/material/snack-bar";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkMessageType } from "../../../common/message";
 import { StarkToastMessage } from "./toast-message.intf";
+import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
  * Name of the component
@@ -15,15 +16,13 @@ const componentName: string = "stark-toast-notification";
 @Component({
 	selector: "stark-toast-notification",
 	templateUrl: "./toast-notification.component.html",
-	encapsulation: ViewEncapsulation.None
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: componentName
+	}
 })
-export class StarkToastNotificationComponent implements OnInit {
-	/**
-	 * Adds class="stark-toast-notification" attribute on the host component
-	 */
-	@HostBinding("class")
-	public class: string = componentName;
-
+export class StarkToastNotificationComponent extends AbstractStarkUiComponent implements OnInit {
 	/**
 	 * The message data linked to the toast notification.
 	 */
@@ -34,12 +33,17 @@ export class StarkToastNotificationComponent implements OnInit {
 	 * @param logger - The logger of the application
 	 * @param snackBar - Tha snackBar used to display the toast
 	 * @param data - the data linked to the toast notification
+	 * @param renderer - Angular Renderer wrapper for DOM manipulations.
+	 * @param elementRef - Reference to the DOM element where this directive is applied to.
 	 */
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
 		public snackBar: MatSnackBar,
-		@Inject(MAT_SNACK_BAR_DATA) public data: StarkToastMessage
+		@Inject(MAT_SNACK_BAR_DATA) public data: StarkToastMessage,
+		protected renderer: Renderer2,
+		protected elementRef: ElementRef
 	) {
+		super(renderer, elementRef);
 		this.message = data;
 		this.logger.debug(componentName + ": data received : %o", this.message);
 	}

--- a/packages/stark-ui/src/modules/toast-notification/services/toast-notification.service.ts
+++ b/packages/stark-ui/src/modules/toast-notification/services/toast-notification.service.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Inject } from "@angular/core";
+import { ApplicationRef, Inject, Injectable } from "@angular/core";
 import {
 	MatSnackBar,
 	MatSnackBarConfig,
@@ -16,8 +16,10 @@ import { STARK_TOAST_NOTIFICATION_OPTIONS, StarkToastNotificationOptions } from 
 import { StarkToastNotificationComponent, StarkToastMessage } from "../components";
 
 /**
+ * @ignore
  * Service to display different types of messages in a toast (info, warning or error).
  */
+@Injectable()
 export class StarkToastNotificationServiceImpl implements StarkToastNotificationService {
 	/**
 	 * Observer linked to the currently displayed toast notification
@@ -56,11 +58,6 @@ export class StarkToastNotificationServiceImpl implements StarkToastNotification
 		this.logger.debug(starkToastNotificationServiceName + " loaded");
 	}
 
-	/**
-	 * Returns an observable that will emit one of the possible StarkToastNotificationResult after the toast is closed
-	 * @param message - Message to be shown in the toast.
-	 * @returns Observable that will emit the result value as soon as the toast is closed.
-	 */
 	public show(message: StarkToastMessage): Observable<StarkToastNotificationResult> {
 		if (this.currentToastResult$ && !this.currentToastResult$.closed) {
 			this.currentToastResult$.next(StarkToastNotificationResult.CLOSED_BY_NEW_TOAST);
@@ -92,9 +89,6 @@ export class StarkToastNotificationServiceImpl implements StarkToastNotification
 		});
 	}
 
-	/**
-	 * Hides the current toast and emits the corresponding result in the observable returned by the show() method
-	 */
 	public hide(): void {
 		if (this.currentToastResult$ && !this.currentToastResult$.closed) {
 			this.currentToastResult$.next(StarkToastNotificationResult.HIDDEN);

--- a/packages/stark-ui/src/modules/toast-notification/testing/toast-notification.mock.ts
+++ b/packages/stark-ui/src/modules/toast-notification/testing/toast-notification.mock.ts
@@ -1,10 +1,35 @@
-/**
- * Mock class of the ToastNotificationService interface.
- * @link ToastNotificationService
- */
 import { Observable } from "rxjs";
 import { StarkToastMessage, StarkToastNotificationService, StarkToastNotificationResult } from "@nationalbankbelgium/stark-ui";
 
+/**
+ * Mock class of the {@link StarkToastNotificationService|StarkToastNotificationService}.
+ *
+ * `IMPORTANT:` This class just provides mocks (jasmine Spies) for all the methods of the actual service.
+ * Therefore, it is up to you to define the return values of such spies according to your needs.
+ *
+ * You can use it in your unit tests by providing it while configuring the testing module in the TestBed. For example:
+ * ```typescript
+ * import { STARK_TOAST_NOTIFICATION_SERVICE } from "@nationalbankbelgium/stark-ui";
+ * import { MockToastNotificationService } from "@nationalbankbelgium/stark-ui/testing";
+ *
+ * describe("Some test", () => {
+ *
+ *     beforeEach(async(() => {
+ *         return TestBed.configureTestingModule({
+ *             imports: [...],
+ *             declarations: [...],
+ *             providers: [
+ *                 // provide is as a value
+ *                 { provide: STARK_TOAST_NOTIFICATION_SERVICE, useValue: new MockToastNotificationService() },
+ *                 // or as a class
+ *                 { provide: STARK_TOAST_NOTIFICATION_SERVICE, useClass: MockToastNotificationService }
+ *             ]
+ *         }).compileComponents();
+ *     }));
+ *
+ * }
+ * ```
+ */
 export class MockToastNotificationService implements StarkToastNotificationService {
 	/**
 	 * Returns an observable that will emit one of the possible StarkToastNotificationResult after the toast is closed


### PR DESCRIPTION
ISSUES CLOSED: #664 #693

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #693 #664 


## What is the new behavior?
- All UI components extend from the AbstractStarkUiComponent class
- The 'host' component metadata property is used now in all UI components instead of the `HostBinding` decorator.
- Add/correct JSDocs

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->