### PR TITLE
perf(stark-build): remove deprecated Angular PurifyPlugin. Enhance UglifyJs options to improve performance

### DIFF
--- a/packages/stark-build/config/webpack.common.js
+++ b/packages/stark-build/config/webpack.common.js
@@ -21,7 +21,6 @@ const HtmlElementsWebpackPlugin = require("html-elements-webpack-plugin");
 const AngularNamedLazyChunksWebpackPlugin = require("angular-named-lazy-chunks-webpack-plugin");
 const ContextReplacementPlugin = require("webpack/lib/ContextReplacementPlugin");
 const CircularDependencyPlugin = require("circular-dependency-plugin");
-const PurifyPlugin = require("@angular-devkit/build-optimizer").PurifyPlugin;
 
 const buildUtils = require("./build-utils");
 
@@ -355,8 +354,6 @@ module.exports = options => {
 			 * See: https://github.com/Independer/angular-named-lazy-chunks-webpack-plugin
 			 */
 			new AngularNamedLazyChunksWebpackPlugin(),
-
-			new PurifyPlugin(),
 
 			new CircularDependencyPlugin({
 				// exclude detection of files based on a RegExp


### PR DESCRIPTION
ISSUES CLOSED: #623

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #623 #585 


## What is the new behavior?
- The PurifyPlugin is no longer used since it is already [deprecated in Angular 6.1](https://github.com/angular/devkit/commit/cb2703e4a44a3055f5bc6284883d39d6c6dc1f00) and [removed in Angular 7](https://github.com/angular/angular-cli/pull/12171/files).
- The number of minification "passes" is set to 1 when running on the CI environment (Travis).
- The `prettier` parsers as well as the `prettier/standalone` file are excluded from the minification process since those files are too big and some of them are already minified.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->