### PR TITLE
chore(release): adapt release-it config to align with the new config since version 9

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -5,13 +5,16 @@
 	"force": false,
 	"pkgFiles": ["package.json", "package-lock.json"],
 	"increment": "conventional:angular",
-	"beforeChangelogCommand": "npm run generate:changelog",
-	"changelogCommand": "npm run generate:changelog-recent",
-	"buildCommand": false,
-	"safeBump": false,
-	"requireCleanWorkingDir": true,
-	"requireUpstream": true,
-	"src": {
+	"scripts": {
+		"afterBump": "npm run generate:changelog",
+		"afterRelease": false,
+		"beforeStage": false,
+		"beforeStart": false,
+		"changelog": "npm run generate:changelog-recent"
+	},
+	"git": {
+		"requireCleanWorkingDir": true,
+		"requireUpstream": true,
 		"commit": true,
 		"commitMessage": "chore(release): release %s",
 		"commitArgs": "",
@@ -20,9 +23,7 @@
 		"tagAnnotation": "%s",
 		"push": true,
 		"pushArgs": "",
-		"pushRepo": "origin",
-		"beforeStartCommand": false,
-		"afterReleaseCommand": false
+		"pushRepo": "origin"
 	},
 	"npm": {
 		"publish": false
@@ -36,13 +37,10 @@
 		"host": null
 	},
 	"prompt": {
-		"src": {
-			"status": false,
-			"commit": true,
-			"tag": true,
-			"push": true,
-			"release": true,
-			"publish": true
-		}
+		"commit": true,
+		"tag": true,
+		"push": true,
+		"release": true,
+		"publish": true
 	}
 }


### PR DESCRIPTION
ISSUES CLOSED: #976

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #976 


## What is the new behavior?
The release-it config is migrated as indicated in the [v9 changelog](https://github.com/webpro/release-it/blob/master/CHANGELOG.md#v9) so no more deprecation warnings are displayed when running the `npm run release` command.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->