### PR TITLE
fix(stark-ui): perform the session login in the Preloading page after fetching the user profile

### DIFF
--- a/packages/stark-ui/src/modules/breadcrumb/components/breadcrumb.component.spec.ts
+++ b/packages/stark-ui/src/modules/breadcrumb/components/breadcrumb.component.spec.ts
@@ -22,7 +22,7 @@ class TestHostComponent {
 	public breadcrumbConfig?: StarkBreadcrumbConfig;
 }
 
-describe("DemoBreadcrumbComponent", () => {
+describe("BreadcrumbComponent", () => {
 	let component: StarkBreadcrumbComponent;
 	let hostComponent: TestHostComponent;
 	let hostFixture: ComponentFixture<TestHostComponent>;

--- a/packages/stark-ui/src/modules/breadcrumb/components/breadcrumb.component.ts
+++ b/packages/stark-ui/src/modules/breadcrumb/components/breadcrumb.component.ts
@@ -71,7 +71,6 @@ export class StarkBreadcrumbComponent extends AbstractStarkUiComponent implement
 			// then refresh the config after every successful transition
 			this.transitionHookDeregisterFn = this.routingService.addTransitionHook(StarkRoutingTransitionHook.ON_SUCCESS, {}, () => {
 				this.breadcrumbConfig = { breadcrumbPaths: this.getPathsFromStateTree() };
-				console.log("breadcrumb: this.breadcrumbConfig  ->  ", this.breadcrumbConfig);
 			});
 		}
 	}

--- a/packages/stark-ui/src/modules/language-selector/components/language-selector.component.spec.ts
+++ b/packages/stark-ui/src/modules/language-selector/components/language-selector.component.spec.ts
@@ -43,7 +43,7 @@ class TestHostComponent {
 	public mode: StarkLanguageSelectorMode;
 }
 
-describe("StarkLanguageSelectorComponent", () => {
+describe("LanguageSelectorComponent", () => {
 	let component: StarkLanguageSelectorComponent;
 	let hostComponent: TestHostComponent;
 	let hostFixture: ComponentFixture<TestHostComponent>;

--- a/packages/stark-ui/src/modules/session-ui/pages/preloading/preloading-page.component.spec.ts
+++ b/packages/stark-ui/src/modules/session-ui/pages/preloading/preloading-page.component.spec.ts
@@ -1,30 +1,47 @@
 /* tslint:disable:completed-docs */
-/* angular imports */
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { async, ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { CommonModule } from "@angular/common";
-/* stark-core imports */
-import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE, STARK_USER_SERVICE } from "@nationalbankbelgium/stark-core";
-
+import {
+	STARK_LOGGING_SERVICE,
+	STARK_ROUTING_SERVICE,
+	STARK_USER_SERVICE,
+	STARK_SESSION_SERVICE,
+	StarkUser,
+	StarkUserService,
+	StarkRoutingService,
+	StarkSessionService
+} from "@nationalbankbelgium/stark-core";
+import {
+	MockStarkLoggingService,
+	MockStarkRoutingService,
+	MockStarkUserService,
+	MockStarkSessionService
+} from "@nationalbankbelgium/stark-core/testing";
 import { TranslateModule } from "@ngx-translate/core";
-
-import { MockStarkLoggingService, MockStarkRoutingService, MockStarkUserService } from "@nationalbankbelgium/stark-core/testing";
-/* stark-ui imports */
-import { StarkPreloadingPageComponent } from "./preloading-page.component";
 import { MatButtonModule } from "@angular/material/button";
+import { of, throwError } from "rxjs";
+import { StarkPreloadingPageComponent } from "./preloading-page.component";
+import Spy = jasmine.Spy;
 
-describe("StarkPreloadingPageComponent", () => {
+describe("PreloadingPageComponent", () => {
 	let component: StarkPreloadingPageComponent;
 	let fixture: ComponentFixture<StarkPreloadingPageComponent>;
 
+	const mockUser: StarkUser = { firstName: "John", lastName: "Doe", username: "jdoe", uuid: "mock-uuid", roles: [] };
+	const mockLogger: MockStarkLoggingService = new MockStarkLoggingService();
+	const mockUserService: StarkUserService = new MockStarkUserService();
+	const mockSessionService: StarkSessionService = new MockStarkSessionService();
+	const mockRoutingService: StarkRoutingService = new MockStarkRoutingService();
+
 	beforeEach(async(() => {
-		const mockLogger: MockStarkLoggingService = new MockStarkLoggingService();
 		return TestBed.configureTestingModule({
 			declarations: [StarkPreloadingPageComponent],
 			imports: [CommonModule, MatButtonModule, TranslateModule.forRoot()],
 			providers: [
 				{ provide: STARK_LOGGING_SERVICE, useValue: mockLogger },
-				{ provide: STARK_ROUTING_SERVICE, useClass: MockStarkRoutingService },
-				{ provide: STARK_USER_SERVICE, useClass: MockStarkUserService }
+				{ provide: STARK_ROUTING_SERVICE, useValue: mockRoutingService },
+				{ provide: STARK_USER_SERVICE, useValue: mockUserService },
+				{ provide: STARK_SESSION_SERVICE, useValue: mockSessionService }
 			]
 		}).compileComponents();
 	}));
@@ -32,6 +49,11 @@ describe("StarkPreloadingPageComponent", () => {
 	beforeEach(() => {
 		fixture = TestBed.createComponent(StarkPreloadingPageComponent);
 		component = fixture.componentInstance;
+
+		(<Spy>mockUserService.fetchUserProfile).calls.reset();
+		(<Spy>mockSessionService.login).calls.reset();
+		(<Spy>mockRoutingService.navigateTo).calls.reset();
+		(<Spy>mockRoutingService.navigateToHome).calls.reset();
 	});
 
 	describe("on initialization", () => {
@@ -45,6 +67,54 @@ describe("StarkPreloadingPageComponent", () => {
 			expect(component.userService).not.toBeNull();
 			expect(component.userService).toBeDefined();
 		});
+	});
+
+	describe("ngOnInit", () => {
+		it("should log the user in automatically after fetching the user profile successfully", fakeAsync(() => {
+			(<Spy>mockUserService.fetchUserProfile).and.returnValue(of(mockUser));
+			component.loginDelay = 1; // override login delay to make unit tests faster
+
+			component.ngOnInit();
+			tick(1);
+
+			expect(mockUserService.fetchUserProfile).toHaveBeenCalledTimes(1);
+			expect(mockSessionService.login).toHaveBeenCalledTimes(1);
+			expect(mockSessionService.login).toHaveBeenCalledWith(mockUser);
+			expect(component.userFetchingFailed).toBeFalsy();
+		}));
+
+		it("should navigate to home or the target state if defined after fetching the user profile successfully", fakeAsync(() => {
+			(<Spy>mockUserService.fetchUserProfile).and.returnValue(of(mockUser));
+			component.loginDelay = 1; // override login delay to make unit tests faster
+
+			component.ngOnInit();
+			tick(1);
+
+			expect(mockRoutingService.navigateToHome).toHaveBeenCalledTimes(1);
+			expect(mockRoutingService.navigateTo).not.toHaveBeenCalled();
+
+			(<Spy>mockRoutingService.navigateToHome).calls.reset();
+			component.targetState = "dummy state";
+			component.targetStateParams = { someParam: "dummy param" };
+			component.ngOnInit();
+			tick(1);
+
+			expect(mockRoutingService.navigateToHome).not.toHaveBeenCalled();
+			expect(mockRoutingService.navigateTo).toHaveBeenCalledTimes(1);
+			expect(mockRoutingService.navigateTo).toHaveBeenCalledWith(component.targetState, component.targetStateParams);
+		}));
+
+		it("should NOT do anything when the user profile cannot be fetched", fakeAsync(() => {
+			(<Spy>mockUserService.fetchUserProfile).and.returnValue(throwError("could not fetch user profile"));
+			component.loginDelay = 1; // override login delay to make unit tests faster
+
+			component.ngOnInit();
+			tick(1);
+
+			expect(mockRoutingService.navigateToHome).not.toHaveBeenCalled();
+			expect(mockRoutingService.navigateTo).not.toHaveBeenCalled();
+			expect(component.userFetchingFailed).toBe(true);
+		}));
 	});
 
 	describe("reload", () => {

--- a/packages/stark-ui/src/modules/session-ui/pages/preloading/preloading-page.component.ts
+++ b/packages/stark-ui/src/modules/session-ui/pages/preloading/preloading-page.component.ts
@@ -6,9 +6,12 @@ import {
 	STARK_LOGGING_SERVICE,
 	STARK_ROUTING_SERVICE,
 	STARK_USER_SERVICE,
+	STARK_SESSION_SERVICE,
+	StarkSessionService,
 	StarkLoggingService,
 	StarkRoutingService,
-	StarkUserService
+	StarkUserService,
+	StarkUser
 } from "@nationalbankbelgium/stark-core";
 
 /**
@@ -35,10 +38,12 @@ export class StarkPreloadingPageComponent implements OnInit {
 
 	public userFetchingFailed: boolean;
 	public correlationId: string;
+	public loginDelay: number = 200;
 
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
 		@Inject(STARK_USER_SERVICE) public userService: StarkUserService,
+		@Inject(STARK_SESSION_SERVICE) public sessionService: StarkSessionService,
 		@Inject(STARK_ROUTING_SERVICE) public routingService: StarkRoutingService
 	) {}
 
@@ -52,10 +57,11 @@ export class StarkPreloadingPageComponent implements OnInit {
 			.fetchUserProfile()
 			.pipe(
 				take(1), // this ensures that the observable will be automatically unsubscribed after emitting the value
-				delay(200)
+				delay(this.loginDelay)
 			)
 			.subscribe(
-				(/*user: StarkUser*/) => {
+				(user: StarkUser) => {
+					this.sessionService.login(user);
 					if (this.targetState) {
 						this.routingService.navigateTo(this.targetState, this.targetStateParams);
 					} else {

--- a/packages/stark-ui/src/modules/session-ui/pages/session-expired/session-expired-page.component.spec.ts
+++ b/packages/stark-ui/src/modules/session-ui/pages/session-expired/session-expired-page.component.spec.ts
@@ -1,27 +1,22 @@
 /* tslint:disable:completed-docs */
-/* angular imports */
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { CommonModule } from "@angular/common";
-/* stark-core imports */
 import { STARK_APP_CONFIG, STARK_LOGGING_SERVICE, StarkApplicationConfig } from "@nationalbankbelgium/stark-core";
-
-import { TranslateModule } from "@ngx-translate/core";
-
 import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
-/* stark-ui imports */
-import { StarkSessionExpiredPageComponent } from "./session-expired-page.component";
 import { MatButtonModule } from "@angular/material/button";
+import { TranslateModule } from "@ngx-translate/core";
+import { StarkSessionExpiredPageComponent } from "./session-expired-page.component";
 
-describe("StarkSessionExpiredPageComponent", () => {
+describe("SessionExpiredPageComponent", () => {
 	let component: StarkSessionExpiredPageComponent;
 	let fixture: ComponentFixture<StarkSessionExpiredPageComponent>;
 
+	const mockLogger: MockStarkLoggingService = new MockStarkLoggingService();
 	const mockStarkAppConfig: Partial<StarkApplicationConfig> = {
 		baseUrl: "base-url"
 	};
 
 	beforeEach(async(() => {
-		const mockLogger: MockStarkLoggingService = new MockStarkLoggingService();
 		return TestBed.configureTestingModule({
 			declarations: [StarkSessionExpiredPageComponent],
 			imports: [CommonModule, MatButtonModule, TranslateModule.forRoot()],

--- a/packages/stark-ui/src/modules/session-ui/pages/session-logout/session-logout-page.component.spec.ts
+++ b/packages/stark-ui/src/modules/session-ui/pages/session-logout/session-logout-page.component.spec.ts
@@ -1,17 +1,12 @@
 /* tslint:disable:completed-docs */
-/* angular imports */
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { CommonModule } from "@angular/common";
-/* stark-core imports */
 import { STARK_APP_CONFIG, STARK_LOGGING_SERVICE, StarkApplicationConfig } from "@nationalbankbelgium/stark-core";
-
-import { TranslateModule } from "@ngx-translate/core";
-
 import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
-/* stark-ui imports */
+import { TranslateModule } from "@ngx-translate/core";
 import { StarkSessionLogoutPageComponent } from "./session-logout-page.component";
 
-describe("StarkSessionLogoutPageComponent", () => {
+describe("SessionLogoutPageComponent", () => {
 	let component: StarkSessionLogoutPageComponent;
 	let fixture: ComponentFixture<StarkSessionLogoutPageComponent>;
 

--- a/packages/stark-ui/src/modules/slider/components/slider.component.spec.ts
+++ b/packages/stark-ui/src/modules/slider/components/slider.component.spec.ts
@@ -40,7 +40,7 @@ class TestHostComponent {
 	}
 }
 
-describe("SliderController", () => {
+describe("SliderComponent", () => {
 	let component: StarkSliderComponent;
 	let hostComponent: TestHostComponent;
 	let hostFixture: ComponentFixture<TestHostComponent>;

--- a/packages/stark-ui/src/modules/toast-notification/services/toast-notification.service.spec.ts
+++ b/packages/stark-ui/src/modules/toast-notification/services/toast-notification.service.spec.ts
@@ -11,7 +11,7 @@ import { StarkToastNotificationServiceImpl } from "./toast-notification.service"
 import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
 import { Observable, Observer } from "rxjs";
 
-describe("Service: StarkToastNotificationService", () => {
+describe("ToastNotificationService", () => {
 	const message: StarkToastMessage = {
 		key: "testMessage",
 		id: "1",


### PR DESCRIPTION
ISSUES CLOSED: #726

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #726 


## What is the new behavior?
The Preloading page now does a session login with the fetched user in order to correctly initialize the app and navigate to the home page.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Minor fixes in some other unit tests.