### PR TITLE
ci(stark-demo): increase Travis wait time to 30 mins for the generation of the Showcase prod build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - npm run lint:all
   - npm run test:ci:all
   - npm run docs:coverage
-  - if [[ ${TRAVIS_TAG} == "" && ${TRAVIS_EVENT_TYPE} != "cron" ]]; then travis_wait 25 npm run build:showcase:ghpages:ci-test-env; else travis_wait 25 npm run build:showcase:ghpages; fi
+  - if [[ ${TRAVIS_TAG} == "" && ${TRAVIS_EVENT_TYPE} != "cron" ]]; then travis_wait 30 npm run build:showcase:ghpages:ci-test-env; else travis_wait 30 npm run build:showcase:ghpages; fi
   - npm run docs:publish
   - npm run release:publish
   - bash ./scripts/ci/print-logs.sh


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The waiting time in Travis for the generation of the production build of the Showcase is by default 20 mins (see [travis_wait)](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received) which is not enough in Node 6 as it often takes longer than that which causes the build to fail.


## What is the new behavior?
The wait time in Travis has been extended to 30 mins which should be enough for Node 6.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->