### PR TITLE
feat(stark-build): add "cspFontSrc" as configurable property to webpack dev server. Add docs to Showcase about adding custom fonts.

### DIFF
--- a/packages/stark-build/config/webpack.dev.js
+++ b/packages/stark-build/config/webpack.dev.js
@@ -47,7 +47,7 @@ module.exports = function(env) {
 		// "default-src 'self'", // FIXME: enable as soon as the issue is fixed in Angular (https://github.com/angular/angular-cli/issues/6872 )
 		"child-src 'self'",
 		"connect-src 'self' ws://" + METADATA.HOST + ":" + METADATA.PORT + " " + webpackCustomConfig["cspConnectSrc"], // ws://HOST:PORT" is due to Webpack
-		"font-src 'self' " + webpackCustomConfig["cspFontSrc"],
+		`font-src 'self' ${webpackCustomConfig["cspFontSrc"] || ''}`,
 		"form-action 'self' " + webpackCustomConfig["cspFormAction"],
 		"frame-src 'self'", // deprecated. Use child-src instead. Used here because child-src is not yet supported by Firefox. Remove as soon as it is fully supported
 		"frame-ancestors 'none'", // the app will not be allowed to be embedded in an iframe (roughly equivalent to X-Frame-Options: DENY)
@@ -279,14 +279,14 @@ module.exports = function(env) {
 			 */
 			...(MONITOR
 				? [
-						new WebpackMonitor({
-							capture: true, // -> default 'true'
-							target: helpers.root("reports/webpack-monitor/stats.json"), // default -> '../monitor/stats.json'
-							launch: true, // -> default 'false'
-							port: 3030, // default -> 8081
-							excludeSourceMaps: true // default 'true'
-						})
-				  ]
+					new WebpackMonitor({
+						capture: true, // -> default 'true'
+						target: helpers.root("reports/webpack-monitor/stats.json"), // default -> '../monitor/stats.json'
+						launch: true, // -> default 'false'
+						port: 3030, // default -> 8081
+						excludeSourceMaps: true // default 'true'
+					})
+				]
 				: [])
 		],
 

