### PR TITLE
fix(stark-demo): add String trimRight polyfill to fix issue with PrettyPrint component in IE11

### DIFF
--- a/showcase/src/polyfills.browser.ts
+++ b/showcase/src/polyfills.browser.ts
@@ -28,6 +28,7 @@
 /* tslint:disable:no-import-side-effect */
 import "core-js/es6";
 import "core-js/es7/reflect";
+import "core-js/es7/string";
 import "core-js/stage/4";
 
 /**

--- a/starter/src/polyfills.browser.ts
+++ b/starter/src/polyfills.browser.ts
@@ -28,6 +28,7 @@
 /* tslint:disable:no-import-side-effect */
 import "core-js/es6";
 import "core-js/es7/reflect";
+import "core-js/es7/string";
 import "core-js/stage/4";
 
 /**


### PR DESCRIPTION
ISSUES CLOSED: #828 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Implementations of the `pretty-print` component which use the format "css", "scss", "json", "javascript" or "typescript" are not formatted / highlighted in IE11.

Issue Number: #828


## What is the new behavior?
With the addition of a polyfill for `String.prototype.trimRight` the issue is resolved.
This is because the dependency `prettier` uses this function.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->