### PR TITLE
ci(build-main): add 'silent' flag to npm pack command to prevent Travis from continuing to the next step before the packaging finishes

### DIFF
--- a/build-functions.sh
+++ b/build-functions.sh
@@ -379,7 +379,7 @@ generateNpmPackage() {
   local NPM_DIR="$1"
   (
     cd $NPM_DIR > /dev/null
-    npm pack ./ > /dev/null
+    npm pack ./ --silent
   )
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
After upgrading NPM to the latest version (6.4.1), Travis builds fail due to the `npm pack` command triggered in our `build.sh` suddenly stops and executes the next command `adaptNpmPackageDependencies` which fails.

Same issue described in this PR: #615 


## What is the new behavior?
The `--silent` options is used in the  `npm pack` so that it is executed correctly and without logging anything to the console so that the command `adaptNpmPackageDependencies` is executed afterwards as soon as the `npm pack` finishes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