--- a/packages/stark-build/config/webpack.dev.js
+++ b/packages/stark-build/config/webpack.dev.js
@@ -47,7 +47,7 @@ module.exports = function(env) {
 		// "default-src 'self'", // FIXME: enable as soon as the issue is fixed in Angular (https://github.com/angular/angular-cli/issues/6872 )
 		"child-src 'self'",
 		"connect-src 'self' ws://" + METADATA.HOST + ":" + METADATA.PORT + " " + webpackCustomConfig["cspConnectSrc"], // ws://HOST:PORT" is due to Webpack
-		"font-src 'self'",
+		"font-src 'self' " + webpackCustomConfig["cspFontSrc"],
 		"form-action 'self' " + webpackCustomConfig["cspFormAction"],
 		"frame-src 'self'", // deprecated. Use child-src instead. Used here because child-src is not yet supported by Firefox. Remove as soon as it is fully supported
 		"frame-ancestors 'none'", // the app will not be allowed to be embedded in an iframe (roughly equivalent to X-Frame-Options: DENY)

--- a/showcase/src/app/demo/typography/demo-typography.component.html
+++ b/showcase/src/app/demo/typography/demo-typography.component.html
@@ -1,14 +1,25 @@
 <h1 class="mat-display-3" translate>SHOWCASE.DEMO.TYPOGRAPHY.TITLE</h1>
+
 <section class="stark-section">
 	<h1 translate>SHOWCASE.DEMO.TYPOGRAPHY.MATERIAL_BASED.TITLE</h1>
 	<p [innerHTML]="'SHOWCASE.DEMO.TYPOGRAPHY.MATERIAL_BASED.DETAILS' | translate"></p>
 </section>
+
 <section class="stark-section">
 	<h1 translate>SHOWCASE.DEMO.TYPOGRAPHY.FONT_FAMILY.TITLE</h1>
 	<p translate>SHOWCASE.DEMO.TYPOGRAPHY.FONT_FAMILY.DETAILS_1</p>
 	<p translate>SHOWCASE.DEMO.TYPOGRAPHY.FONT_FAMILY.DETAILS_2</p>
 	<p>
 		<stark-pretty-print [data]="fontFamilyCSS" format="css" [enableHighlighting]="true"></stark-pretty-print>
+	</p>
+	<p class="mt3" [innerHTML]="'SHOWCASE.DEMO.TYPOGRAPHY.FONT_FAMILY.CUSTOM_FONT_EXPLAINED' | translate"></p>
+	<p>
+		<stark-pretty-print [data]="fontFaceExample" format="scss" [enableHighlighting]="true"></stark-pretty-print>
+	</p>
+	<p class="mat-caption" translate [innerHTML]="'SHOWCASE.DEMO.TYPOGRAPHY.FONT_FAMILY.IE_NOTE' | translate"></p>
+	<p class="mt3" [innerHTML]="'SHOWCASE.DEMO.TYPOGRAPHY.FONT_FAMILY.CDN_FONT_EXPLAINED' | translate"></p>
+	<p>
+		<stark-pretty-print [data]="webpackExample" format="json" [enableHighlighting]="true"></stark-pretty-print>
 	</p>
 </section>
 
@@ -29,6 +40,7 @@
 		<p class="mat-caption">Mat-Caption</p>
 	</example-viewer>
 </section>
+
 <section class="stark-section">
 	<h1 translate>SHOWCASE.DEMO.TYPOGRAPHY.CUSTOMIZATION.TITLE</h1>
 	<p translate [innerHTML]="'SHOWCASE.DEMO.TYPOGRAPHY.CUSTOMIZATION.DETAILS' | translate"></p>

--- a/showcase/src/app/demo/typography/demo-typography.component.ts
+++ b/showcase/src/app/demo/typography/demo-typography.component.ts
@@ -6,15 +6,36 @@ import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium
 	templateUrl: "./demo-typography.component.html"
 })
 export class DemoTypographyComponent implements OnInit {
-	public customizeMap: string;
 	public fontFamilyCSS: string;
-	public importTheme: string;
+	public fontFaceExample: string;
+	public webpackExample: string;
+	public customizeMap: string;
 
 	public constructor(@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService) {}
 
 	public ngOnInit(): void {
 		this.fontFamilyCSS = `
 			font-family: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif";
+		`;
+
+		this.fontFaceExample = `
+		@font-face {
+		  font-family: "Roboto";
+		  font-style: "Regular";
+		  src: url("/assets/fonts/Roboto-Regular.ttf") format("truetype")
+		}
+		
+		$stark-typography-theme: (
+		  font-family: "'Roboto',  sans-serif",
+		);
+	 	`;
+
+		this.webpackExample = `
+		{
+			"cspConnectSrc": "http://localhost:5000 http://localhost:5001 http://localhost:5002 http://localhost:4000 https://nationalbankbelgium.github.io",
+			"cspFormAction": "http://localhost:5000/myAwesomeUpload",
+			"cspFontSrc": "http://fonts.gstatic.com"
+		}
 		`;
 
 		this.customizeMap = `
@@ -35,6 +56,7 @@ export class DemoTypographyComponent implements OnInit {
 			input:(inherit, 1.125, 400)
 		  );
 
-		@import "~@nationalbankbelgium/stark-ui/assets/themes/theming";`;
+		@import "~@nationalbankbelgium/stark-ui/assets/themes/theming";
+		`;
 	}
 }

--- a/showcase/src/assets/translations/en.json
+++ b/showcase/src/assets/translations/en.json
@@ -226,14 +226,17 @@
           "TITLE": "Available classes & tags"
         },
         "CUSTOMIZATION": {
+          "TITLE": "Customization",
           "DETAILS": "Stark allows you to customize simultaneously the typography settings of Angular Material and Stark easily by adding a simple SCSS map declaration. <br>First, declare the SCSS map and then you need to import the Stark's theme. On this example, a full version of the map is shown but you can also use it partially.",
-          "MAP_EXPLAINED": "Here are the corresponding classes and tags:",
-          "TITLE": "Customization"
+          "MAP_EXPLAINED": "Here are the corresponding classes and tags:"
         },
         "FONT_FAMILY": {
+          "TITLE": "Font family",
           "DETAILS_1": "Material Design does not require to use a specific font, but it suggests Roboto, the sans-serif font available on Android mobile devices. We have chosen to let the system decide the most readable font it has to offer. This has the added advantage that no font will be embedded, reducing the first page load time.",
           "DETAILS_2": "The font stack used to get the optimal sans-serif font the system provides:",
-          "TITLE": "Font family"
+          "CUSTOM_FONT_EXPLAINED": "To set a web font (eg: Roboto) you must first add the font (ttf, woff, ...) to your projects assets, add it as a font-face in SCSS and set it trough the <code>$stark-typography-theme</code> (more about customization below).",
+          "IE_NOTE": "* The font format woff2 is not supported by IE. <a href=\"https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face#Browser_compatibility\" target=\"_blank\" rel=\"noopener\">MDN</a>",
+          "CDN_FONT_EXPLAINED": "To set a web font from an external source (CDN) webpack needs to be told to allow fonts from external sources. To do this add a the host/port to cspFontSrc in <code>config/webpack-custom-config.dev.json</code>. For more details check out: <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src\" target=\"_blank\" rel=\"noopener\"> CSP: font-src </a>."
         },
         "MATERIAL_BASED": {
           "DETAILS": "We try to keep consistency with Angular Material. For more details checkout: <a href=\"https://material.angular.io/guide/typography\" target=\"_blank\">https://material.angular.io/guide/typography</a>",

--- a/showcase/src/assets/translations/fr.json
+++ b/showcase/src/assets/translations/fr.json
@@ -226,14 +226,17 @@
           "TITLE": "Classes & tags disponibles"
         },
         "CUSTOMIZATION": {
+          "TITLE": "Personnalisation",
           "DETAILS": "Stark vous permet de personnaliser les polices de caractères à la fois des composants Stark et des composants Angular Material en déclarant une simple map SCSS.<br>Déclarer d'abord la map SCSS puis importer le theme de Stark. Cet example montr une version complète de la map mais vous pouvez aussi l'utiliser partiellement.",
-          "MAP_EXPLAINED": "Voici la liste de classes et tags correspondant:",
-          "TITLE": "Personnalisation"
+          "MAP_EXPLAINED": "Voici la liste de classes et tags correspondant:"
         },
         "FONT_FAMILY": {
+          "TITLE": "Familles de police de caractère",
           "DETAILS_1": "Material Design suggère d'utiliser Roboto, la police sans-serif disponible sur Android. Nous avons choisi de laisser le système décider de la police qui lui parait la plus adaptée. Grâce à cela aucune police n'est embeddé, ce qui réduit la temps de chargement de la page.",
           "DETAILS_2": "Voici la liste de police fournit que le système va se charger d'interpréter:",
-          "TITLE": "Familles de police de caractère"
+          "CUSTOM_FONT_EXPLAINED": "Pour définir une police web (ex. Roboto), ajouter la police (ttf, woff, ...) aux \"assets\" de votre projet, ajouter la police comme une font-face a SCSS et le définir dans <code>stark-typography-theme</code>",
+          "IE_NOTE": "* Le format de police woff2 n'est pas pris en charge par IE. <a href=\"https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face#Browser_compatibility\" target=\"_blank\" rel=\"noopener\">MDN</a>",
+          "CDN_FONT_EXPLAINED": "Pour définir une police web d'une source externe (CDN) vous devez indiquer à Webpack d'autoriser les polices à partir de sources externes. Dans le fichier <code>config/webpack-custom-config.dev.json</code> ajouter l'hôte/port a <code>cspFontSrc</code>. Pour plus d'informations, consultez <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src\" target=\"_blank\" rel=\"noopener\"> CSP: font-src </a>."
         },
         "MATERIAL_BASED": {
           "DETAILS": "Nous avons garder un maximum de compatibilité avec Angular Material. Pour plus de détails sur la philosophie derrière Angular Material, consulter cetee page: <a href=\"https://material.angular.io/guide/typography\" target=\"_blank\">https://material.angular.io/guide/typography</a>",

--- a/showcase/src/assets/translations/nl.json
+++ b/showcase/src/assets/translations/nl.json
@@ -226,14 +226,17 @@
           "TITLE": "Available classes & tags"
         },
         "CUSTOMIZATION": {
+          "TITLE": "Customization",
           "DETAILS": "Stark allows you to customize simultaneously the typography settings of Angular Material and Stark easily by adding a simple SCSS map declaration. <br>First, declare the SCSS map and then you need to import the Stark's theme. On this example, a full version of the map is shown but you can also use it partially.",
-          "MAP_EXPLAINED": "Here are the corresponding classes and tags:",
-          "TITLE": "Customization"
+          "MAP_EXPLAINED": "Here are the corresponding classes and tags:"
         },
         "FONT_FAMILY": {
+          "TITLE": "Font family",
           "DETAILS_1": "Material Design does not require to use a specific font, but it suggests Roboto, the sans-serif font available on Android mobile devices. We have chosen to let the system decide the most readable font it has to offer. This has the added advantage that no font will be embedded, reducing the first page load time.",
           "DETAILS_2": "The font stack used to get the optimal sans-serif font the system provides:",
-          "TITLE": "Font family"
+          "CUSTOM_FONT_EXPLAINED": "To set a web font (eg: Roboto) you must first add the font (ttf, woff, ...) to your projects assets, add it as a font-face in SCSS and set it trough the <code>$stark-typography-theme</code> (more about customization below).",
+          "IE_NOTE": "* The font format woff2 is not supported by IE. <a href=\"https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face#Browser_compatibility\" target=\"_blank\" rel=\"noopener\">MDN</a>",
+          "CDN_FONT_EXPLAINED": "To set a web font from an external source (CDN) webpack needs to be told to allow fonts from external sources. To do this add a the host/port to cspFontSrc in <code>config/webpack-custom-config.dev.json</code>. For more details check out: <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src\" target=\"_blank\" rel=\"noopener\"> CSP: font-src </a>."
         },
         "MATERIAL_BASED": {
           "DETAILS": "We try to keep consistency with Angular Material. For more details checkout: <a href=\"https://material.angular.io/guide/typography\" target=\"_blank\">https://material.angular.io/guide/typography</a>",

--- a/showcase/src/styles/_variables.scss
+++ b/showcase/src/styles/_variables.scss
@@ -1,7 +1,22 @@
-/*$stark-typography-theme: (
-  font-family: '"Oswald", sans-serif',
+/*
+// Define a font-face for a web font
+@font-face {
+  font-family: "font-name";
+  font-style: normal;
+  src: url("path-to-font") format("woff | woff2 | truetype | opentype | embedded-opentype | svg");
+}
+
+// A separate css with the font-faces defined can also be added
+// If the fonts are hosted remotely (eg: https://fonts.gstatic.com)
+// the host and port should be added to "cspFontSrc" property in /config/webpack-custom-config.dev.json
+@import url('https://fonts.googleapis.com/css?family=Roboto');
+
+// Define the custom maps for Stark styles if needed 
+$stark-typography-theme: (
+  font-family: "'font-name', sans-serif",
   headline: (90px, 48px, 400),
   body-1: (14px, 20px, 400),
   body-2: (14px, 24px, 500),
   caption: (12px, 20px, 400)
-);*/
+);
+*/

--- a/starter/src/styles/_variables.scss
+++ b/starter/src/styles/_variables.scss
@@ -1,9 +1,22 @@
-/* Define the custom maps for Stark styles if needed */
+/*
+// Define a font-face for a web font
+@font-face {
+  font-family: "font-name";
+  font-style: normal;
+  src: url("path-to-font") format("woff | woff2 | truetype | opentype | embedded-opentype | svg");
+}
 
-/*$stark-typography-theme: (
-  font-family: '"Oswald", sans-serif',
+// A separate css with the font-faces defined can also be added
+// If the fonts are hosted remotely (eg: https://fonts.gstatic.com)
+// the host and port should be added to "cspFontSrc" property in /config/webpack-custom-config.dev.json
+@import url('https://fonts.googleapis.com/css?family=Roboto');
+
+// Define the custom maps for Stark styles if needed 
+$stark-typography-theme: (
+  font-family: "'font-name', sans-serif",
   headline: (90px, 48px, 400),
   body-1: (14px, 20px, 400),
   body-2: (14px, 24px, 500),
   caption: (12px, 20px, 400)
-);*/
+);
+*/


### PR DESCRIPTION
ISSUES CLOSED #768 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is confusion about adding custom fonts and no way to add a font from a CDN.

Issue Number: #768


## What is the new behavior?

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information