### PR TITLE
feat(stark-ui): split translations from UI components in the different modules they belong to. Split common Core and common UI translations.

### DIFF
--- a/packages/stark-core/src/common/translations/common-translations.ts
+++ b/packages/stark-core/src/common/translations/common-translations.ts
@@ -1,0 +1,11 @@
+import { translationsEn } from "./translations/en";
+import { translationsFr } from "./translations/fr";
+import { translationsNl } from "./translations/nl";
+
+/**
+ * Common translations for features available in Stark-Core package
+ */
+export const commonCoreTranslations: object[] = [];
+commonCoreTranslations["en"] = translationsEn;
+commonCoreTranslations["fr"] = translationsFr;
+commonCoreTranslations["nl"] = translationsNl;

--- a/packages/stark-core/src/common/translations/merge-translations.spec.ts
+++ b/packages/stark-core/src/common/translations/merge-translations.spec.ts
@@ -1,0 +1,112 @@
+import { inject, TestBed } from "@angular/core/testing";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
+import { mergeTranslations } from "./merge-translations";
+import { StarkLocale } from "./locale.intf";
+
+/* tslint:disable:no-duplicate-string */
+describe("Translations: mergeTranslations", () => {
+	const translateModule: TranslateModule = TranslateModule.forRoot();
+	let translateService: TranslateService;
+
+	const moduleTranslationsEn: any = {
+		STARK: {
+			TEST: {
+				TEXT1: "Text1 from module",
+				TEXT2: "Text2 from module"
+			}
+		}
+	};
+
+	const appTranslationsEn: any = {
+		STARK: {
+			TEST: {
+				TEXT2: "Text2 from app",
+				TEXT3: "Text3 from app"
+			}
+		}
+	};
+
+	const appTranslationsDe: any = {
+		STARK: {
+			TEST: {
+				TEXT1: "Text1 aus der app",
+				TEXT2: "Text2 aus der app",
+				TEXT3: "Text3 aus der app"
+			}
+		}
+	};
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [translateModule]
+		});
+	});
+
+	// Inject module dependencies
+	beforeEach(inject([TranslateService], (_translateService: TranslateService) => {
+		translateService = _translateService;
+		translateService.addLangs(["en", "fr", "nl", "de"]);
+		translateService.setDefaultLang("en");
+	}));
+
+	describe("mergeTranslations", () => {
+		it("should return the merged translations from common, module and app", () => {
+			// First the module is loaded
+			const english: StarkLocale = { languageCode: "en", translations: moduleTranslationsEn };
+			mergeTranslations(translateService, english);
+
+			// then the app is loaded
+			translateService.setTranslation("en", appTranslationsEn, true);
+			translateService.use("en");
+
+			const text1: string = translateService.instant("STARK.TEST.TEXT1");
+			const text2: string = translateService.instant("STARK.TEST.TEXT2");
+			const text3: string = translateService.instant("STARK.TEST.TEXT3");
+			const languageFr: string = translateService.instant("STARK.LANGUAGES.FR");
+
+			expect(text1).toBe(moduleTranslationsEn.STARK.TEST.TEXT1);
+			expect(text2).toBe(appTranslationsEn.STARK.TEST.TEXT2); // the app has the upper hand
+			expect(text3).toBe(appTranslationsEn.STARK.TEST.TEXT3);
+			expect(languageFr).toBe("Français"); // Common translations
+		});
+
+		it("should return the merged translations from common, module and app when lazy loading modules", () => {
+			// First the app is loaded
+			translateService.setTranslation("en", appTranslationsEn, true);
+			translateService.use("en");
+
+			// Then the module is lazy loaded
+			const english: StarkLocale = { languageCode: "en", translations: moduleTranslationsEn };
+			mergeTranslations(translateService, english);
+
+			const text1: string = translateService.instant("STARK.TEST.TEXT1");
+			const text2: string = translateService.instant("STARK.TEST.TEXT2");
+			const text3: string = translateService.instant("STARK.TEST.TEXT3");
+			const languageFr: string = translateService.instant("STARK.LANGUAGES.FR");
+
+			expect(text1).toBe(moduleTranslationsEn.STARK.TEST.TEXT1);
+			expect(text2).toBe(appTranslationsEn.STARK.TEST.TEXT2); // the app has the upper hand
+			expect(text3).toBe(appTranslationsEn.STARK.TEST.TEXT3);
+			expect(languageFr).toBe("Français"); // Common translations
+		});
+
+		it("should return the merged translations, where the app has an extra language", () => {
+			translateService.setTranslation("en", appTranslationsEn, true);
+			translateService.setTranslation("de", appTranslationsDe, true);
+			translateService.use("de");
+
+			const english: StarkLocale = { languageCode: "en", translations: moduleTranslationsEn };
+			mergeTranslations(translateService, english);
+
+			const text1: string = translateService.instant("STARK.TEST.TEXT1");
+			const text2: string = translateService.instant("STARK.TEST.TEXT2");
+			const text3: string = translateService.instant("STARK.TEST.TEXT3");
+			const languageFr: string = translateService.instant("STARK.LANGUAGES.FR");
+
+			expect(text1).toBe("Text1 aus der app");
+			expect(text2).toBe("Text2 aus der app");
+			expect(text3).toBe("Text3 aus der app");
+			expect(languageFr).toBe("Français"); // missing in the app => translated from the default language 'en'
+		});
+	});
+});

--- a/packages/stark-core/src/common/translations/merge-translations.ts
+++ b/packages/stark-core/src/common/translations/merge-translations.ts
@@ -1,13 +1,11 @@
 import { TranslateService } from "@ngx-translate/core";
+import { StarkLocale } from "./locale.intf";
+import { commonCoreTranslations } from "./common-translations";
+
 /**
  *  @ignore
  */
 const _cloneDeep: Function = require("lodash/cloneDeep");
-
-import { StarkLocale } from "./locale.intf";
-import { translationsEn } from "./translations/en";
-import { translationsFr } from "./translations/fr";
-import { translationsNl } from "./translations/nl";
 
 /**
  * This function can be used by Stark modules to merge their translations into existing translations,
@@ -31,26 +29,18 @@ import { translationsNl } from "./translations/nl";
  *   3. The 'module' translations are added in the translateService, replacing any existing translations
  *   4. The 'stored' translations are added in the translateService, replacing any existing translations
  *
- * @param translateService
- *   Description: a reference to the translateService instance
- * @param args
- *   Description: a list of StarkLocales that contain the translations for a specific language
+ * @param translateService - A reference to the translateService instance
+ * @param localesToMerge - A list of StarkLocales that contain the translations for a specific language
  *
  * @example:
  *   mergeTranslations(this.translateService, english, french, dutch);
  */
