### PR TITLE
refactor(stark-core): refactor logic to validate StarkSessionConfig to prevent Angular AOT error "Function calls are not supported in decorators"

### DIFF
--- a/packages/stark-core/src/modules/session/session.module.ts
+++ b/packages/stark-core/src/modules/session/session.module.ts
@@ -4,37 +4,6 @@ import { starkSessionReducers } from "./reducers";
 import { StarkSessionConfig, STARK_SESSION_CONFIG } from "./entities";
 import { STARK_SESSION_SERVICE, StarkSessionServiceImpl } from "./services";
 import { StarkUserModule } from "../user/user.module";
-import { starkAppExitStateName, starkAppInitStateName } from "./routes";
-
-/**
- * Validates and creates the StarkSessionConfig to be provided for the Stark Session Service
- * @param customConfig - Custom configuration object passed via the StarkSessionModule.forRoot() method
- * @returns The StarkSessionConfig to be provided for the Stark Session Service.
- * @throws In case the configuration object passed via the StarkSessionModule.forRoot() method is not valid
- */
-export function starkSessionConfigFactory(customConfig: StarkSessionConfig): StarkSessionConfig {
-	const invalidConfigErrorPrefix: string = "StarkSessionModule: invalid StarkSessionConfig object. ";
-	const invalidConfigErrorAppInitSuffix: string =
-		" should have the prefix '" + starkAppInitStateName + ".' in order to be configured correctly as an application initial state";
-	const invalidConfigErrorAppExitSuffix: string =
-		" should have the prefix '" + starkAppExitStateName + ".' in order to be configured correctly as an application exit state";
-
-	// validate config to ensure that the init/exit states have the correct StarkAppInit or StarkAppExit parent
-	if (customConfig.loginStateName && !customConfig.loginStateName.startsWith(starkAppInitStateName)) {
-		throw new Error(invalidConfigErrorPrefix + "'loginStateName' value" + invalidConfigErrorAppInitSuffix);
-	}
-	if (customConfig.preloadingStateName && !customConfig.preloadingStateName.startsWith(starkAppInitStateName)) {
-		throw new Error(invalidConfigErrorPrefix + "'preloadingStateName' value" + invalidConfigErrorAppInitSuffix);
-	}
-	if (customConfig.sessionExpiredStateName && !customConfig.sessionExpiredStateName.startsWith(starkAppExitStateName)) {
-		throw new Error(invalidConfigErrorPrefix + "'sessionExpiredStateName' value" + invalidConfigErrorAppExitSuffix);
-	}
-	if (customConfig.sessionLogoutStateName && !customConfig.sessionLogoutStateName.startsWith(starkAppExitStateName)) {
-		throw new Error(invalidConfigErrorPrefix + "'sessionLogoutStateName' value" + invalidConfigErrorAppExitSuffix);
-	}
-
-	return customConfig;
-}
 
 @NgModule({
 	imports: [StoreModule.forFeature("StarkSession", starkSessionReducers), StarkUserModule]
@@ -52,7 +21,7 @@ export class StarkSessionModule {
 			ngModule: StarkSessionModule,
 			providers: [
 				{ provide: STARK_SESSION_SERVICE, useClass: StarkSessionServiceImpl },
-				sessionConfig ? { provide: STARK_SESSION_CONFIG, useValue: starkSessionConfigFactory(sessionConfig) } : []
+				sessionConfig ? { provide: STARK_SESSION_CONFIG, useValue: sessionConfig } : []
 			]
 		};
 	}


### PR DESCRIPTION
ISSUES CLOSED: #797

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #797 #727 


## What is the new behavior?
AOT Production build succeeds even if a session config object is passed to the `SessionModule.forRoot()`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->