### PR TITLE
feat(stark-ui): add rowClick event emitter to table component

### DIFF
--- a/packages/stark-ui/assets/styles/_base.scss
+++ b/packages/stark-ui/assets/styles/_base.scss
@@ -71,7 +71,6 @@ body {
       -webkit-overflow-scrolling: touch;
       & > ui-view {
         flex: 1 0 auto;
-        padding: 16px;
       }
     }
   }

--- a/packages/stark-ui/src/modules/action-bar/components/action-bar.component.ts
+++ b/packages/stark-ui/src/modules/action-bar/components/action-bar.component.ts
@@ -100,6 +100,11 @@ export class StarkActionBarComponent extends AbstractStarkUiComponent implements
 	 * Action onClick handler
 	 */
 	public onClick(action: StarkAction, $event: Event): void {
+		if ($event) {
+			// Prevents further propagation of the current event in the capturing and bubbling phases.
+			// This makes it so that the parent does not also trigger on the event.
+			$event.stopPropagation();
+		}
 		if (action.isEnabled) {
 			let scope: any = {};
 			if (this.actionBarScope) {

--- a/packages/stark-ui/src/modules/app-sidebar/components/_app-sidebar.component.scss
+++ b/packages/stark-ui/src/modules/app-sidebar/components/_app-sidebar.component.scss
@@ -6,6 +6,7 @@
 .stark-app-sidebar {
   .mat-sidenav-content {
     margin-top: $stark-header-size;
+    overflow: initial; // fixes double scrollbar
     [stark-app-sidenav-content] {
       align-items: center;
       display: flex;

--- a/packages/stark-ui/src/modules/table/assets/translations/en.ts
+++ b/packages/stark-ui/src/modules/table/assets/translations/en.ts
@@ -21,7 +21,7 @@ export const translationsEn: object = {
 			TOGGLE_SELECTION: "Toggle selection",
 			SELECT_ALL: "Select all",
 			DESELECT_ALL: "Deselect all",
-			SELECT_DESELECT_ALL: "SELECT all/Deselect all",
+			SELECT_DESELECT_ALL: "Select all/Deselect all",
 			MORE: "More",
 			INDEX: "Index",
 			ACTIONS: "Actions",

--- a/packages/stark-ui/src/modules/table/components/_table-theme.scss
+++ b/packages/stark-ui/src/modules/table/components/_table-theme.scss
@@ -1,0 +1,19 @@
+/* ============================================================================== */
+/*  S t a r k   A p p   T a b l e                                                  */
+/* ============================================================================== */
+/* stark-ui: src/modules/app-menu/components/_table-theme.scss */
+
+.stark-table {
+  tr {
+    &:hover td {
+      background-color: mat-color($grey-palette, 100);
+    }
+
+    &.selected td {
+      background-color: mat-color($accent-palette, 100);
+      color: mat-contrast($accent-palette, 100);
+    }
+  }
+}
+
+/* END stark-ui: src/modules/app-menu/components/_table-theme.scss */

--- a/packages/stark-ui/src/modules/table/components/column-properties.intf.ts
+++ b/packages/stark-ui/src/modules/table/components/column-properties.intf.ts
@@ -13,7 +13,7 @@ export interface StarkTableColumnProperties {
 	 *
 	 * This could also be a static string with class(es)
 	 */
-	cellClassName?: ((value: any, row?: any, columnName?: string) => string) | string;
+	cellClassName?: ((value: any, row?: object, columnName?: string) => string) | string;
 
 	/**
 	 * Function that returns a formatted value (string) to be set in the cell. It can be used to set different formats
@@ -22,18 +22,18 @@ export interface StarkTableColumnProperties {
 	 * @param row - The row object that contains the cell
 	 * @param columnName - The column that the cell belongs to
 	 */
-	cellFormatter?: (value: any, row?: any, columnName?: string) => string;
+	cellFormatter?: (value: any, row?: object, columnName?: string) => string;
 
 	/**
 	 * Function that returns
-	 *   1 : if obj1 > obj2
-	 *   0 : if obj1 === obj2
-	 *  -1 : if obj1 < obj2
+	 *   1 : if val1 > val2
+	 *   0 : if val1 === val2
+	 *  -1 : if val1 < val2
 	 *
-	 * @param obj1 - First object in the comparison
-	 * @param obj2 - Second object in the comparison
+	 * @param val1 - First value in the comparison
+	 * @param val2 - Second value in the comparison
 	 */
-	compareFn?: (obj1: any, obj2: any) => number;
+	compareFn?: (val1: any, val2: any) => number;
 
 	/**
 	 * Class(es) to be set to the column's header.
@@ -66,7 +66,7 @@ export interface StarkTableColumnProperties {
 	 * @param row - The row object that contains the cell that was clicked
 	 * @param columnName - The column that the cell belongs to
 	 */
-	onClickCallback?: (value: any, row?: any, columnName?: string) => void;
+	onClickCallback?: (value: any, row?: object, columnName?: string) => void;
 
 	/**
 	 * Priority of the column. Default: PERSIST

--- a/packages/stark-ui/src/modules/table/components/column.component.html
+++ b/packages/stark-ui/src/modules/table/components/column.component.html
@@ -6,14 +6,26 @@
 			<div [ngSwitch]="sortDirection" class="sort-header" (click)="onSortChange()">
 				<span>{{ getHeaderLabel() }}</span>
 				<ng-container *ngIf="sortable" [ngSwitch]="sortDirection">
-					<mat-icon *ngSwitchCase="'asc'" starkSvgViewBox svgIcon="arrow-up" class="stark-small-icon"></mat-icon>
-					<mat-icon *ngSwitchCase="'desc'" starkSvgViewBox svgIcon="arrow-down" class="stark-small-icon"></mat-icon>
-					<mat-icon class="order-tip stark-small-icon" *ngSwitchDefault starkSvgViewBox svgIcon="arrow-up"></mat-icon>
+					<mat-icon *ngSwitchCase="'asc'"
+							  starkSvgViewBox
+							  svgIcon="arrow-up"
+							  class="stark-small-icon"></mat-icon>
+					<mat-icon *ngSwitchCase="'desc'"
+							  starkSvgViewBox
+							  svgIcon="arrow-down"
+							  class="stark-small-icon"></mat-icon>
+					<mat-icon class="order-tip stark-small-icon"
+							  *ngSwitchDefault
+							  starkSvgViewBox
+							  svgIcon="arrow-up"></mat-icon>
 				</ng-container>
 				<span *ngIf="sortPriority < 1000 && sortDirection" class="priority">{{ sortPriority }}</span>
 			</div>
 			<button *ngIf="filterable" class="button-filter" [matMenuTriggerFor]="filterMenu" mat-icon-button>
-				<mat-icon class="stark-small-icon" starkSvgViewBox svgIcon="filter" [matTooltip]="'STARK.TABLE.TOGGLE_COLUMNS' | translate"></mat-icon>
+				<mat-icon class="stark-small-icon"
+						  starkSvgViewBox
+						  svgIcon="filter"
+						  [matTooltip]="'STARK.TABLE.TOGGLE_COLUMNS' | translate"></mat-icon>
 			</button>
 		</div>
 		<mat-menu class="mat-table-filter" #filterMenu="matMenu" xPosition="before" [overlapTrigger]="false">
@@ -32,7 +44,6 @@
 	<!-- the column template defined by the user will be displayed here -->
 	<!-- and it will receive the right context containing the displayedValue and the row data-->
 	<td mat-cell *matCellDef="let rowItem" [ngClass]="getCellClassNames(rowItem)">
-		<ng-container
-				*ngTemplateOutlet="columnTemplate; context:{ $implicit: { rowData: rowItem, displayedValue: getDisplayedValue(rowItem) } }"></ng-container>
+		<ng-container *ngTemplateOutlet="columnTemplate; context:{ $implicit: { rowData: rowItem, displayedValue: getDisplayedValue(rowItem) } }"></ng-container>
 	</td>
 </ng-container>

--- a/packages/stark-ui/src/modules/table/components/column.component.ts
+++ b/packages/stark-ui/src/modules/table/components/column.component.ts
@@ -65,13 +65,13 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent {
 	 * @param obj2 - Second object in the comparison
 	 */
 	@Input()
-	public compareFn?: ((obj1: any, obj2: any) => number);
+	public compareFn?: ((obj1: object, obj2: object) => number);
 
 	/**
 	 * Function that returns the raw value of this column in case the access to such value can't be provided via the column name.
 	 */
 	@Input()
-	public dataAccessor?: ((data: any, name: string) => string); // TODO: really needed?
+	public dataAccessor?: ((data: object, name: string) => string); // TODO: really needed?
 
 	/**
 	 * Function that returns a formatted value (string) to be set in the cell. It can be used to set different formats
@@ -81,7 +81,7 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent {
 	 * @param columnName - The column that the cell belongs to
 	 */
 	@Input()
-	public cellFormatter?: ((value: any, row?: any, columnName?: string) => string);
+	public cellFormatter?: ((value: any, row?: object, columnName?: string) => string);
 
 	/**
 	 * Sorting direction of the column.
@@ -126,7 +126,7 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent {
 	 * Or a static string with the classNames.
 	 */
 	@Input()
-	public cellClassName?: ((value: any, row?: any, columnName?: string) => string) | string;
+	public cellClassName?: ((value: any, row?: object, columnName?: string) => string) | string;
 
 	/**
 	 * A static className for the header
@@ -156,7 +156,7 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent {
 	 * Reference to the transcluded template in this component via the ngTemplateOutlet
 	 */
 	@ContentChild(TemplateRef)
-	public columnTemplate: TemplateRef<any>;
+	public columnTemplate: TemplateRef<object>;
 
 	/**
 	 * Class constructor
@@ -179,7 +179,7 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent {
 	 * @param row - The row item
 	 * @returns The raw value of the property from the given row item
 	 */
-	public getRawValue(row: any): any | undefined {
+	public getRawValue(row: object): any | undefined {
 		let rawValue: any | undefined = _get(row, this.name);
 
 		if (this.dataAccessor) {
@@ -196,7 +196,7 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent {
 	 * @returns The displayed value of the property from the given row item after applying the
 	 * formatter (if there was any defined in the column) and translating the value (in case the value is a translation key)
 	 */
-	public getDisplayedValue(row: any): string | number {
+	public getDisplayedValue(row: object): string | number {
 		let formattedValue: string = "";
 		const rawValue: any | undefined = this.getRawValue(row);
 
@@ -244,7 +244,7 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent {
 	 * @param row - The data object of the row the cell is in.
 	 * @returns The classes for the cell.
 	 */
-	public getCellClassNames(row: any): string {
+	public getCellClassNames(row: object): string {
 		if (!this.cellClassName) {
 			return "";
 		}

--- a/packages/stark-ui/src/modules/table/components/table.component.html
+++ b/packages/stark-ui/src/modules/table/components/table.component.html
@@ -38,16 +38,17 @@
 
 <div [ngClass]="{'fixed-header': isFixedHeaderEnabled}">
 	<table #matTable mat-table [dataSource]="dataSource" [ngClass]="{'multi-sorting': isMultiSorting}">
-		<ng-container *ngIf="isMultiSelectEnabled" matColumnDef="select">
+		<ng-container matColumnDef="select">
 			<th mat-header-cell *matHeaderCellDef>
-				<mat-checkbox (change)="$event ? masterToggle() : null"
+				<mat-checkbox *ngIf="isMultiSelectEnabled"
+							  (change)="$event ? masterToggle() : null"
 							  [checked]="selection.hasValue() && isAllSelected()"
 							  [indeterminate]="selection.hasValue() && !isAllSelected()"
 							  [matTooltip]="'STARK.TABLE.SELECT_DESELECT_ALL' | translate"></mat-checkbox>
 			</th>
 			<td mat-cell *matCellDef="let row">
 				<mat-checkbox (click)="$event.stopPropagation()" (change)="$event ? selection.toggle(row) : null"
-							  [checked]="selection.isSelected(row)"></mat-checkbox>
+							  [checked]="selection?.isSelected(row)"></mat-checkbox>
 			</td>
 		</ng-container>
 
@@ -80,7 +81,8 @@
 		<tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: isFixedHeaderEnabled"></tr>
 		<tr mat-row
 			*matRowDef="let row; columns: displayedColumns; let i = index;"
-			[ngClass]="getRowClasses(row, i)">
+			[ngClass]="getRowClasses(row, i)"
+			(click)="onRowClick(row)">
 		</tr>
 	</table>
 </div>

--- a/showcase/src/app/demo/demo.module.ts
+++ b/showcase/src/app/demo/demo.module.ts
@@ -63,6 +63,7 @@ import { SharedModule } from "../shared/shared.module";
 import { DEMO_STATES } from "./routes";
 import {
 	TableRegularComponent,
+	TableWithSelectionComponent,
 	TableWithCustomActionsComponent,
 	TableWithTranscludedActionBarComponent,
 	TableWithFixedHeaderComponent,
@@ -131,6 +132,7 @@ import {
 		DemoSliderComponent,
 		DemoTableComponent,
 		TableRegularComponent,
+		TableWithSelectionComponent,
 		TableWithCustomActionsComponent,
 		TableWithTranscludedActionBarComponent,
 		TableWithFixedHeaderComponent,
@@ -162,8 +164,7 @@ import {
 		DemoSliderComponent,
 		DemoTableComponent,
 		DemoToastComponent,
-		DemoTypographyComponent,
-		DemoTableComponent
+		DemoTypographyComponent
 	],
 	providers: [{ provide: MAT_DATE_FORMATS, useValue: STARK_DATE_FORMATS }]
 })

--- a/showcase/src/app/demo/table/components/index.ts
+++ b/showcase/src/app/demo/table/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./table-regular/table-regular.component";
+export * from "./table-with-selection/table-with-selection";
 export * from "./table-with-custom-actions/table-with-custom-actions.component";
 export * from "./table-with-transcluded-action-bar/table-with-transcluded-action-bar.component";
 export * from "./table-with-fixed-header/table-with-fixed-header.component";

--- a/showcase/src/app/demo/table/components/table-regular/table-regular.component.html
+++ b/showcase/src/app/demo/table/components/table-regular/table-regular.component.html
@@ -5,6 +5,7 @@
 			 [orderProperties]="order"
 			 [paginationConfig]="pagination"
 			 [tableRowsActionBarConfig]="rowActionBarConfig"
-			 multiSort>
+			 multiSort
+			 (rowClicked)="handleRowClicked($event)">
 	<header><h1 class="mb0" translate>SHOWCASE.DEMO.TABLE.REGULAR</h1></header>
 </stark-table>

--- a/showcase/src/app/demo/table/components/table-regular/table-regular.component.ts
+++ b/showcase/src/app/demo/table/components/table-regular/table-regular.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit, ViewEncapsulation } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkActionBarConfig, StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
-const DUMMY_DATA: any[] = [
+const DUMMY_DATA: object[] = [
 	{ id: 1, title: { label: "first title (value: 1)", value: 1 }, description: "number one" },
 	{ id: 10, title: { label: "second title (value: 2)", value: 2 }, description: "second description" },
 	{ id: 12, title: { label: "third title (value: 3)", value: 3 }, description: "the third description" },
@@ -24,7 +24,7 @@ const DUMMY_DATA: any[] = [
 	encapsulation: ViewEncapsulation.None // Important
 })
 export class TableRegularComponent implements OnInit {
-	public data: any[];
+	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
 
@@ -46,10 +46,10 @@ export class TableRegularComponent implements OnInit {
 			{
 				name: "title",
 				label: "Title",
-				cellFormatter: (value: any): string => "~" + value.label,
+				cellFormatter: (value: { label: string }): string => "~" + value.label,
 				isFilterable: true,
 				isSortable: true,
-				compareFn: (n1: any, n2: any) => n1.value - n2.value
+				compareFn: (n1: { value: number }, n2: { value: number }) => n1.value - n2.value
 			},
 			{ name: "description", label: "Description", isFilterable: true, isSortable: true }
 		];
@@ -62,9 +62,25 @@ export class TableRegularComponent implements OnInit {
 
 		this.rowActionBarConfig = {
 			actions: [
-				{ id: "edit-item", label: "STARK.ICONS.EDIT_ITEM", icon: "pencil", actionCall: this.logger.debug, isEnabled: true },
-				{ id: "delete-item", label: "STARK.ICONS.DELETE_ITEM", icon: "delete", actionCall: this.logger.debug, isEnabled: false }
+				{
+					id: "edit-item",
+					label: "STARK.ICONS.EDIT_ITEM",
+					icon: "pencil",
+					actionCall: ($event: Event, data: object) => this.logger.debug("EDIT", $event, data),
+					isEnabled: true
+				},
+				{
+					id: "delete-item",
+					label: "STARK.ICONS.DELETE_ITEM",
+					icon: "delete",
+					actionCall: ($event: Event, data: object) => this.logger.debug("DELETE", $event, data),
+					isEnabled: false
+				}
 			]
 		};
+	}
+
+	public handleRowClicked(data: object): void {
+		this.logger.debug("ROW CLICKED:", data);
 	}
 }

--- a/showcase/src/app/demo/table/components/table-with-custom-actions/table-with-custom-actions.component.ts
+++ b/showcase/src/app/demo/table/components/table-with-custom-actions/table-with-custom-actions.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkAction, StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
-const DUMMY_DATA: any[] = [
+const DUMMY_DATA: object[] = [
 	{ id: 1, title: { label: "first title (value: 1)", value: 1 }, description: "number one" },
 	{ id: 10, title: { label: "second title (value: 2)", value: 2 }, description: "second description" },
 	{ id: 12, title: { label: "third title (value: 3)", value: 3 }, description: "the third description" },
@@ -22,7 +22,7 @@ const DUMMY_DATA: any[] = [
 	templateUrl: "./table-with-custom-actions.component.html"
 })
 export class TableWithCustomActionsComponent implements OnInit {
-	public data: any[];
+	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
 
@@ -39,7 +39,7 @@ export class TableWithCustomActionsComponent implements OnInit {
 
 		this.columns = [
 			{ name: "id", label: "Id" },
-			{ name: "title", label: "Title", cellFormatter: (value: any): string => "~" + value.label },
+			{ name: "title", label: "Title", cellFormatter: (value: { label: string }): string => "~" + value.label },
 			{ name: "description", label: "Description" }
 		];
 
@@ -48,8 +48,20 @@ export class TableWithCustomActionsComponent implements OnInit {
 		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: 10 };
 
 		this.tableActions = [
-			{ id: "edit-item", label: "STARK.ICONS.EDIT_ITEM", icon: "pencil", actionCall: this.logger.debug, isEnabled: false },
-			{ id: "reload", label: "STARK.ICONS.RELOAD_PAGE", icon: "autorenew", actionCall: this.logger.debug, isEnabled: true }
+			{
+				id: "edit-item",
+				label: "STARK.ICONS.EDIT_ITEM",
+				icon: "pencil",
+				actionCall: ($event: Event, data: object) => this.logger.debug("EDIT:", $event, data),
+				isEnabled: false
+			},
+			{
+				id: "reload",
+				label: "STARK.ICONS.RELOAD_PAGE",
+				icon: "autorenew",
+				actionCall: ($event: Event, data: object) => this.logger.debug("RELOAD:", $event, data),
+				isEnabled: true
+			}
 		];
 	}
 }

--- a/showcase/src/app/demo/table/components/table-with-custom-styling/table-with-custom-styling.component.ts
+++ b/showcase/src/app/demo/table/components/table-with-custom-styling/table-with-custom-styling.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewEncapsulation } from "@angular/core";
 import { StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
-const DUMMY_DATA: any[] = [
+const DUMMY_DATA: object[] = [
 	{ id: 1, title: { label: "first title (value: 1)", value: 1 }, description: "number one" },
 	{ id: 10, title: { label: "second title (value: 2)", value: 2 }, description: "second description" },
 	{ id: 12, title: { label: "third title (value: 3)", value: 3 }, description: "the third description" },
@@ -23,7 +23,7 @@ const DUMMY_DATA: any[] = [
 	encapsulation: ViewEncapsulation.None // Important
 })
 export class TableWithCustomStylingComponent implements OnInit {
-	public data: any[];
+	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
 
@@ -31,7 +31,7 @@ export class TableWithCustomStylingComponent implements OnInit {
 
 	public pagination: StarkPaginationConfig;
 
-	public getRowClassName: (_row: any, index: number) => string;
+	public getRowClassName: (_row: object, index: number) => string;
 
 	public ngOnInit(): void {
 		this.data = DUMMY_DATA;
@@ -41,7 +41,7 @@ export class TableWithCustomStylingComponent implements OnInit {
 			{
 				name: "title",
 				label: "Title",
-				cellFormatter: (value: any): string => "~" + value.label,
+				cellFormatter: (value: { label: string }): string => "~" + value.label,
 				cellClassName: (title: { value: number }) => (title.value < 5 ? "danger" : title.value < 9 ? "warning" : "success")
 			},
 			{ name: "description", label: "Description" }
@@ -51,6 +51,6 @@ export class TableWithCustomStylingComponent implements OnInit {
 
 		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: 10 };
 
-		this.getRowClassName = (_row: any, index: number) => (index % 2 === 0 ? "even" : "odd");
+		this.getRowClassName = (_row: object, index: number) => (index % 2 === 0 ? "even" : "odd");
 	}
 }

--- a/showcase/src/app/demo/table/components/table-with-fixed-header/table-with-fixed-header.component.ts
+++ b/showcase/src/app/demo/table/components/table-with-fixed-header/table-with-fixed-header.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from "@angular/core";
 import { StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
-const DUMMY_DATA: any[] = [
+const DUMMY_DATA: object[] = [
 	{ id: 1, title: { label: "first title (value: 1)", value: 1 }, description: "number one" },
 	{ id: 10, title: { label: "second title (value: 2)", value: 2 }, description: "second description" },
 	{ id: 12, title: { label: "third title (value: 3)", value: 3 }, description: "the third description" },
@@ -21,7 +21,7 @@ const DUMMY_DATA: any[] = [
 	templateUrl: "./table-with-fixed-header.component.html"
 })
 export class TableWithFixedHeaderComponent implements OnInit {
-	public data: any[];
+	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
 
@@ -34,7 +34,7 @@ export class TableWithFixedHeaderComponent implements OnInit {
 
 		this.columns = [
 			{ name: "id", label: "Id" },
-			{ name: "title", label: "Title", cellFormatter: (value: any): string => "~" + value.label },
+			{ name: "title", label: "Title", cellFormatter: (value: { label: string }): string => "~" + value.label },
 			{ name: "description", label: "Description" }
 		];
 

--- a/showcase/src/app/demo/table/components/table-with-selection/table-with-selection.component.html
+++ b/showcase/src/app/demo/table/components/table-with-selection/table-with-selection.component.html
@@ -1,0 +1,9 @@
+<stark-table [data]="data"
+			 [columnProperties]="columns"
+			 [filter]="filter"
+			 [paginationConfig]="pagination"
+			 [rowsSelectable]="true"
+			 (selectChanged)="handleRowSelected($event)"
+			 multiSelect>
+	<header><h1 class="mb0" translate>SHOWCASE.DEMO.TABLE.WITH_SELECTION</h1></header>
+</stark-table>

--- a/showcase/src/app/demo/table/components/table-with-selection/table-with-selection.ts
+++ b/showcase/src/app/demo/table/components/table-with-selection/table-with-selection.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
 const DUMMY_DATA: object[] = [
@@ -17,10 +18,10 @@ const DUMMY_DATA: object[] = [
 ];
 
 @Component({
-	selector: "showcase-table-with-fixed-header",
-	templateUrl: "./table-with-fixed-header.component.html"
+	selector: "showcase-table-with-selection",
+	templateUrl: "./table-with-selection.component.html"
 })
-export class TableWithFixedHeaderComponent implements OnInit {
+export class TableWithSelectionComponent implements OnInit {
 	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
@@ -29,17 +30,27 @@ export class TableWithFixedHeaderComponent implements OnInit {
 
 	public pagination: StarkPaginationConfig;
 
+	public constructor(@Inject(STARK_LOGGING_SERVICE) private logger: StarkLoggingService) {}
+
 	public ngOnInit(): void {
 		this.data = DUMMY_DATA;
 
 		this.columns = [
-			{ name: "id", label: "Id" },
-			{ name: "title", label: "Title", cellFormatter: (value: { label: string }): string => "~" + value.label },
+			{ name: "id", label: "Id", isFilterable: true, isSortable: true },
+			{
+				name: "title",
+				label: "Title",
+				cellFormatter: (value: { label: string }): string => "~" + value.label
+			},
 			{ name: "description", label: "Description" }
 		];
 
 		this.filter = { globalFilterPresent: false, columns: [] };
 
-		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: DUMMY_DATA.length };
+		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: 10 };
+	}
+
+	public handleRowSelected(data: object[]): void {
+		this.logger.debug("SELECTED ROW:", data);
 	}
 }

--- a/showcase/src/app/demo/table/components/table-with-transcluded-action-bar/table-with-transcluded-action-bar.component.ts
+++ b/showcase/src/app/demo/table/components/table-with-transcluded-action-bar/table-with-transcluded-action-bar.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkAction, StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
-const DUMMY_DATA: any[] = [
+const DUMMY_DATA: object[] = [
 	{ id: 1, title: { label: "first title (value: 1)", value: 1 }, description: "number one" },
 	{ id: 10, title: { label: "second title (value: 2)", value: 2 }, description: "second description" },
 	{ id: 12, title: { label: "third title (value: 3)", value: 3 }, description: "the third description" },
@@ -23,7 +23,7 @@ const DUMMY_DATA: any[] = [
 	styleUrls: ["./table-with-transcluded-action-bar.scss"]
 })
 export class TableWithTranscludedActionBarComponent implements OnInit {
-	public data: any[];
+	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
 
@@ -40,7 +40,7 @@ export class TableWithTranscludedActionBarComponent implements OnInit {
 
 		this.columns = [
 			{ name: "id", label: "Id" },
-			{ name: "title", label: "Title", cellFormatter: (value: any): string => "~" + value.label },
+			{ name: "title", label: "Title", cellFormatter: (value: { label: string }): string => "~" + value.label },
 			{ name: "description", label: "Description" }
 		];
 
@@ -49,8 +49,20 @@ export class TableWithTranscludedActionBarComponent implements OnInit {
 		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: 10 };
 
 		this.tableActions = [
-			{ id: "edit-item", label: "STARK.ICONS.EDIT_ITEM", icon: "pencil", actionCall: this.logger.debug, isEnabled: false },
-			{ id: "reload", label: "STARK.ICONS.RELOAD_PAGE", icon: "autorenew", actionCall: this.logger.debug, isEnabled: true }
+			{
+				id: "edit-item",
+				label: "STARK.ICONS.EDIT_ITEM",
+				icon: "pencil",
+				actionCall: ($event: Event, data: object) => this.logger.debug("EDIT:", $event, data),
+				isEnabled: false
+			},
+			{
+				id: "reload",
+				label: "STARK.ICONS.RELOAD_PAGE",
+				icon: "autorenew",
+				actionCall: ($event: Event, data: object) => this.logger.debug("RELOAD:", $event, data),
+				isEnabled: true
+			}
 		];
 	}
 }

--- a/showcase/src/app/demo/table/demo-table.component.html
+++ b/showcase/src/app/demo/table/demo-table.component.html
@@ -7,6 +7,12 @@
 		<showcase-table-regular></showcase-table-regular>
 	</example-viewer>
 
+	<example-viewer exampleTitle="SHOWCASE.DEMO.TABLE.WITH_SELECTION"
+					filesPath="table/with-selection/table"
+					[extensions]="['HTML','TS']">
+		<showcase-table-with-selection></showcase-table-with-selection>
+	</example-viewer>
+
 	<example-viewer exampleTitle="SHOWCASE.DEMO.TABLE.WITH_CUSTOM_ACTIONS"
 					filesPath="table/with-custom-actions/table"
 					[extensions]="['HTML', 'TS']">

--- a/showcase/src/assets/examples/table/regular/table.html
+++ b/showcase/src/assets/examples/table/regular/table.html
@@ -5,6 +5,7 @@
 			 [orderProperties]="order"
 			 [paginationConfig]="pagination"
 			 [tableRowsActionBarConfig]="rowActionBarConfig"
-			 multiSort>
+			 multiSort
+			 (rowClicked)="handleRowClicked($event)">
 	<header><h1 class="mb0">Regular Table</h1></header>
 </stark-table>

--- a/showcase/src/assets/examples/table/regular/table.ts
+++ b/showcase/src/assets/examples/table/regular/table.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit, ViewEncapsulation } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkActionBarConfig, StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
-const DUMMY_DATA: any[] = [
+const DUMMY_DATA: object[] = [
 	{ id: 1, title: { label: "first title (value: 1)", value: 1 }, description: "number one" },
 	{ id: 10, title: { label: "second title (value: 2)", value: 2 }, description: "second description" },
 	{ id: 12, title: { label: "third title (value: 3)", value: 3 }, description: "the third description" },
@@ -24,7 +24,7 @@ const DUMMY_DATA: any[] = [
 	encapsulation: ViewEncapsulation.None // Important
 })
 export class TableRegularComponent implements OnInit {
-	public data: any[];
+	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
 
@@ -46,10 +46,10 @@ export class TableRegularComponent implements OnInit {
 			{
 				name: "title",
 				label: "Title",
-				cellFormatter: (value: any): string => "~" + value.label,
+				cellFormatter: (value: { label: string }): string => "~" + value.label,
 				isFilterable: true,
 				isSortable: true,
-				compareFn: (n1: any, n2: any) => n1.value - n2.value
+				compareFn: (n1: { value: number }, n2: { value: number }) => n1.value - n2.value
 			},
 			{ name: "description", label: "Description", isFilterable: true, isSortable: true }
 		];
@@ -62,9 +62,25 @@ export class TableRegularComponent implements OnInit {
 
 		this.rowActionBarConfig = {
 			actions: [
-				{ id: "edit-item", label: "STARK.ICONS.EDIT_ITEM", icon: "pencil", actionCall: this.logger.debug, isEnabled: true },
-				{ id: "delete-item", label: "STARK.ICONS.DELETE_ITEM", icon: "delete", actionCall: this.logger.debug, isEnabled: false }
+				{
+					id: "edit-item",
+					label: "STARK.ICONS.EDIT_ITEM",
+					icon: "pencil",
+					actionCall: ($event: Event, data: object) => this.logger.debug("EDIT", $event, data),
+					isEnabled: true
+				},
+				{
+					id: "delete-item",
+					label: "STARK.ICONS.DELETE_ITEM",
+					icon: "delete",
+					actionCall: ($event: Event, data: object) => this.logger.debug("DELETE", $event, data),
+					isEnabled: false
+				}
 			]
 		};
+	}
+
+	public handleRowClicked(data: object): void {
+		this.logger.debug("ROW CLICKED:", data);
 	}
 }

--- a/showcase/src/assets/examples/table/with-custom-actions/table.ts
+++ b/showcase/src/assets/examples/table/with-custom-actions/table.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkAction, StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
-const DUMMY_DATA: any[] = [
+const DUMMY_DATA: object[] = [
 	{ id: 1, title: { label: "first title (value: 1)", value: 1 }, description: "number one" },
 	{ id: 10, title: { label: "second title (value: 2)", value: 2 }, description: "second description" },
 	{ id: 12, title: { label: "third title (value: 3)", value: 3 }, description: "the third description" },
@@ -22,7 +22,7 @@ const DUMMY_DATA: any[] = [
 	templateUrl: "./table-with-custom-actions.component.html"
 })
 export class TableWithCustomActionsComponent implements OnInit {
-	public data: any[];
+	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
 
@@ -39,7 +39,7 @@ export class TableWithCustomActionsComponent implements OnInit {
 
 		this.columns = [
 			{ name: "id", label: "Id" },
-			{ name: "title", label: "Title", cellFormatter: (value: any): string => "~" + value.label },
+			{ name: "title", label: "Title", cellFormatter: (value: { label: string }): string => "~" + value.label },
 			{ name: "description", label: "Description" }
 		];
 
@@ -48,8 +48,20 @@ export class TableWithCustomActionsComponent implements OnInit {
 		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: 10 };
 
 		this.tableActions = [
-			{ id: "edit-item", label: "STARK.ICONS.EDIT_ITEM", icon: "pencil", actionCall: this.logger.debug, isEnabled: false },
-			{ id: "reload", label: "STARK.ICONS.RELOAD_PAGE", icon: "autorenew", actionCall: this.logger.debug, isEnabled: true }
+			{
+				id: "edit-item",
+				label: "STARK.ICONS.EDIT_ITEM",
+				icon: "pencil",
+				actionCall: ($event: Event, data: object) => this.logger.debug("EDIT:", $event, data),
+				isEnabled: false
+			},
+			{
+				id: "reload",
+				label: "STARK.ICONS.RELOAD_PAGE",
+				icon: "autorenew",
+				actionCall: ($event: Event, data: object) => this.logger.debug("RELOAD:", $event, data),
+				isEnabled: true
+			}
 		];
 	}
 }

--- a/showcase/src/assets/examples/table/with-custom-styling/table.scss
+++ b/showcase/src/assets/examples/table/with-custom-styling/table.scss
@@ -6,7 +6,7 @@
 // Id cell class
 .large {
   font-weight: bold;
-  font-size: 30px;
+  font-size: 20px;
 }
 
 // Title cell classes

--- a/showcase/src/assets/examples/table/with-custom-styling/table.ts
+++ b/showcase/src/assets/examples/table/with-custom-styling/table.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ViewEncapsulation } from "@angular/core";
 import { StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
-const DUMMY_DATA: any[] = [
+const DUMMY_DATA: object[] = [
 	{ id: 1, title: { label: "first title (value: 1)", value: 1 }, description: "number one" },
 	{ id: 10, title: { label: "second title (value: 2)", value: 2 }, description: "second description" },
 	{ id: 12, title: { label: "third title (value: 3)", value: 3 }, description: "the third description" },
@@ -23,7 +23,7 @@ const DUMMY_DATA: any[] = [
 	encapsulation: ViewEncapsulation.None // Important
 })
 export class TableWithCustomStylingComponent implements OnInit {
-	public data: any[];
+	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
 
@@ -31,7 +31,7 @@ export class TableWithCustomStylingComponent implements OnInit {
 
 	public pagination: StarkPaginationConfig;
 
-	public getRowClassName: (_row: any, index: number) => string;
+	public getRowClassName: (_row: object, index: number) => string;
 
 	public ngOnInit(): void {
 		this.data = DUMMY_DATA;
@@ -41,7 +41,7 @@ export class TableWithCustomStylingComponent implements OnInit {
 			{
 				name: "title",
 				label: "Title",
-				cellFormatter: (value: any): string => "~" + value.label,
+				cellFormatter: (value: { label: string }): string => "~" + value.label,
 				cellClassName: (title: { value: number }) => (title.value < 5 ? "danger" : title.value < 9 ? "warning" : "success")
 			},
 			{ name: "description", label: "Description" }
@@ -51,6 +51,6 @@ export class TableWithCustomStylingComponent implements OnInit {
 
 		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: 10 };
 
-		this.getRowClassName = (_row: any, index: number) => (index % 2 === 0 ? "even" : "odd");
+		this.getRowClassName = (_row: object, index: number) => (index % 2 === 0 ? "even" : "odd");
 	}
 }

--- a/showcase/src/assets/examples/table/with-selection/table.html
+++ b/showcase/src/assets/examples/table/with-selection/table.html
@@ -1,0 +1,9 @@
+<stark-table [data]="data"
+			 [columnProperties]="columns"
+			 [filter]="filter"
+			 [paginationConfig]="pagination"
+			 [rowsSelectable]="true"
+			 (selectChanged)="handleRowSelected($event)"
+			 multiSelect>
+	<header><h1 class="mb0">Table with selection</h1></header>
+</stark-table>

--- a/showcase/src/assets/examples/table/with-selection/table.ts
+++ b/showcase/src/assets/examples/table/with-selection/table.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, Inject, OnInit } from "@angular/core";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
 const DUMMY_DATA: object[] = [
@@ -17,10 +18,10 @@ const DUMMY_DATA: object[] = [
 ];
 
 @Component({
-	selector: "showcase-table-with-fixed-header",
-	templateUrl: "./table-with-fixed-header.component.html"
+	selector: "showcase-table-with-selection",
+	templateUrl: "./table-with-selection.component.html"
 })
-export class TableWithFixedHeaderComponent implements OnInit {
+export class TableWithSelectionComponent implements OnInit {
 	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
@@ -29,17 +30,27 @@ export class TableWithFixedHeaderComponent implements OnInit {
 
 	public pagination: StarkPaginationConfig;
 
+	public constructor(@Inject(STARK_LOGGING_SERVICE) private logger: StarkLoggingService) {}
+
 	public ngOnInit(): void {
 		this.data = DUMMY_DATA;
 
 		this.columns = [
-			{ name: "id", label: "Id" },
-			{ name: "title", label: "Title", cellFormatter: (value: { label: string }): string => "~" + value.label },
+			{ name: "id", label: "Id", isFilterable: true, isSortable: true },
+			{
+				name: "title",
+				label: "Title",
+				cellFormatter: (value: { label: string }): string => "~" + value.label
+			},
 			{ name: "description", label: "Description" }
 		];
 
 		this.filter = { globalFilterPresent: false, columns: [] };
 
-		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: DUMMY_DATA.length };
+		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: 10 };
+	}
+
+	public handleRowSelected(data: object[]): void {
+		this.logger.debug("SELECTED ROW:", data);
 	}
 }

--- a/showcase/src/assets/examples/table/with-transcluded-action-bar/table.ts
+++ b/showcase/src/assets/examples/table/with-transcluded-action-bar/table.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkAction, StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
 
-const DUMMY_DATA: any[] = [
+const DUMMY_DATA: object[] = [
 	{ id: 1, title: { label: "first title (value: 1)", value: 1 }, description: "number one" },
 	{ id: 10, title: { label: "second title (value: 2)", value: 2 }, description: "second description" },
 	{ id: 12, title: { label: "third title (value: 3)", value: 3 }, description: "the third description" },
@@ -23,7 +23,7 @@ const DUMMY_DATA: any[] = [
 	styleUrls: ["./table-with-transcluded-action-bar.scss"]
 })
 export class TableWithTranscludedActionBarComponent implements OnInit {
-	public data: any[];
+	public data: object[];
 
 	public columns: StarkTableColumnProperties[];
 
@@ -40,7 +40,7 @@ export class TableWithTranscludedActionBarComponent implements OnInit {
 
 		this.columns = [
 			{ name: "id", label: "Id" },
-			{ name: "title", label: "Title", cellFormatter: (value: any): string => "~" + value.label },
+			{ name: "title", label: "Title", cellFormatter: (value: { label: string }): string => "~" + value.label },
 			{ name: "description", label: "Description" }
 		];
 
@@ -49,8 +49,20 @@ export class TableWithTranscludedActionBarComponent implements OnInit {
 		this.pagination = { totalItems: DUMMY_DATA.length, page: 1, itemsPerPage: 10 };
 
 		this.tableActions = [
-			{ id: "edit-item", label: "STARK.ICONS.EDIT_ITEM", icon: "pencil", actionCall: this.logger.debug, isEnabled: false },
-			{ id: "reload", label: "STARK.ICONS.RELOAD_PAGE", icon: "autorenew", actionCall: this.logger.debug, isEnabled: true }
+			{
+				id: "edit-item",
+				label: "STARK.ICONS.EDIT_ITEM",
+				icon: "pencil",
+				actionCall: ($event: Event, data: object) => this.logger.debug("EDIT:", $event, data),
+				isEnabled: false
+			},
+			{
+				id: "reload",
+				label: "STARK.ICONS.RELOAD_PAGE",
+				icon: "autorenew",
+				actionCall: ($event: Event, data: object) => this.logger.debug("RELOAD:", $event, data),
+				isEnabled: true
+			}
 		];
 	}
 }

--- a/showcase/src/assets/translations/en.json
+++ b/showcase/src/assets/translations/en.json
@@ -243,6 +243,7 @@
       },
       "TABLE": {
         "REGULAR": "Regular Table",
+        "WITH_SELECTION": "Table with selection",
         "WITH_CUSTOM_ACTIONS": "Table with custom actions",
         "WITH_FIXED_HEADER": "Table with fixed header",
         "WITH_TRANSCLUDED_ACTION_BAR": "Table with transcluded Action bar",

--- a/showcase/src/assets/translations/fr.json
+++ b/showcase/src/assets/translations/fr.json
@@ -243,6 +243,7 @@
       },
       "TABLE": {
         "REGULAR": "Table régulière",
+        "WITH_SELECTION": "Table avec sélection",
         "WITH_CUSTOM_ACTIONS": "Table avec actions personalisé",
         "WITH_FIXED_HEADER": "Table avec en-tête fixe",
         "WITH_TRANSCLUDED_ACTION_BAR": "Table avec Action Bar 'transcluded'",

--- a/showcase/src/assets/translations/nl.json
+++ b/showcase/src/assets/translations/nl.json
@@ -243,6 +243,7 @@
       },
       "TABLE": {
         "REGULAR": "Normale tabel",
+        "WITH_SELECTION": "Tabel met selectie",
         "WITH_CUSTOM_ACTIONS": "Tabel met aangepaste acties",
         "WITH_FIXED_HEADER": "Tabel met vaste header",
         "WITH_TRANSCLUDED_ACTION_BAR": "Tabel met 'transcluded' Action Bar",

--- a/showcase/src/styles/_stark-styles.scss
+++ b/showcase/src/styles/_stark-styles.scss
@@ -29,6 +29,7 @@ IMPORTANT: Stark styles are provided as SCSS styles so they should be imported i
 @import "~@nationalbankbelgium/stark-ui/src/modules/pagination/components/pagination-theme";
 @import "~@nationalbankbelgium/stark-ui/src/modules/pretty-print/components/pretty-print.component";
 @import "~@nationalbankbelgium/stark-ui/src/modules/table/components/table.component";
+@import "~@nationalbankbelgium/stark-ui/src/modules/table/components/table-theme";
 @import "~@nationalbankbelgium/stark-ui/src/modules/table/components/dialogs/multisort.component";
 @import "~@nationalbankbelgium/stark-ui/src/modules/dropdown/components/dropdown-theme";
 @import "~@nationalbankbelgium/stark-ui/src/modules/toast-notification/components/toast-notification.component";


### PR DESCRIPTION
ISSUES CLOSED: #795 #880 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Enable `(rowClick)` on `Table` component
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Clicking on a row does nothing
Issue Number: #795 #880


## What is the new behavior?
- added `(rowClick)` emitter to handle a row click so that an observer can be passed to the emitter for custom behaviour.
- set default row click to selecting the row
- fixed selecting rows
- fixed action buttons propagation
- added hover styling to rows
- added test for row click
- added example to demo page

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information