-export function mergeTranslations(translateService: TranslateService, ...args: StarkLocale[]): void {
-	const locales: StarkLocale[] = [...args];
-	const translations: object = _cloneDeep(translateService.translations);
+export function mergeTranslations(translateService: TranslateService, ...localesToMerge: StarkLocale[]): void {
+	const currentTranslations: object = _cloneDeep(translateService.translations);
 
-	const commonTranslations: any[] = [];
-	commonTranslations["en"] = translationsEn;
-	commonTranslations["fr"] = translationsFr;
-	commonTranslations["nl"] = translationsNl;
-
-	locales.forEach((starkLocale: StarkLocale) => {
-		translateService.setTranslation(starkLocale.languageCode, commonTranslations[starkLocale.languageCode], false);
-		translateService.setTranslation(starkLocale.languageCode, starkLocale.translations, true);
-		translateService.setTranslation(starkLocale.languageCode, translations[starkLocale.languageCode], true);
-	});
+	for (const locale of localesToMerge) {
+		translateService.setTranslation(locale.languageCode, commonCoreTranslations[locale.languageCode], false);
+		translateService.setTranslation(locale.languageCode, locale.translations, true);
+		translateService.setTranslation(locale.languageCode, currentTranslations[locale.languageCode], true);
+	}
 }

--- a/packages/stark-core/src/common/translations/translations/en.ts
+++ b/packages/stark-core/src/common/translations/translations/en.ts
@@ -3,92 +3,11 @@
  */
 export const translationsEn: object = {
 	STARK: {
-		APP_LOGOUT: {
-			TITLE: "Log out"
-		},
-		APP_FOOTER: {
-			COPYRIGHT: "National Bank of Belgium. All rights reserved",
-			COPYRIGHT_YEAR: "2016",
-			HELP: "Help",
-			LEGAL_INFO: "Legal information"
-		},
-		DATE_RANGE_PICKER: {
-			FROM: "From",
-			TO: "To"
-		},
-		ICONS: {
-			ADD_ITEM: "Add",
-			APP_DATA: "App data",
-			EDIT_ITEM: "Edit",
-			DELETE_ITEM: "Delete",
-			APPROVE_ITEM: "Approve",
-			REJECT_ITEM: "Reject",
-			RELOAD_PAGE: "Reload page",
-			OPEN_SELECTION: "Open selection",
-			SAVE_ITEM: "Save",
-			CLOSE_ITEM: "Close",
-			RESET: "Reset",
-			SEARCH: "Search",
-			NEW_ITEM: "New",
-			SAVE_AND_NEXT: "Save And Next"
-		},
 		LANGUAGES: {
 			EN: "English",
 			FR: "Français",
 			NL: "Nederlands",
 			DE: "Deutsch"
-		},
-		LOGIN: {
-			TITLE: "Login",
-			NO_PROFILE: "No profile available"
-		},
-		MULTI_COLUMN_SORTING: {
-			TITLE: "Multi-Column Sorting",
-			ADD_SORTING_LEVEL: "Add sorting level",
-			REMOVE_SORTING_LEVEL: "Remove sorting level",
-			SORT_BY: "Sort by",
-			THEN_BY: "Then by",
-			CANCEL: "Cancel",
-			SAVE: "Save"
-		},
-		PRELOADING: {
-			FETCHING_USER_PROFILE: "Initializing...",
-			FETCHING_USER_PROFILE_FAILURE: "Initialization failed: could not fetch user profile.",
-			CONTACT_IT_SUPPORT: "Please contact your IT support department.",
-			CORRELATION_ID: "Correlation ID",
-			RELOAD: "Reload"
-		},
-		SESSION_EXPIRED: {
-			TITLE: "Session expired",
-			MESSAGE: "",
-			RELOAD: "Reload"
-		},
-		SESSION_LOGOUT: {
-			TITLE: "Logged out",
-			LOGIN: "Log in again"
-		},
-		SORTING: {
-			ASC: "Ascending",
-			DESC: "Descending"
-		},
-		TABLE: {
-			NB_SELECTED_ROWS: "Selected",
-			TOGGLE_SELECTION: "Toggle selection",
-			SELECT_ALL: "Select all",
-			DESELECT_ALL: "Deselect all",
-			SELECT_DESELECT_ALL: "SELECT all/Deselect all",
-			MORE: "More",
-			INDEX: "Index",
-			ACTIONS: "Actions",
-			FILTER: "Filter (max 20 chars)",
-			CLEAR_FILTER: "Clear filter",
-			EXPAND_ALL: "Expand all lines",
-			COLLAPSE_ALL: "Collapse all lines",
-			PRISTINE_MESSAGE: "No data loaded yet.",
-			EMPTY_MESSAGE: "No elements found. Have a nice day!",
-			ITEMS_FOUND: "item(s)",
-			TOGGLE_COLUMNS: "Column filters",
-			MULTI_COLUMN_SORTING: "Multi-Column Sorting"
 		}
 	}
 };

--- a/packages/stark-core/src/common/translations/translations/fr.ts
+++ b/packages/stark-core/src/common/translations/translations/fr.ts
@@ -3,92 +3,11 @@
  */
 export const translationsFr: object = {
 	STARK: {
-		APP_LOGOUT: {
-			TITLE: "Déconnecter"
-		},
-		APP_FOOTER: {
-			COPYRIGHT: "Banque Nationale de Belgique. Tous droits réservés",
-			COPYRIGHT_YEAR: "2016",
-			HELP: "Aide",
-			LEGAL_INFO: "Informations légales"
-		},
-		DATE_RANGE_PICKER: {
-			FROM: "De",
-			TO: "A"
-		},
-		ICONS: {
-			ADD_ITEM: "Ajouter",
-			APP_DATA: "App data",
-			EDIT_ITEM: "Modifier",
-			DELETE_ITEM: "Supprimer",
-			APPROVE_ITEM: "Approuver",
-			REJECT_ITEM: "Rejeter",
-			RELOAD_PAGE: "Recharger la page",
-			OPEN_SELECTION: "Ouvrir la sélection",
-			SAVE_ITEM: "Sauver",
-			CLOSE_ITEM: "Fermer",
-			RESET: "Réinitialiser",
-			SEARCH: "Chercher",
-			NEW_ITEM: "Nouveau",
-			SAVE_AND_NEXT: "Sauver et Suivant"
-		},
 		LANGUAGES: {
 			EN: "English",
 			FR: "Français",
 			NL: "Nederlands",
 			DE: "Deutsch"
-		},
-		LOGIN: {
-			TITLE: "Connexion",
-			NO_PROFILE: "Aucun profil utilisateur disponible"
-		},
-		MULTI_COLUMN_SORTING: {
-			TITLE: "Tri multi-colonnes",
-			ADD_SORTING_LEVEL: "Ajouter le niveau de tri",
-			REMOVE_SORTING_LEVEL: "Supprimer le niveau de tri",
-			SORT_BY: "Trier par",
-			THEN_BY: "Puis par",
-			CANCEL: "Annuler",
-			SAVE: "Enregistrer"
-		},
-		PRELOADING: {
-			FETCHING_USER_PROFILE: "Initialisation...",
-			FETCHING_USER_PROFILE_FAILURE: "Échec de l'initialisation: impossible de récupérer le profil de l'utilisateur.",
-			CONTACT_IT_SUPPORT: "Veuillez contacter votre service d'assistance informatique.",
-			CORRELATION_ID: "ID de corrélation",
-			RELOAD: "Recharger"
-		},
-		SESSION_EXPIRED: {
-			TITLE: "La session a expiré",
-			MESSAGE: "",
-			RELOAD: "Recharger"
-		},
-		SESSION_LOGOUT: {
-			TITLE: "Déconnecté",
-			LOGIN: "Connexion"
-		},
-		SORTING: {
-			ASC: "Ascendant",
-			DESC: "Descendant"
-		},
-		TABLE: {
-			NB_SELECTED_ROWS: "Sélectionné",
-			TOGGLE_SELECTION: "Inverser la sélection",
-			SELECT_ALL: "Tout sélectionner",
-			DESELECT_ALL: "Tout désélectionner",
-			SELECT_DESELECT_ALL: "Tout sélectionner/Tout désélectionner",
-			MORE: "Plus",
-			INDEX: "Index",
-			ACTIONS: "Actions",
-			FILTER: "Filtre (max 20 cars)",
-			CLEAR_FILTER: "Vider le filtre",
-			EXPAND_ALL: "Afficher toutes les lignes",
-			COLLAPSE_ALL: "Cacher toutes les lignes",
-			PRISTINE_MESSAGE: "Il n'y a pas encore de données chargées.",
-			EMPTY_MESSAGE: "Aucun élément trouvé. Passez une bonne journée !",
-			ITEMS_FOUND: "élément(s)",
-			TOGGLE_COLUMNS: "Filtre colonnes",
-			MULTI_COLUMN_SORTING: "Tri multi-colonnes"
 		}
 	}
 };

--- a/packages/stark-core/src/common/translations/translations/nl.ts
+++ b/packages/stark-core/src/common/translations/translations/nl.ts
@@ -3,92 +3,11 @@
  */
 export const translationsNl: object = {
 	STARK: {
-		APP_LOGOUT: {
-			TITLE: "Afmelden"
-		},
-		APP_FOOTER: {
-			COPYRIGHT: "Nationale Bank van België. Alle rechten voorbehouden",
-			COPYRIGHT_YEAR: "2016",
-			HELP: "Help",
-			LEGAL_INFO: "Juridische informatie"
-		},
-		DATE_RANGE_PICKER: {
-			FROM: "Van",
-			TO: "Tot"
-		},
-		ICONS: {
-			ADD_ITEM: "Toevoegen",
-			APP_DATA: "App data",
-			EDIT_ITEM: "Wijzig",
-			DELETE_ITEM: "Verwijder",
-			APPROVE_ITEM: "Goedkeuren",
-			REJECT_ITEM: "Afkeuren",
-			RELOAD_PAGE: "Pagina vernieuwen",
-			OPEN_SELECTION: "Open selectie",
-			SAVE_ITEM: "Bewaren",
-			CLOSE_ITEM: "Sluiten",
-			RESET: "Reset",
-			SEARCH: "Zoeken",
-			NEW_ITEM: "Nieuw",
-			SAVE_AND_NEXT: "Bewaar en volgende"
-		},
 		LANGUAGES: {
 			EN: "English",
 			FR: "Français",
 			NL: "Nederlands",
 			DE: "Deutsch"
-		},
-		LOGIN: {
-			TITLE: "Aanmelden",
-			NO_PROFILE: "Geen profiel beschikbaar"
-		},
-		MULTI_COLUMN_SORTING: {
-			TITLE: "Sorteren van meerdere kolommen",
-			ADD_SORTING_LEVEL: "Voeg sorteringsniveau toe",
-			REMOVE_SORTING_LEVEL: "Verwijder sorteringsniveau",
-			SORT_BY: "Sorteer op",
-			THEN_BY: "Dan op",
-			CANCEL: "Annuleer",
-			SAVE: "Opslaan"
-		},
-		PRELOADING: {
-			FETCHING_USER_PROFILE: "Initialiseren...",
-			FETCHING_USER_PROFILE_FAILURE: "Initialisatie mislukt: het gebruikersprofiel kon niet worden opgehaald.",
-			CONTACT_IT_SUPPORT: "Neem contact op met uw IT-support afdeling.",
-			CORRELATION_ID: "Correlatie ID",
-			RELOAD: "Herladen"
-		},
-		SESSION_EXPIRED: {
-			TITLE: "Sessie verlopen",
-			MESSAGE: "",
-			RELOAD: "Herladen"
-		},
-		SESSION_LOGOUT: {
-			TITLE: "Afgemeld",
-			LOGIN: "Opnieuw aanmelden"
-		},
-		SORTING: {
-			ASC: "Oplopend",
-			DESC: "Aflopend"
-		},
-		TABLE: {
-			NB_SELECTED_ROWS: "Geselecteerd",
-			TOGGLE_SELECTION: "Selectie omkeren",
-			SELECT_ALL: "Alles selectioneren",
-			DESELECT_ALL: "Selectie wissen",
-			SELECT_DESELECT_ALL: "Alles selectioneren/Selectie wissen",
-			MORE: "Meer",
-			INDEX: "Index",
-			ACTIONS: "Acties",
-			FILTER: "Filter (max 20 tekens)",
-			CLEAR_FILTER: "Filter wissen",
-			EXPAND_ALL: "Alle lijnen tonen",
-			COLLAPSE_ALL: "Alle lijnen verbergen",
-			PRISTINE_MESSAGE: "Nog geen data geladen.",
-			EMPTY_MESSAGE: "Geen elementen gevonden. Fijne dag!",
-			ITEMS_FOUND: "gegeven(s)",
-			TOGGLE_COLUMNS: "Kolom filters",
-			MULTI_COLUMN_SORTING: "Sorteren van meerdere kolommen"
 		}
 	}
 };

--- a/packages/stark-ui/src/common/translations.ts
+++ b/packages/stark-ui/src/common/translations.ts
@@ -1,3 +1,2 @@
 export * from "./translations/common-translations";
-export * from "./translations/locale.intf";
 export * from "./translations/merge-translations";

--- a/packages/stark-ui/src/common/translations/common-translations.ts
+++ b/packages/stark-ui/src/common/translations/common-translations.ts
@@ -1,0 +1,11 @@
+import { translationsEn } from "./translations/en";
+import { translationsFr } from "./translations/fr";
+import { translationsNl } from "./translations/nl";
+
+/**
+ * Common translations for features available in Stark-Ui package
+ */
+export const commonUiTranslations: object[] = [];
+commonUiTranslations["en"] = translationsEn;
+commonUiTranslations["fr"] = translationsFr;
+commonUiTranslations["nl"] = translationsNl;

--- a/packages/stark-ui/src/common/translations/merge-translations.spec.ts
+++ b/packages/stark-ui/src/common/translations/merge-translations.spec.ts
@@ -1,10 +1,10 @@
 import { inject, TestBed } from "@angular/core/testing";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
-import { mergeTranslations } from "./translations";
-import { StarkLocale } from "./locale.intf";
+import { StarkLocale } from "@nationalbankbelgium/stark-core";
+import { mergeUiTranslations } from "./merge-translations";
 
 /* tslint:disable:no-duplicate-string */
-describe("Translations: mergeTranslations", () => {
+describe("Translations: mergeUiTranslations", () => {
 	const translateModule: TranslateModule = TranslateModule.forRoot();
 	let translateService: TranslateService;
 
@@ -49,11 +49,11 @@ describe("Translations: mergeTranslations", () => {
 		translateService.setDefaultLang("en");
 	}));
 
-	describe("mergeTranslations", () => {
-		it("should return the merged translations from common, module and app", () => {
+	describe("mergeUiTranslations", () => {
+		it("should return the merged translations from common Core, common Ui, module and app", () => {
 			// First the module is loaded
 			const english: StarkLocale = { languageCode: "en", translations: moduleTranslationsEn };
-			mergeTranslations(translateService, english);
+			mergeUiTranslations(translateService, english);
 
 			// then the app is loaded
 			translateService.setTranslation("en", appTranslationsEn, true);
@@ -62,32 +62,36 @@ describe("Translations: mergeTranslations", () => {
 			const text1: string = translateService.instant("STARK.TEST.TEXT1");
 			const text2: string = translateService.instant("STARK.TEST.TEXT2");
 			const text3: string = translateService.instant("STARK.TEST.TEXT3");
-			const ascending: string = translateService.instant("STARK.SORTING.ASC");
+			const languageFr: string = translateService.instant("STARK.LANGUAGES.FR");
+			const closeItem: string = translateService.instant("STARK.ICONS.CLOSE_ITEM");
 
 			expect(text1).toBe(moduleTranslationsEn.STARK.TEST.TEXT1);
 			expect(text2).toBe(appTranslationsEn.STARK.TEST.TEXT2); // the app has the upper hand
 			expect(text3).toBe(appTranslationsEn.STARK.TEST.TEXT3);
-			expect(ascending).toBe("Ascending"); // Common translations
+			expect(languageFr).toBe("Français"); // Common Core translations
+			expect(closeItem).toBe("Close"); // Common Ui translations
 		});
 
-		it("should return the merged translations from common, module and app when lazy loading modules", () => {
+		it("should return the merged translations from common Core, common Ui, module and app when lazy loading modules", () => {
 			// First the app is loaded
 			translateService.setTranslation("en", appTranslationsEn, true);
 			translateService.use("en");
 
 			// Then the module is lazy loaded
 			const english: StarkLocale = { languageCode: "en", translations: moduleTranslationsEn };
-			mergeTranslations(translateService, english);
+			mergeUiTranslations(translateService, english);
 
 			const text1: string = translateService.instant("STARK.TEST.TEXT1");
 			const text2: string = translateService.instant("STARK.TEST.TEXT2");
 			const text3: string = translateService.instant("STARK.TEST.TEXT3");
-			const ascending: string = translateService.instant("STARK.SORTING.ASC");
+			const languageFr: string = translateService.instant("STARK.LANGUAGES.FR");
+			const closeItem: string = translateService.instant("STARK.ICONS.CLOSE_ITEM");
 
 			expect(text1).toBe(moduleTranslationsEn.STARK.TEST.TEXT1);
 			expect(text2).toBe(appTranslationsEn.STARK.TEST.TEXT2); // the app has the upper hand
 			expect(text3).toBe(appTranslationsEn.STARK.TEST.TEXT3);
-			expect(ascending).toBe("Ascending"); // Common translations
+			expect(languageFr).toBe("Français"); // Common Core translations
+			expect(closeItem).toBe("Close"); // Common Ui translations
 		});
 
 		it("should return the merged translations, where the app has an extra language", () => {
@@ -96,18 +100,19 @@ describe("Translations: mergeTranslations", () => {
 			translateService.use("de");
 
 			const english: StarkLocale = { languageCode: "en", translations: moduleTranslationsEn };
-			mergeTranslations(translateService, english);
+			mergeUiTranslations(translateService, english);
 
 			const text1: string = translateService.instant("STARK.TEST.TEXT1");
 			const text2: string = translateService.instant("STARK.TEST.TEXT2");
 			const text3: string = translateService.instant("STARK.TEST.TEXT3");
-			const ascending: string = translateService.instant("STARK.SORTING.ASC");
+			const languageFr: string = translateService.instant("STARK.LANGUAGES.FR");
+			const closeItem: string = translateService.instant("STARK.ICONS.CLOSE_ITEM");
 
 			expect(text1).toBe("Text1 aus der app");
 			expect(text2).toBe("Text2 aus der app");
 			expect(text3).toBe("Text3 aus der app");
-			expect(ascending).toBe("Ascending"); // missing in the app => translated from the default language 'en'
+			expect(languageFr).toBe("Français"); // missing in the app => translated from the default language 'en'
+			expect(closeItem).toBe("Close"); // missing in the app => translated from the default language 'en'
 		});
 	});
 });
-/* tslint:enable */

--- a/packages/stark-ui/src/common/translations/merge-translations.ts
+++ b/packages/stark-ui/src/common/translations/merge-translations.ts
@@ -1,0 +1,35 @@
+import { TranslateService } from "@ngx-translate/core";
+import { StarkLocale, mergeTranslations } from "@nationalbankbelgium/stark-core";
+import { commonUiTranslations } from "./common-translations";
+
+/**
+ *  @ignore
+ */
+const _merge: Function = require("lodash/merge");
+
+/**
+ * This function can be used by Stark UI modules to merge their translations into existing translations,
+ * without losing any existing translations.
+ *
+ * See {@link mergeTranslations} docs for more information about how the translations are merged.
+ *
+ * @param translateService - A reference to the translateService instance
+ * @param localesToMerge - A list of StarkLocales that contain the translations for a specific language
+ *
+ * @example:
+ *   mergeTranslations(this.translateService, english, french, dutch);
+ */
+export function mergeUiTranslations(translateService: TranslateService, ...localesToMerge: StarkLocale[]): void {
+	const allLocalesToMerge: StarkLocale[] = [];
+
+	// the common UI translations are merged with the given locales before calling the mergeTranslations from Stark-Core
+	for (const locale of localesToMerge) {
+		allLocalesToMerge.push({
+			languageCode: locale.languageCode,
+			translations: _merge({}, commonUiTranslations[locale.languageCode], locale.translations)
+		});
+	}
+
+	// finally the mergeTranslations from Stark-Core merges all the locales (common UI + given locales)
+	mergeTranslations(translateService, ...allLocalesToMerge);
+}

--- a/packages/stark-ui/src/common/translations/translations/en.ts
+++ b/packages/stark-ui/src/common/translations/translations/en.ts
@@ -1,0 +1,23 @@
+/**
+ * @ignore
+ */
+export const translationsEn: object = {
+	STARK: {
+		ICONS: {
+			ADD_ITEM: "Add",
+			APP_DATA: "App data",
+			EDIT_ITEM: "Edit",
+			DELETE_ITEM: "Delete",
+			APPROVE_ITEM: "Approve",
+			REJECT_ITEM: "Reject",
+			RELOAD_PAGE: "Reload page",
+			OPEN_SELECTION: "Open selection",
+			SAVE_ITEM: "Save",
+			CLOSE_ITEM: "Close",
+			RESET: "Reset",
+			SEARCH: "Search",
+			NEW_ITEM: "New",
+			SAVE_AND_NEXT: "Save And Next"
+		}
+	}
+};

--- a/packages/stark-ui/src/common/translations/translations/fr.ts
+++ b/packages/stark-ui/src/common/translations/translations/fr.ts
@@ -1,0 +1,23 @@
+/**
+ * @ignore
+ */
+export const translationsFr: object = {
+	STARK: {
+		ICONS: {
+			ADD_ITEM: "Ajouter",
+			APP_DATA: "App data",
+			EDIT_ITEM: "Modifier",
+			DELETE_ITEM: "Supprimer",
+			APPROVE_ITEM: "Approuver",
+			REJECT_ITEM: "Rejeter",
+			RELOAD_PAGE: "Recharger la page",
+			OPEN_SELECTION: "Ouvrir la sélection",
+			SAVE_ITEM: "Sauver",
+			CLOSE_ITEM: "Fermer",
+			RESET: "Réinitialiser",
+			SEARCH: "Chercher",
+			NEW_ITEM: "Nouveau",
+			SAVE_AND_NEXT: "Sauver et Suivant"
+		}
+	}
+};

--- a/packages/stark-ui/src/common/translations/translations/nl.ts
+++ b/packages/stark-ui/src/common/translations/translations/nl.ts
@@ -1,0 +1,23 @@
+/**
+ * @ignore
+ */
+export const translationsNl: object = {
+	STARK: {
+		ICONS: {
+			ADD_ITEM: "Toevoegen",
+			APP_DATA: "App data",
+			EDIT_ITEM: "Wijzig",
+			DELETE_ITEM: "Verwijder",
+			APPROVE_ITEM: "Goedkeuren",
+			REJECT_ITEM: "Afkeuren",
+			RELOAD_PAGE: "Pagina vernieuwen",
+			OPEN_SELECTION: "Open selectie",
+			SAVE_ITEM: "Bewaren",
+			CLOSE_ITEM: "Sluiten",
+			RESET: "Reset",
+			SEARCH: "Zoeken",
+			NEW_ITEM: "Nieuw",
+			SAVE_AND_NEXT: "Bewaar en volgende"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/app-footer/app-footer.module.ts
+++ b/packages/stark-ui/src/modules/app-footer/app-footer.module.ts
@@ -1,11 +1,27 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
+import { StarkLocale } from "@nationalbankbelgium/stark-core";
 import { StarkAppFooterComponent } from "./components";
-import { TranslateModule } from "@ngx-translate/core";
+import { translationsEn } from "./assets/translations/en";
+import { translationsFr } from "./assets/translations/fr";
+import { translationsNl } from "./assets/translations/nl";
+import { mergeUiTranslations } from "../../common/translations";
 
 @NgModule({
 	declarations: [StarkAppFooterComponent],
 	imports: [CommonModule, TranslateModule],
 	exports: [StarkAppFooterComponent]
 })
-export class StarkAppFooterModule {}
+export class StarkAppFooterModule {
+	/**
+	 * Class constructor
+	 * @param translateService - the translation service of the application
+	 */
+	public constructor(translateService: TranslateService) {
+		const english: StarkLocale = { languageCode: "en", translations: translationsEn };
+		const french: StarkLocale = { languageCode: "fr", translations: translationsFr };
+		const dutch: StarkLocale = { languageCode: "nl", translations: translationsNl };
+		mergeUiTranslations(translateService, english, french, dutch);
+	}
+}

--- a/packages/stark-ui/src/modules/app-footer/assets/translations/en.ts
+++ b/packages/stark-ui/src/modules/app-footer/assets/translations/en.ts
@@ -1,0 +1,13 @@
+/**
+ * @ignore
+ */
+export const translationsEn: object = {
+	STARK: {
+		APP_FOOTER: {
+			COPYRIGHT: "National Bank of Belgium. All rights reserved",
+			COPYRIGHT_YEAR: "2018",
+			HELP: "Help",
+			LEGAL_INFO: "Legal information"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/app-footer/assets/translations/fr.ts
+++ b/packages/stark-ui/src/modules/app-footer/assets/translations/fr.ts
@@ -1,0 +1,13 @@
+/**
+ * @ignore
+ */
+export const translationsFr: object = {
+	STARK: {
+		APP_FOOTER: {
+			COPYRIGHT: "Banque Nationale de Belgique. Tous droits réservés",
+			COPYRIGHT_YEAR: "2018",
+			HELP: "Aide",
+			LEGAL_INFO: "Informations légales"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/app-footer/assets/translations/nl.ts
+++ b/packages/stark-ui/src/modules/app-footer/assets/translations/nl.ts
@@ -1,0 +1,13 @@
+/**
+ * @ignore
+ */
+export const translationsNl: object = {
+	STARK: {
+		APP_FOOTER: {
+			COPYRIGHT: "Nationale Bank van België. Alle rechten voorbehouden",
+			COPYRIGHT_YEAR: "2018",
+			HELP: "Help",
+			LEGAL_INFO: "Juridische informatie"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/app-logout/app-logout.module.ts
+++ b/packages/stark-ui/src/modules/app-logout/app-logout.module.ts
@@ -1,14 +1,30 @@
 import { NgModule } from "@angular/core";
-import { StarkAppLogoutComponent } from "./components";
 import { MatIconModule } from "@angular/material/icon";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { MatButtonModule } from "@angular/material/button";
-import { TranslateModule } from "@ngx-translate/core";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
+import { StarkLocale } from "@nationalbankbelgium/stark-core";
+import { StarkAppLogoutComponent } from "./components";
 import { StarkSvgViewBoxModule } from "../svg-view-box/svg-view-box.module";
+import { translationsEn } from "./assets/translations/en";
+import { translationsFr } from "./assets/translations/fr";
+import { translationsNl } from "./assets/translations/nl";
+import { mergeUiTranslations } from "../../common/translations";
 
 @NgModule({
 	declarations: [StarkAppLogoutComponent],
 	exports: [StarkAppLogoutComponent],
 	imports: [MatIconModule, StarkSvgViewBoxModule, TranslateModule, MatTooltipModule, MatButtonModule]
 })
-export class StarkAppLogoutModule {}
+export class StarkAppLogoutModule {
+	/**
+	 * Class constructor
+	 * @param translateService - the translation service of the application
+	 */
+	public constructor(translateService: TranslateService) {
+		const english: StarkLocale = { languageCode: "en", translations: translationsEn };
+		const french: StarkLocale = { languageCode: "fr", translations: translationsFr };
+		const dutch: StarkLocale = { languageCode: "nl", translations: translationsNl };
+		mergeUiTranslations(translateService, english, french, dutch);
+	}
+}

--- a/packages/stark-ui/src/modules/app-logout/assets/translations/en.ts
+++ b/packages/stark-ui/src/modules/app-logout/assets/translations/en.ts
@@ -1,0 +1,10 @@
+/**
+ * @ignore
+ */
+export const translationsEn: object = {
+	STARK: {
+		APP_LOGOUT: {
+			TITLE: "Log out"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/app-logout/assets/translations/fr.ts
+++ b/packages/stark-ui/src/modules/app-logout/assets/translations/fr.ts
@@ -1,0 +1,10 @@
+/**
+ * @ignore
+ */
+export const translationsFr: object = {
+	STARK: {
+		APP_LOGOUT: {
+			TITLE: "Déconnecter"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/app-logout/assets/translations/nl.ts
+++ b/packages/stark-ui/src/modules/app-logout/assets/translations/nl.ts
@@ -1,0 +1,10 @@
+/**
+ * @ignore
+ */
+export const translationsNl: object = {
+	STARK: {
+		APP_LOGOUT: {
+			TITLE: "Afmelden"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/date-range-picker/assets/translations/en.ts
+++ b/packages/stark-ui/src/modules/date-range-picker/assets/translations/en.ts
@@ -1,0 +1,11 @@
+/**
+ * @ignore
+ */
+export const translationsEn: object = {
+	STARK: {
+		DATE_RANGE_PICKER: {
+			FROM: "From",
+			TO: "To"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/date-range-picker/assets/translations/fr.ts
+++ b/packages/stark-ui/src/modules/date-range-picker/assets/translations/fr.ts
@@ -1,0 +1,11 @@
+/**
+ * @ignore
+ */
+export const translationsFr: object = {
+	STARK: {
+		DATE_RANGE_PICKER: {
+			FROM: "De",
+			TO: "A"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/date-range-picker/assets/translations/nl.ts
+++ b/packages/stark-ui/src/modules/date-range-picker/assets/translations/nl.ts
@@ -1,0 +1,11 @@
+/**
+ * @ignore
+ */
+export const translationsNl: object = {
+	STARK: {
+		DATE_RANGE_PICKER: {
+			FROM: "Van",
+			TO: "Tot"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/date-range-picker/date-range-picker.module.ts
+++ b/packages/stark-ui/src/modules/date-range-picker/date-range-picker.module.ts
@@ -1,12 +1,28 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
+import { StarkLocale } from "@nationalbankbelgium/stark-core";
 import { StarkDatePickerModule } from "../date-picker";
 import { StarkDateRangePickerComponent } from "./components";
-import { TranslateModule } from "@ngx-translate/core";
+import { translationsEn } from "./assets/translations/en";
+import { translationsFr } from "./assets/translations/fr";
+import { translationsNl } from "./assets/translations/nl";
+import { mergeUiTranslations } from "../../common/translations";
 
 @NgModule({
 	declarations: [StarkDateRangePickerComponent],
 	imports: [CommonModule, StarkDatePickerModule, TranslateModule],
 	exports: [StarkDateRangePickerComponent]
 })
-export class StarkDateRangePickerModule {}
+export class StarkDateRangePickerModule {
+	/**
+	 * Class constructor
+	 * @param translateService - the translation service of the application
+	 */
+	public constructor(translateService: TranslateService) {
+		const english: StarkLocale = { languageCode: "en", translations: translationsEn };
+		const french: StarkLocale = { languageCode: "fr", translations: translationsFr };
+		const dutch: StarkLocale = { languageCode: "nl", translations: translationsNl };
+		mergeUiTranslations(translateService, english, french, dutch);
+	}
+}

--- a/packages/stark-ui/src/modules/message-pane/message-pane.module.ts
+++ b/packages/stark-ui/src/modules/message-pane/message-pane.module.ts
@@ -7,7 +7,7 @@ import { StoreModule } from "@ngrx/store";
 import { EffectsModule } from "@ngrx/effects";
 
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
-import { mergeTranslations, StarkLocale } from "@nationalbankbelgium/stark-core";
+import { StarkLocale } from "@nationalbankbelgium/stark-core";
 
 import { translationsEn } from "./assets/translations/en";
 import { translationsFr } from "./assets/translations/fr";
@@ -17,6 +17,7 @@ import { StarkMessagePaneComponent } from "./components";
 import { STARK_MESSAGE_PANE_SERVICE, StarkMessagePaneServiceImpl } from "./services";
 import { starkMessagesReducers } from "./reducers";
 import { StarkMessagePaneEffects } from "./effects";
+import { mergeUiTranslations } from "../../common/translations";
 
 @NgModule({
 	declarations: [StarkMessagePaneComponent],
@@ -54,7 +55,7 @@ export class StarkMessagePaneModule {
 		@Optional()
 		@SkipSelf()
 		parentModule: StarkMessagePaneModule,
-		private translateService: TranslateService
+		translateService: TranslateService
 	) {
 		if (parentModule) {
 			throw new Error("StarkMessagePaneModule is already loaded. Import it in the AppModule only");
@@ -63,6 +64,6 @@ export class StarkMessagePaneModule {
 		const english: StarkLocale = { languageCode: "en", translations: translationsEn };
 		const french: StarkLocale = { languageCode: "fr", translations: translationsFr };
 		const dutch: StarkLocale = { languageCode: "nl", translations: translationsNl };
-		mergeTranslations(this.translateService, english, french, dutch);
+		mergeUiTranslations(translateService, english, french, dutch);
 	}
 }

--- a/packages/stark-ui/src/modules/session-ui/assets/translations/en.ts
+++ b/packages/stark-ui/src/modules/session-ui/assets/translations/en.ts
@@ -1,0 +1,27 @@
+/**
+ * @ignore
+ */
+export const translationsEn: object = {
+	STARK: {
+		LOGIN: {
+			TITLE: "Login",
+			NO_PROFILE: "No profile available"
+		},
+		PRELOADING: {
+			FETCHING_USER_PROFILE: "Initializing...",
+			FETCHING_USER_PROFILE_FAILURE: "Initialization failed: could not fetch user profile.",
+			CONTACT_IT_SUPPORT: "Please contact your IT support department.",
+			CORRELATION_ID: "Correlation ID",
+			RELOAD: "Reload"
+		},
+		SESSION_EXPIRED: {
+			TITLE: "Session expired",
+			MESSAGE: "",
+			RELOAD: "Reload"
+		},
+		SESSION_LOGOUT: {
+			TITLE: "Logged out",
+			LOGIN: "Log in again"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/session-ui/assets/translations/fr.ts
+++ b/packages/stark-ui/src/modules/session-ui/assets/translations/fr.ts
@@ -1,0 +1,27 @@
+/**
+ * @ignore
+ */
+export const translationsFr: object = {
+	STARK: {
+		LOGIN: {
+			TITLE: "Connexion",
+			NO_PROFILE: "Aucun profil utilisateur disponible"
+		},
+		PRELOADING: {
+			FETCHING_USER_PROFILE: "Initialisation...",
+			FETCHING_USER_PROFILE_FAILURE: "Échec de l'initialisation: impossible de récupérer le profil de l'utilisateur.",
+			CONTACT_IT_SUPPORT: "Veuillez contacter votre service d'assistance informatique.",
+			CORRELATION_ID: "ID de corrélation",
+			RELOAD: "Recharger"
+		},
+		SESSION_EXPIRED: {
+			TITLE: "La session a expiré",
+			MESSAGE: "",
+			RELOAD: "Recharger"
+		},
+		SESSION_LOGOUT: {
+			TITLE: "Déconnecté",
+			LOGIN: "Connexion"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/session-ui/assets/translations/nl.ts
+++ b/packages/stark-ui/src/modules/session-ui/assets/translations/nl.ts
@@ -1,0 +1,27 @@
+/**
+ * @ignore
+ */
+export const translationsNl: object = {
+	STARK: {
+		LOGIN: {
+			TITLE: "Aanmelden",
+			NO_PROFILE: "Geen profiel beschikbaar"
+		},
+		PRELOADING: {
+			FETCHING_USER_PROFILE: "Initialiseren...",
+			FETCHING_USER_PROFILE_FAILURE: "Initialisatie mislukt: het gebruikersprofiel kon niet worden opgehaald.",
+			CONTACT_IT_SUPPORT: "Neem contact op met uw IT-support afdeling.",
+			CORRELATION_ID: "Correlatie ID",
+			RELOAD: "Herladen"
+		},
+		SESSION_EXPIRED: {
+			TITLE: "Sessie verlopen",
+			MESSAGE: "",
+			RELOAD: "Herladen"
+		},
+		SESSION_LOGOUT: {
+			TITLE: "Afgemeld",
+			LOGIN: "Opnieuw aanmelden"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/session-ui/session-ui.module.ts
+++ b/packages/stark-ui/src/modules/session-ui/session-ui.module.ts
@@ -1,8 +1,9 @@
 import { ModuleWithProviders, NgModule, Optional, SkipSelf } from "@angular/core";
 import { UIRouterModule } from "@uirouter/angular";
-import { TranslateModule } from "@ngx-translate/core";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { CommonModule } from "@angular/common";
 import { MatButtonModule } from "@angular/material/button";
+import { StarkLocale } from "@nationalbankbelgium/stark-core";
 import { SESSION_UI_STATES } from "./routes";
 import {
 	StarkLoginPageComponent,
@@ -10,6 +11,10 @@ import {
 	StarkSessionExpiredPageComponent,
 	StarkSessionLogoutPageComponent
 } from "./pages";
+import { translationsEn } from "./assets/translations/en";
+import { translationsFr } from "./assets/translations/fr";
+import { translationsNl } from "./assets/translations/nl";
+import { mergeUiTranslations } from "../../common/translations";
 
 @NgModule({
 	declarations: [
@@ -45,14 +50,21 @@ export class StarkSessionUiModule {
 	 * Prevents this module from being re-imported
 	 * @link https://angular.io/guide/singleton-services#prevent-reimport-of-the-coremodule
 	 * @param parentModule - The parent module
+	 * @param translateService - the translation service of the application
 	 */
 	public constructor(
 		@Optional()
 		@SkipSelf()
-		parentModule: StarkSessionUiModule
+		parentModule: StarkSessionUiModule,
+		translateService: TranslateService
 	) {
 		if (parentModule) {
 			throw new Error("StarkSessionUiModule is already loaded. Import it in the AppModule only");
 		}
+
+		const english: StarkLocale = { languageCode: "en", translations: translationsEn };
+		const french: StarkLocale = { languageCode: "fr", translations: translationsFr };
+		const dutch: StarkLocale = { languageCode: "nl", translations: translationsNl };
+		mergeUiTranslations(translateService, english, french, dutch);
 	}
 }

--- a/packages/stark-ui/src/modules/table/assets/translations/en.ts
+++ b/packages/stark-ui/src/modules/table/assets/translations/en.ts
@@ -1,0 +1,39 @@
+/**
+ * @ignore
+ */
+export const translationsEn: object = {
+	STARK: {
+		MULTI_COLUMN_SORTING: {
+			TITLE: "Multi-Column Sorting",
+			ADD_SORTING_LEVEL: "Add sorting level",
+			REMOVE_SORTING_LEVEL: "Remove sorting level",
+			SORT_BY: "Sort by",
+			THEN_BY: "Then by",
+			CANCEL: "Cancel",
+			SAVE: "Save"
+		},
+		SORTING: {
+			ASC: "Ascending",
+			DESC: "Descending"
+		},
+		TABLE: {
+			NB_SELECTED_ROWS: "Selected",
+			TOGGLE_SELECTION: "Toggle selection",
+			SELECT_ALL: "Select all",
+			DESELECT_ALL: "Deselect all",
+			SELECT_DESELECT_ALL: "SELECT all/Deselect all",
+			MORE: "More",
+			INDEX: "Index",
+			ACTIONS: "Actions",
+			FILTER: "Filter (max 20 chars)",
+			CLEAR_FILTER: "Clear filter",
+			EXPAND_ALL: "Expand all lines",
+			COLLAPSE_ALL: "Collapse all lines",
+			PRISTINE_MESSAGE: "No data loaded yet.",
+			EMPTY_MESSAGE: "No elements found. Have a nice day!",
+			ITEMS_FOUND: "item(s)",
+			TOGGLE_COLUMNS: "Column filters",
+			MULTI_COLUMN_SORTING: "Multi-Column Sorting"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/table/assets/translations/fr.ts
+++ b/packages/stark-ui/src/modules/table/assets/translations/fr.ts
@@ -1,0 +1,39 @@
+/**
+ * @ignore
+ */
+export const translationsFr: object = {
+	STARK: {
+		MULTI_COLUMN_SORTING: {
+			TITLE: "Tri multi-colonnes",
+			ADD_SORTING_LEVEL: "Ajouter le niveau de tri",
+			REMOVE_SORTING_LEVEL: "Supprimer le niveau de tri",
+			SORT_BY: "Trier par",
+			THEN_BY: "Puis par",
+			CANCEL: "Annuler",
+			SAVE: "Enregistrer"
+		},
+		SORTING: {
+			ASC: "Ascendant",
+			DESC: "Descendant"
+		},
+		TABLE: {
+			NB_SELECTED_ROWS: "Sélectionné",
+			TOGGLE_SELECTION: "Inverser la sélection",
+			SELECT_ALL: "Tout sélectionner",
+			DESELECT_ALL: "Tout désélectionner",
+			SELECT_DESELECT_ALL: "Tout sélectionner/Tout désélectionner",
+			MORE: "Plus",
+			INDEX: "Index",
+			ACTIONS: "Actions",
+			FILTER: "Filtre (max 20 cars)",
+			CLEAR_FILTER: "Vider le filtre",
+			EXPAND_ALL: "Afficher toutes les lignes",
+			COLLAPSE_ALL: "Cacher toutes les lignes",
+			PRISTINE_MESSAGE: "Il n'y a pas encore de données chargées.",
+			EMPTY_MESSAGE: "Aucun élément trouvé. Passez une bonne journée !",
+			ITEMS_FOUND: "élément(s)",
+			TOGGLE_COLUMNS: "Filtre colonnes",
+			MULTI_COLUMN_SORTING: "Tri multi-colonnes"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/table/assets/translations/nl.ts
+++ b/packages/stark-ui/src/modules/table/assets/translations/nl.ts
@@ -1,0 +1,39 @@
+/**
+ * @ignore
+ */
+export const translationsNl: object = {
+	STARK: {
+		MULTI_COLUMN_SORTING: {
+			TITLE: "Sorteren van meerdere kolommen",
+			ADD_SORTING_LEVEL: "Voeg sorteringsniveau toe",
+			REMOVE_SORTING_LEVEL: "Verwijder sorteringsniveau",
+			SORT_BY: "Sorteer op",
+			THEN_BY: "Dan op",
+			CANCEL: "Annuleer",
+			SAVE: "Opslaan"
+		},
+		SORTING: {
+			ASC: "Oplopend",
+			DESC: "Aflopend"
+		},
+		TABLE: {
+			NB_SELECTED_ROWS: "Geselecteerd",
+			TOGGLE_SELECTION: "Selectie omkeren",
+			SELECT_ALL: "Alles selectioneren",
+			DESELECT_ALL: "Selectie wissen",
+			SELECT_DESELECT_ALL: "Alles selectioneren/Selectie wissen",
+			MORE: "Meer",
+			INDEX: "Index",
+			ACTIONS: "Acties",
+			FILTER: "Filter (max 20 tekens)",
+			CLEAR_FILTER: "Filter wissen",
+			EXPAND_ALL: "Alle lijnen tonen",
+			COLLAPSE_ALL: "Alle lijnen verbergen",
+			PRISTINE_MESSAGE: "Nog geen data geladen.",
+			EMPTY_MESSAGE: "Geen elementen gevonden. Fijne dag!",
+			ITEMS_FOUND: "gegeven(s)",
+			TOGGLE_COLUMNS: "Kolom filters",
+			MULTI_COLUMN_SORTING: "Sorteren van meerdere kolommen"
+		}
+	}
+};

--- a/packages/stark-ui/src/modules/table/table.module.ts
+++ b/packages/stark-ui/src/modules/table/table.module.ts
@@ -11,12 +11,17 @@ import { MatSelectModule } from "@angular/material/select";
 import { MatSortModule } from "@angular/material/sort";
 import { MatTableModule } from "@angular/material/table";
 import { MatTooltipModule } from "@angular/material/tooltip";
-import { TranslateModule } from "@ngx-translate/core";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
+import { StarkLocale } from "@nationalbankbelgium/stark-core";
 import { StarkTableComponent, StarkTableColumnComponent } from "./components";
 import { StarkTableMultisortDialogComponent } from "./components/dialogs/multisort.component";
 import { StarkActionBarModule } from "../action-bar/action-bar.module";
 import { StarkPaginationModule } from "../pagination/pagination.module";
 import { StarkSvgViewBoxModule } from "../svg-view-box/svg-view-box.module";
+import { translationsEn } from "./assets/translations/en";
+import { translationsFr } from "./assets/translations/fr";
+import { translationsNl } from "./assets/translations/nl";
+import { mergeUiTranslations } from "../../common/translations";
 
 @NgModule({
 	declarations: [StarkTableComponent, StarkTableMultisortDialogComponent, StarkTableColumnComponent],
@@ -41,4 +46,15 @@ import { StarkSvgViewBoxModule } from "../svg-view-box/svg-view-box.module";
 		StarkSvgViewBoxModule
 	]
 })
-export class StarkTableModule {}
+export class StarkTableModule {
+	/**
+	 * Class constructor
+	 * @param translateService - the translation service of the application
+	 */
+	public constructor(translateService: TranslateService) {
+		const english: StarkLocale = { languageCode: "en", translations: translationsEn };
+		const french: StarkLocale = { languageCode: "fr", translations: translationsFr };
+		const dutch: StarkLocale = { languageCode: "nl", translations: translationsNl };
+		mergeUiTranslations(translateService, english, french, dutch);
+	}
+}

--- a/showcase/src/app/demo/date-range-picker/demo-date-range-picker.component.html
+++ b/showcase/src/app/demo/date-range-picker/demo-date-range-picker.component.html
@@ -1,11 +1,18 @@
 <h1 class="mat-display-3" translate>SHOWCASE.DEMO.DATE_RANGE_PICKER.TITLE</h1>
 <section class="stark-section">
 	<h1 translate>SHOWCASE.DEMO.SHARED.EXAMPLE_VIEWER_LIST</h1>
-	<example-viewer [extensions]="['HTML', 'TS']" filesPath="date-range-picker/full" exampleTitle="SHOWCASE.DEMO.DATE_RANGE_PICKER.TITLE">
+	<example-viewer [extensions]="['HTML', 'TS']" filesPath="date-range-picker/full"
+					exampleTitle="SHOWCASE.DEMO.DATE_RANGE_PICKER.TITLE">
 		<div>
-			<stark-date-range-picker [dateFilter]="customDateFilter" rangePickerId="id-range-picker" rangePickerName="name-range-picker"
-			 [endDate]="endDate" endDateLabel="To" [endMinDate]="minDate" [endMaxDate]="maxDate" [isDisabled]="isDisabled"
-			 [startDate]="startDate" startDateLabel="From" [startMinDate]="minDate" [startMaxDate]="maxDate" (dateRangeChanged)="onDateChanged($event)">
+			<stark-date-range-picker rangePickerId="id-range-picker"
+									 rangePickerName="name-range-picker"
+									 [isDisabled]="isDisabled"
+									 [dateFilter]="customDateFilter"
+									 [startDate]="startDate" startDateLabel="STARK.DATE_RANGE_PICKER.FROM"
+									 [endDate]="endDate" endDateLabel="STARK.DATE_RANGE_PICKER.TO"
+									 [startMinDate]="minDate" [startMaxDate]="maxDate"
+									 [endMinDate]="minDate" [endMaxDate]="maxDate"
+									 (dateRangeChanged)="onDateChanged($event)">
 			</stark-date-range-picker>
 		</div>
 		<mat-checkbox [(ngModel)]="isDisabled">isDisabled</mat-checkbox>

--- a/showcase/src/assets/examples/date-range-picker/full.html
+++ b/showcase/src/assets/examples/date-range-picker/full.html
@@ -1,16 +1,16 @@
 <stark-date-range-picker
-		[dateFilter]="customDateFilter"
 		rangePickerId="id-range-picker"
 		rangePickerName="name-range-picker"
-		[endDate]="endDate"
-		endDateLabel="To"
-		[endMinDate]="minDate"
-		[endMaxDate]="maxDate"
 		[isDisabled]="isDisabled"
+		[dateFilter]="customDateFilter"
 		[startDate]="startDate"
 		startDateLabel="From"
 		[startMinDate]="minDate"
 		[startMaxDate]="maxDate"
+		[endDate]="endDate"
+		endDateLabel="To"
+		[endMinDate]="minDate"
+		[endMaxDate]="maxDate"
 		(dateRangeChanged)="onDateChanged($event)">
 </stark-date-range-picker>
 <mat-checkbox [(ngModel)]="isDisabled">isDisabled</mat-checkbox>


### PR DESCRIPTION
ISSUES CLOSED: #511 #39 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #511 #39 


## What is the new behavior?
- Common translations are now split in Stark-Core and Stark-Ui
- Every UI module declares and loads its own translations (from the `assets/translations` subfolder).

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->