### PR TITLE
feat(stark-ui): make dropdown component working with reactive form + add stark form util

### DIFF
--- a/packages/stark-ui/src/common/translations/translations/en.ts
+++ b/packages/stark-ui/src/common/translations/translations/en.ts
@@ -18,6 +18,9 @@ export const translationsEn: object = {
 			SEARCH: "Search",
 			NEW_ITEM: "New",
 			SAVE_AND_NEXT: "Save And Next"
+		},
+		VALIDATION: {
+			REQUIRED: "This field is required"
 		}
 	}
 };

--- a/packages/stark-ui/src/common/translations/translations/fr.ts
+++ b/packages/stark-ui/src/common/translations/translations/fr.ts
@@ -18,6 +18,9 @@ export const translationsFr: object = {
 			SEARCH: "Chercher",
 			NEW_ITEM: "Nouveau",
 			SAVE_AND_NEXT: "Sauver et Suivant"
+		},
+		VALIDATION: {
+			REQUIRED: "Ce champ est obligatoire"
 		}
 	}
 };

--- a/packages/stark-ui/src/common/translations/translations/nl.ts
+++ b/packages/stark-ui/src/common/translations/translations/nl.ts
@@ -18,6 +18,9 @@ export const translationsNl: object = {
 			SEARCH: "Zoeken",
 			NEW_ITEM: "Nieuw",
 			SAVE_AND_NEXT: "Bewaar en volgende"
+		},
+		VALIDATION: {
+			REQUIRED: "Dit veld is verplicht"
 		}
 	}
 };

--- a/packages/stark-ui/src/modules/dropdown/components/dropdown.component.html
+++ b/packages/stark-ui/src/modules/dropdown/components/dropdown.component.html
@@ -1,15 +1,12 @@
 <mat-form-field>
-	<label *ngIf="label !== undefined && label !== ''" translate>{{ label }}</label>
 	<!-- single-selection view -->
 	<mat-select
 		*ngIf="!isMultiSelectEnabled"
 		[id]="dropdownId"
-		[(ngModel)]="value"
+		[formControl]="formControl"
 		[placeholder]="placeholder | translate"
 		[attr.aria-label]="dropdownName | translate"
-		[disabled]="isDisabled"
 		[required]="required"
-		(selectionChange)="selectionChanged()"
 	>
 		<!-- FIXME find a replacement for md-select-header as mat-select-header does not exist yet https://github.com/angular/material2/pull/7835 -->
 		<!--<mat-select-header-->
@@ -32,12 +29,10 @@
 	<mat-select
 		*ngIf="isMultiSelectEnabled"
 		[id]="dropdownId"
-		[(ngModel)]="value"
+		[formControl]="formControl"
 		[placeholder]="placeholder | translate"
 		[attr.aria-label]="dropdownName | translate"
 		[required]="required"
-		[disabled]="isDisabled"
-		(selectionChange)="selectionChanged()"
 		multiple
 	>
 		<!-- FIXME find a replacement for md-select-header as mat-select-header does not exist yet https://github.com/angular/material2/pull/7835 -->
@@ -58,4 +53,9 @@
 			</mat-option>
 		</span>
 	</mat-select>
+
+	<mat-error>
+		<div #ref><ng-content></ng-content></div>
+		<span *ngIf="ref.children.length === 0 && required" translate>STARK.VALIDATION.REQUIRED</span>
+	</mat-error>
 </mat-form-field>

--- a/packages/stark-ui/src/modules/dropdown/components/dropdown.component.spec.ts
+++ b/packages/stark-ui/src/modules/dropdown/components/dropdown.component.spec.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:completed-docs max-inline-declarations no-commented-code no-big-function no-identical-functions */
 import { Component, DebugElement, NO_ERRORS_SCHEMA, ViewChild } from "@angular/core";
-import { FormsModule } from "@angular/forms";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatOptionModule } from "@angular/material/core";
 import { MatSelectModule } from "@angular/material/select";
@@ -12,17 +12,22 @@ import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 
+import Spy = jasmine.Spy;
+
 @Component({
 	selector: `host-component`,
 	template: `
 		<stark-dropdown
 			[dropdownId]="dropdownId"
-			[label]="label"
+			[dropdownFormControl]="formControl"
+			[isDisabled]="disabled"
 			[multiSelect]="multiSelect"
+			[optionIdProperty]="optionIdProperty"
+			[optionLabelProperty]="optionLabelProperty"
 			[options]="options"
 			[placeholder]="placeholder"
 			[required]="required"
-			[selectionChange]="dropdownSelectionChanged"
+			(selectionChanged)="selectionChanged"
 			[value]="value"
 		>
 		</stark-dropdown>
@@ -32,13 +37,16 @@ class TestHostComponent {
 	@ViewChild(StarkDropdownComponent)
 	public dropdownComponent: StarkDropdownComponent;
 	public dropdownId: string;
+	public formControl: FormControl;
 	// public header?: string;
-	public label?: string;
+	public disabled?: boolean;
 	public multiSelect?: string;
+	public optionIdProperty?: string;
+	public optionLabelProperty?: string;
 	public options: any[];
 	public placeholder: string;
 	public value: any | any[];
-	public dropdownSelectionChanged: Function;
+	public selectionChanged: Function;
 	public required?: boolean;
 }
 
@@ -48,97 +56,347 @@ describe("DropdownComponent", () => {
 	let hostFixture: ComponentFixture<TestHostComponent>;
 
 	const simpleOptions: string[] = ["1", "2", "3"];
-	const dropdownLabel: string = "dropdown label";
+	const complexOptions: object[] = [
+		{
+			id: 0,
+			label: "label0"
+		},
+		{
+			id: 1,
+			label: "label1"
+		},
+		{
+			id: 2,
+			label: "label2"
+		}
+	];
 	const dropdownPlaceholder: string = "dropdown placeholder";
 	const dropdownValue: string = "dropdownValue";
 	const dropdownId: string = "dropdownId";
 	const dropdownOnChange: any = () => {
 		return "dummyDropdownOnChange";
 	};
+	const dropdownFormControl: FormControl = new FormControl("dropdownFormControl");
+	const dropdownOptionIdProperty: string = "id";
+	const dropdownOptionLabelProperty: string = "label";
+	const matSelectSelector: string = "mat-select";
 
 	beforeEach(async(() => {
 		return TestBed.configureTestingModule({
-			imports: [CommonModule, MatSelectModule, MatOptionModule, FormsModule, TranslateModule.forRoot(), NoopAnimationsModule],
+			imports: [CommonModule, MatSelectModule, MatOptionModule, ReactiveFormsModule, TranslateModule.forRoot(), NoopAnimationsModule],
 			declarations: [StarkDropdownComponent, TestHostComponent],
 			providers: [{ provide: STARK_LOGGING_SERVICE, useValue: new MockStarkLoggingService() }, TranslateService],
 			schemas: [NO_ERRORS_SCHEMA] // tells the Angular compiler to ignore unrecognized elements and attributes (selectionChange)
 		}).compileComponents();
 	}));
 
-	// Inject the mocked services
-	beforeEach(() => {
-		hostFixture = TestBed.createComponent(TestHostComponent);
-		hostComponent = hostFixture.componentInstance;
-		hostFixture.detectChanges();
-		component = hostComponent.dropdownComponent;
-
-		hostComponent.dropdownId = dropdownId;
-		hostComponent.label = dropdownLabel;
-		hostComponent.dropdownSelectionChanged = dropdownOnChange;
-		hostComponent.options = simpleOptions;
-		hostComponent.placeholder = dropdownPlaceholder;
-		hostComponent.value = dropdownValue;
-
-		hostFixture.detectChanges();
-	});
-
-	describe("on initialization", () => {
-		it("should set internal component properties", () => {
-			expect(hostFixture).toBeDefined();
-			expect(component).toBeDefined();
-			expect(component.logger).not.toBeNull();
-			expect(component.logger).toBeDefined();
-		});
-
-		it("should NOT have any inputs set", () => {
-			expect(component.dropdownId).toBe(hostComponent.dropdownId);
-			expect(component.dropdownSelectionChanged).toBeDefined();
-			expect(component.label).toBe(hostComponent.label);
-			expect(component.multiSelect).toBe(hostComponent.multiSelect);
-			expect(component.options).toBe(hostComponent.options);
-			expect(component.placeholder).toBe(hostComponent.placeholder);
-			expect(component.required).toBe(<boolean>hostComponent.required);
-			expect(component.value).toBe(hostComponent.value);
-		});
-	});
-
-	describe("on change", () => {
-		it("should assign right value to isMultiSelectEnabled when multiSelect changes", () => {
-			hostComponent.multiSelect = "true";
-			hostComponent.value = [];
+	describe("Using value + selectionChanged", () => {
+		// Inject the mocked services
+		beforeEach(() => {
+			hostFixture = TestBed.createComponent(TestHostComponent);
+			hostComponent = hostFixture.componentInstance;
 			hostFixture.detectChanges();
-			expect(component.isMultiSelectEnabled).toBe(true);
+			component = hostComponent.dropdownComponent;
 
-			hostComponent.multiSelect = "false";
-			hostComponent.value = undefined;
+			hostComponent.dropdownId = dropdownId;
+			hostComponent.selectionChanged = dropdownOnChange;
+			hostComponent.options = simpleOptions;
+			hostComponent.placeholder = dropdownPlaceholder;
+			hostComponent.value = dropdownValue;
+
 			hostFixture.detectChanges();
-			expect(component.isMultiSelectEnabled).toBe(false);
+		});
+
+		describe("on initialization", () => {
+			it("should set internal component properties", () => {
+				expect(hostFixture).toBeDefined();
+				expect(component).toBeDefined();
+				expect(component.logger).not.toBeNull();
+				expect(component.logger).toBeDefined();
+			});
+
+			it("should NOT have any inputs set", () => {
+				expect(component.dropdownId).toBe(hostComponent.dropdownId);
+				expect(component.selectionChanged).toBeDefined();
+				expect(component.multiSelect).toBe(hostComponent.multiSelect);
+				expect(component.options).toBe(hostComponent.options);
+				expect(component.placeholder).toBe(hostComponent.placeholder);
+				expect(component.required).toBe(<boolean>hostComponent.required);
+				expect(component.value).toBe(hostComponent.value);
+			});
+		});
+
+		describe("on change", () => {
+			describe("required", () => {
+				it("should set the right value to the formControl when 'required' changes", () => {
+					hostComponent.required = true;
+					hostFixture.detectChanges();
+					expect(component.formControl.validator !== null).toBe(true);
+					// Solution found on Angular GitHub issue: https://github.com/angular/angular/issues/13461
+					//tslint:disable-next-line:no-null-keyword
+					expect(new FormControl(undefined, component.formControl.validator).errors).toEqual({ required: true });
+
+					hostComponent.required = false;
+					hostFixture.detectChanges();
+					//tslint:disable-next-line:no-null-keyword
+					expect(component.formControl.validator).toBe(<any>null);
+				});
+			});
+
+			describe("isDisabled", () => {
+				it("should set the right value to the formControl when 'isDisabled' changes", () => {
+					hostComponent.disabled = true;
+					hostFixture.detectChanges();
+					expect(component.formControl.disabled).toBe(true);
+
+					hostComponent.disabled = false;
+					hostFixture.detectChanges();
+					expect(component.formControl.disabled).toBe(false);
+				});
+
+				it("should log a warning if 'dropdownFormControl' and 'isDisabled' are set", () => {
+					hostComponent.formControl = dropdownFormControl;
+					hostComponent.disabled = true;
+					hostFixture.detectChanges();
+					expect(component.logger.warn).toHaveBeenCalledTimes(1);
+					expect((<Spy>component.logger.warn).calls.mostRecent().args[0]).toMatch(/When dropdownFormControl is set/);
+				});
+			});
+
+			describe("value", () => {
+				it("should set the right value to the formControl when 'isDisabled' changes", () => {
+					hostComponent.disabled = true;
+					hostFixture.detectChanges();
+					expect(component.formControl.disabled).toBe(true);
+
+					hostComponent.disabled = false;
+					hostFixture.detectChanges();
+					expect(component.formControl.disabled).toBe(false);
+				});
+
+				it("should log a warning if 'dropdownFormControl' and 'isDisabled' are set", () => {
+					hostComponent.formControl = dropdownFormControl;
+					hostComponent.disabled = true;
+					hostFixture.detectChanges();
+					expect(component.logger.warn).toHaveBeenCalledTimes(1);
+					expect((<Spy>component.logger.warn).calls.mostRecent().args[0]).toMatch(/When dropdownFormControl is set/);
+				});
+			});
+
+			describe("multiSelect", () => {
+				it("should set the right value to isMultiSelectEnabled when 'multiSelect' changes", () => {
+					hostComponent.value = [];
+					hostComponent.multiSelect = "true";
+					hostFixture.detectChanges();
+					expect(component.isMultiSelectEnabled).toBe(true);
+
+					hostComponent.multiSelect = "";
+					hostFixture.detectChanges();
+					expect(component.isMultiSelectEnabled).toBe(true);
+
+					hostComponent.multiSelect = undefined;
+					hostFixture.detectChanges();
+					expect(component.isMultiSelectEnabled).toBe(false);
+				});
+			});
+
+			describe("optionIdProperty & optionLabelProperty", () => {
+				it("should set the right value to optionsAreSimpleTypes when 'optionIdProperty' or 'optionLabelProperty' change", () => {
+					hostComponent.optionIdProperty = dropdownOptionIdProperty;
+					hostFixture.detectChanges();
+					expect(component.optionsAreSimpleTypes).toBe(true);
+
+					hostComponent.optionLabelProperty = dropdownOptionLabelProperty;
+					hostComponent.options = complexOptions;
+					hostFixture.detectChanges();
+					expect(component.optionsAreSimpleTypes).toBe(false);
+
+					hostComponent.optionLabelProperty = undefined;
+					hostFixture.detectChanges();
+					expect(component.optionsAreSimpleTypes).toBe(true);
+				});
+			});
+		});
+
+		describe("options defined as array of simple types", () => {
+			it("should render the appropriate content", () => {
+				const dropdownComponent: DebugElement = hostFixture.debugElement.query(By.directive(StarkDropdownComponent));
+				expect(dropdownComponent.nativeElement.getAttribute("ng-reflect-value")).toBe(dropdownValue); // ngModel is replaced by Angular to "ng-reflect-value"
+				expect(hostFixture.nativeElement.innerHTML).toContain("<mat-select");
+				const dropdownElement: HTMLElement = dropdownComponent.nativeElement.querySelector(matSelectSelector);
+				expect(dropdownElement.getAttribute("ng-reflect-placeholder")).toBe(dropdownPlaceholder);
+				expect(dropdownElement.getAttribute("ng-reflect-id")).toBe(dropdownId);
+
+				//FIXME find a solution to make those tests work again
+				// Angular now does not diplay the option of mat-select in the html file, which means that we have no solution to test those options
+
+				// expect(dropdownElement.html()).toContain("<md-option");
+				// const optionElements: IAugmentedJQuery = UnitTestingUtils.getElementsByTagName(element, "md-option");
+				// expect(optionElements.length).toBe(3);
+				//
+				// for (let index: number = 0; index < optionElements.length; index++) {
+				// 	const option: IAugmentedJQuery = angular.element(optionElements[index]);
+				// 	expect(option.attr("ng-value")).toBe("$ctrl.optionsAreSimpleTypes ? option : option[$ctrl.optionIdProperty]");
+				// 	expect(option.attr("value")).toBe(String(index + 1));
+				// 	expect(option.text().trim()).toBe(String(index + 1));
+				// }
+			});
 		});
 	});
 
-	describe("options defined as array of simple types", () => {
-		it("should render the appropriate content", () => {
-			const dropdownComponent: DebugElement = hostFixture.debugElement.query(By.directive(StarkDropdownComponent));
-			expect(dropdownComponent.nativeElement.getAttribute("ng-reflect-value")).toBe(dropdownValue); // ngModel is replaced by Angular to "ng-reflect-value"
-			expect(hostFixture.nativeElement.innerHTML).toContain("<mat-select");
-			const dropdownElement: DebugElement = dropdownComponent.query(By.css("mat-select"));
-			expect(dropdownElement.nativeElement.getAttribute("ng-reflect-placeholder")).toBe(dropdownPlaceholder);
-			expect(dropdownElement.nativeElement.getAttribute("ng-reflect-id")).toBe(dropdownId);
+	describe("Using reactive forms", () => {
+		// Inject the mocked services
+		beforeEach(() => {
+			hostFixture = TestBed.createComponent(TestHostComponent);
+			hostComponent = hostFixture.componentInstance;
+			hostFixture.detectChanges();
+			component = hostComponent.dropdownComponent;
 
-			//FIXME find a solution to make those tests work again
-			// Angular now does not diplay the option of mat-select in the html file, which means that we have no solution to test those options
+			hostComponent.dropdownId = dropdownId;
+			hostComponent.options = simpleOptions;
+			hostComponent.placeholder = dropdownPlaceholder;
+			hostComponent.formControl = dropdownFormControl;
 
-			// expect(dropdownElement.html()).toContain("<md-option");
-			// const optionElements: IAugmentedJQuery = UnitTestingUtils.getElementsByTagName(element, "md-option");
-			// expect(optionElements.length).toBe(3);
-			//
-			// for (let index: number = 0; index < optionElements.length; index++) {
-			// 	const option: IAugmentedJQuery = angular.element(optionElements[index]);
-			// 	expect(option.attr("ng-value")).toBe("$ctrl.optionsAreSimpleTypes ? option : option[$ctrl.optionIdProperty]");
-			// 	expect(option.attr("value")).toBe(String(index + 1));
-			// 	expect(option.text().trim()).toBe(String(index + 1));
-			// }
+			hostFixture.detectChanges();
 		});
+
+		describe("on initialization", () => {
+			it("should set internal component properties", () => {
+				expect(hostFixture).toBeDefined();
+				expect(component).toBeDefined();
+				expect(component.logger).not.toBeNull();
+				expect(component.logger).toBeDefined();
+			});
+
+			it("should NOT have any inputs set", () => {
+				expect(component.dropdownId).toBe(hostComponent.dropdownId);
+				expect(component.selectionChanged).toBeDefined();
+				expect(component.multiSelect).toBe(hostComponent.multiSelect);
+				expect(component.options).toBe(hostComponent.options);
+				expect(component.placeholder).toBe(hostComponent.placeholder);
+				expect(component.required).toBe(<boolean>hostComponent.required);
+				expect(component.dropdownFormControl).toBe(hostComponent.formControl);
+			});
+		});
+
+		describe("on change", () => {
+			it("should assign right value to isMultiSelectEnabled when multiSelect changes", () => {
+				hostComponent.multiSelect = "true";
+				// hostComponent.value = [];
+				hostFixture.detectChanges();
+				expect(component.isMultiSelectEnabled).toBe(true);
+
+				hostComponent.multiSelect = "false";
+				// hostComponent.value = undefined;
+				hostFixture.detectChanges();
+				expect(component.isMultiSelectEnabled).toBe(false);
+			});
+		});
+
+		describe("options defined as array of simple types", () => {
+			it("should render the appropriate content", () => {
+				const dropdownComponent: DebugElement = hostFixture.debugElement.query(By.directive(StarkDropdownComponent));
+				expect(dropdownComponent.nativeElement.getAttribute("ng-reflect-dropdown-form-control")).toBe("[object Object]"); // ngModel is replaced by Angular to "ng-reflect-value"
+				expect(hostFixture.nativeElement.innerHTML).toContain("<mat-select");
+				const dropdownElement: HTMLElement = dropdownComponent.nativeElement.querySelector(matSelectSelector);
+				expect(dropdownElement.getAttribute("ng-reflect-placeholder")).toBe(dropdownPlaceholder);
+				expect(dropdownElement.getAttribute("ng-reflect-id")).toBe(dropdownId);
+
+				//FIXME find a solution to make those tests work again
+				// Angular now does not diplay the option of mat-select in the html file, which means that we have no solution to test those options
+
+				// expect(dropdownElement.html()).toContain("<md-option");
+				// const optionElements: IAugmentedJQuery = UnitTestingUtils.getElementsByTagName(element, "md-option");
+				// expect(optionElements.length).toBe(3);
+				//
+				// for (let index: number = 0; index < optionElements.length; index++) {
+				// 	const option: IAugmentedJQuery = angular.element(optionElements[index]);
+				// 	expect(option.attr("ng-value")).toBe("$ctrl.optionsAreSimpleTypes ? option : option[$ctrl.optionIdProperty]");
+				// 	expect(option.attr("value")).toBe(String(index + 1));
+				// 	expect(option.text().trim()).toBe(String(index + 1));
+				// }
+			});
+		});
+
+		describe("setDefaultBlank", () => {
+			it("should set 'defaultBlank' to false when it is not set or it is set to false", () => {
+				component.defaultBlank = false;
+				component.setDefaultBlank();
+				expect(component.defaultBlank).toBe(false);
+
+				component.defaultBlank = <any>undefined;
+				component.setDefaultBlank();
+				expect(component.defaultBlank).toBe(false);
+			});
+
+			it("should set 'defaultBlank' to false when 'required' is true", () => {
+				component.defaultBlank = <any>undefined;
+				component.required = true;
+				component.setDefaultBlank();
+				expect(component.defaultBlank).toBe(false);
+			});
+		});
+
+		// describe("multiSelect", () => {
+		// 	const checkboxSelector: string = ".mat-select-panel mat-option mat-pseudo-checkbox";
+		//
+		// 	it("should display a checkbox for every option in the dropdown when multiSelect is set to 'true'", () => {
+		// 		hostComponent.multiSelect = "true";
+		// 		hostFixture.detectChanges();
+
+				// const dropdownElement: HTMLElement = getMatSelectNativeElement();
+				// const dropdownElement: HTMLElement = hostFixture.nativeElement.querySelector(matSelectSelector);
+				// dropdownElement.click();
+				// hostFixture.detectChanges();
+				// console.log(dropdownElement);
+				// (<HTMLElement>hostFixture.nativeElement.querySelector(matSelectSelector)).click();
+				// (<HTMLElement>hostFixture.nativeElement.querySelector("mat-select")).click();
+
+				// console.log(hostFixture.nativeElement);
+				// const optionCheckboxElements: DebugElement[] = hostFixture.nativeElement.querySelectorAll(checkboxSelector);
+				// expect(optionCheckboxElements.length).toBe(3);
+				//
+				// hostFixture.whenStable().then(() => {
+				// 	console.log(hostFixture.nativeElement);
+				// 	const optionCheckboxElements: DebugElement[] = hostFixture.nativeElement.querySelectorAll(checkboxSelector);
+				// 	expect(optionCheckboxElements.length).toBe(3);
+				// 	// done();
+				// });
+			// });
+
+		// 	it("should display a checkbox for every option in the dropdown when multiSelect has no value defined", (done: DoneFn) => {
+		// 		hostComponent.multiSelect = undefined;
+		// 		hostFixture.detectChanges();
+		//
+		// 		// const dropdownElement: HTMLElement = getMatSelectNativeElement();
+		// 		// dropdownElement.click();
+		// 		(<HTMLElement>hostFixture.nativeElement.querySelector(matSelectSelector)).click();
+		// 		// (<HTMLElement>hostFixture.nativeElement.querySelector(matSelectSelector)).click();
+		//
+		// 		hostFixture.whenStable().then(() => {
+		// 			const optionCheckboxElements: DebugElement[] = hostFixture.nativeElement.querySelectorAll(checkboxSelector);
+		// 			console.log(optionCheckboxElements);
+		// 			expect(optionCheckboxElements.length).toBe(component.options.length);
+		// 			done();
+		// 		});
+		// 	});
+		//
+		// 	it("should NOT render the checkboxes if multiSelect is to any value other than 'true'", (done: DoneFn) => {
+		// 		hostComponent.multiSelect = "whatever";
+		// 		hostFixture.detectChanges();
+		//
+		// 		// const dropdownElement: HTMLElement = getMatSelectNativeElement();
+		// 		// dropdownElement.click();
+		// 		(<HTMLElement>hostFixture.nativeElement.querySelector(matSelectSelector)).click();
+		// 		// (<HTMLElement>hostFixture.nativeElement.querySelector("mat-select")).click();
+		//
+		// 		hostFixture.whenStable().then(() => {
+		// 			const optionCheckboxElements: DebugElement[] = hostFixture.nativeElement.querySelectorAll(checkboxSelector);
+		// 			expect(optionCheckboxElements.length).toBe(0);
+		// 			done();
+		// 		});
+		// 	});
+		// });
 	});
 
 	// FIXME Reenable this test
@@ -171,28 +429,6 @@ describe("DropdownComponent", () => {
 	// 	});
 	// });
 
-	//TODO reenable if label still needed
-	// describe("label", () => {
-	// 	it("should be displayed when label is defined", () => {
-	// 		const labelElement: DebugElement = hostFixture.debugElement.query(By.css("label"));
-	// 		expect(labelElement).not.toBeNull();
-	// 	});
-	//
-	// 	it("should be hidden when label is undefined", () => {
-	// 		hostComponent.label = undefined;
-	// 		hostFixture.detectChanges();
-	// 		const labelElement: DebugElement = hostFixture.debugElement.query(By.css("label"));
-	// 		expect(labelElement).toBeNull();
-	// 	});
-	//
-	// 	it("should be hidden when label is an empty string", () => {
-	// 		hostComponent.label = "";
-	// 		hostFixture.detectChanges();
-	// 		const labelElement: DebugElement = hostFixture.debugElement.query(By.css("label"));
-	// 		expect(labelElement).toBeNull();
-	// 	});
-	// });
-
 	//FIXME reenable those tests as soon as a solution to replace the md-select-header as been found: https://github.com/angular/material2/pull/7835
 	//
 	// describe("header", () => {
@@ -214,83 +450,4 @@ describe("DropdownComponent", () => {
 	// });
 
 	// FIXME reenable and adapt those tests once the solution for the option has been found
-	// describe("multiple-select", () => {
-	// 	const checkboxSelector: string = ".mat-container > .mat-icon";
-	//
-	// 	it("should display a checkbox for every option in the dropdown when multiple-select is set to 'true'", () => {
-	// 		hostComponent.dropdownComponent.multipleSelect = "true";
-	// 		// simulating the scope life cycle (so the watchers and bindings are executed)
-	// 		hostFixture.detectChanges();
-	//
-	//
-	// 		const optionElements: DebugElement[] = hostFixture.debugElement.queryAll(hostFixture.debugElement[0]);
-	//
-	// 		expect(optionElements.length).toBe(3);
-	// 	});
-
-	// it("should display a checkbox for every option in the dropdown when multiple-select has no value defined", () => {
-	// 	// $scope.multipleSelect = undefined;
-	//
-	// 	element = $compile("<stark-dropdown " +
-	// 		"options='options' " +
-	// 		"option-id-property='{{ optionIdProperty }}' " +
-	// 		"option-label-property='{{ optionLabelProperty }}' " +
-	// 		"label='{{ label }}' " +
-	// 		"header='{{ header }}' " +
-	// 		"placeholder='{{ placeholder }}' " +
-	// 		"value='value' " +
-	// 		"on-value-change='onValueChange()' " +
-	// 		"dropdown-id='{{ dropdownId }}' " +
-	// 		"dropdown-name='{{ dropdownName }}' " +
-	// 		"multiple-select" +
-	// 		"></stark-dropdown>")($scope);
-	// 	// simulating the scope life cycle (so the watchers and bindings are executed)
-	// 	hostFixture.detectChanges();
-	//
-	// 	const optionElements: NodeListOf<Element> = StarkDOMUtil.getElementsBySelector(element[0], "md-option > " + checkboxSelector);
-	// 	expect(optionElements.length).toBe($scope.options.length);
-	// });
-
-	// it("should NOT render the checkboxes if multiple-select is to any value other than 'true'", () => {
-	// 	hostComponent.multipleSelect = "whatever";
-	//
-	// 	element = $compile("<stark-dropdown " +
-	// 		"options='options' " +
-	// 		"option-id-property='{{ optionIdProperty }}' " +
-	// 		"option-label-property='{{ optionLabelProperty }}' " +
-	// 		"label='{{ label }}' " +
-	// 		"header='{{ header }}' " +
-	// 		"placeholder='{{ placeholder }}' " +
-	// 		"value='value' " +
-	// 		"on-value-change='onValueChange()' " +
-	// 		"dropdown-id='{{ dropdownId }}' " +
-	// 		"dropdown-name='{{ dropdownName }}' " +
-	// 		"multiple-select='{{ multipleSelect }}'" +
-	// 		"></stark-dropdown>")($scope);
-	// 	// simulating the scope life cycle (so the watchers and bindings are executed)
-	// 	$scope.$digest();
-	//
-	// 	const optionElements: NodeListOf<Element> = StarkDOMUtil.getElementsBySelector(element[0], "md-option > " + checkboxSelector);
-	// 	expect(optionElements.length).toBe(0);
-	// });
-	// });
-
-	describe("setDefaultBlank", () => {
-		it("should set 'defaultBlank' to false when it is not set or it is set to false", () => {
-			component.defaultBlank = false;
-			component.setDefaultBlank();
-			expect(component.defaultBlank).toBe(false);
-
-			component.defaultBlank = <any>undefined;
-			component.setDefaultBlank();
-			expect(component.defaultBlank).toBe(false);
-		});
-
-		it("should set 'defaultBlank' to false when 'required' is true", () => {
-			component.defaultBlank = <any>undefined;
-			component.required = true;
-			component.setDefaultBlank();
-			expect(component.defaultBlank).toBe(false);
-		});
-	});
 });

--- a/packages/stark-ui/src/modules/dropdown/dropdown.module.ts
+++ b/packages/stark-ui/src/modules/dropdown/dropdown.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { FormsModule } from "@angular/forms";
+import { ReactiveFormsModule } from "@angular/forms";
 import { MatOptionModule } from "@angular/material/core";
 import { MatSelectModule } from "@angular/material/select";
 import { TranslateModule } from "@ngx-translate/core";
@@ -8,7 +8,7 @@ import { StarkDropdownComponent } from "./components";
 
 @NgModule({
 	declarations: [StarkDropdownComponent],
-	imports: [CommonModule, TranslateModule, FormsModule, MatSelectModule, MatOptionModule],
+	imports: [CommonModule, TranslateModule, MatSelectModule, MatOptionModule, ReactiveFormsModule],
 	exports: [StarkDropdownComponent]
 })
 export class StarkDropdownModule {}

--- a/packages/stark-ui/src/modules/language-selector/components/language-selector.component.html
+++ b/packages/stark-ui/src/modules/language-selector/components/language-selector.component.html
@@ -7,7 +7,7 @@
 		placeholder=""
 		optionIdProperty="code"
 		optionLabelProperty="translationKey"
-		(dropdownSelectionChanged)="changeLanguage($event)"
+		(selectionChanged)="changeLanguage($event)"
 	>
 	</stark-dropdown>
 </div>

--- a/packages/stark-ui/src/modules/pagination/components/pagination.component.html
+++ b/packages/stark-ui/src/modules/pagination/components/pagination.component.html
@@ -48,7 +48,7 @@
 			[options]="paginationConfig.itemsPerPageOptions"
 			[value]="paginationConfig.itemsPerPage"
 			placeholder=""
-			(dropdownSelectionChanged)="onChangeItemsPerPage($event)"
+			(selectionChanged)="onChangeItemsPerPage($event)"
 			dropdownId="items-per-page-{{ htmlSuffixId }}"
 			dropdownName="items-per-page-{{ htmlSuffixId }}"
 		></stark-dropdown>

--- a/packages/stark-ui/src/modules/pagination/components/pagination.component.spec.ts
+++ b/packages/stark-ui/src/modules/pagination/components/pagination.component.spec.ts
@@ -650,16 +650,21 @@ describe("PaginationComponent", () => {
 			expect(component.paginationConfig.page).toBe(1);
 		});
 
-		it("should call setPageNumbers 1 time", () => {
-			spyOn(component, "setPageNumbers");
+		it("should change itempsPerPage to 8", () => {
 			component.onChangeItemsPerPage((<number[]>component.paginationConfig.itemsPerPageOptions)[1]);
-			expect(component.setPageNumbers).toHaveBeenCalledTimes(1);
+			expect(component.paginationConfig.itemsPerPage).toBe(8);
 		});
 
 		it("should call onChangePagination 1 time", () => {
 			spyOn(component, "onChangePagination");
 			component.onChangeItemsPerPage((<number[]>component.paginationConfig.itemsPerPageOptions)[1]);
 			expect(component.onChangePagination).toHaveBeenCalledTimes(1);
+		});
+
+		it("should NOT call onChangePagination if current 'itemsPerPage' value is the same than the new one", () => {
+			spyOn(component, "onChangePagination");
+			component.onChangeItemsPerPage((<number[]>paginationConfig.itemsPerPageOptions)[0]);
+			expect(component.paginationConfig.page).toBe(paginationConfig.page);
 		});
 	});
 

--- a/packages/stark-ui/src/modules/pagination/components/pagination.component.ts
+++ b/packages/stark-ui/src/modules/pagination/components/pagination.component.ts
@@ -310,9 +310,11 @@ export class StarkPaginationComponent extends MatPaginator implements OnInit, On
 	 * Set page to first then call onChangePagination function.
 	 */
 	public onChangeItemsPerPage(itemsPerPage: number): void {
-		this.paginationConfig.page = 1;
-		this.paginationConfig.itemsPerPage = itemsPerPage;
-		this.onChangePagination();
+		if (this.paginationConfig.itemsPerPage !== itemsPerPage) {
+			this.paginationConfig.page = 1;
+			this.paginationConfig.itemsPerPage = itemsPerPage;
+			this.onChangePagination();
+		}
 	}
 
 	/**

--- a/packages/stark-ui/src/util.ts
+++ b/packages/stark-ui/src/util.ts
@@ -1,2 +1,3 @@
 export * from "./util/component";
 export * from "./util/dom";
+export * from "./util/form";

--- a/packages/stark-ui/src/util/form.ts
+++ b/packages/stark-ui/src/util/form.ts
@@ -1,0 +1,1 @@
+export * from "./form/form.util";

--- a/packages/stark-ui/src/util/form/form.util.spec.ts
+++ b/packages/stark-ui/src/util/form/form.util.spec.ts
@@ -1,10 +1,10 @@
+/* tslint:disable:completed-docs no-identical-functions */
 import { StarkFormControlState, StarkFormUtil } from "./form.util";
-import { FormControl, FormGroup /*, Validators*/ } from "@angular/forms";
-
-// import Spy = jasmine.Spy;
+import { FormControl, FormGroup } from "@angular/forms";
 
 const _startCase: Function = require("lodash/startCase");
 
+/* tslint:disable:no-big-function */
 describe("Util: FormUtil", () => {
 	const formItemStates: string[] = ["untouched", "touched", "pristine", "dirty"];
 
@@ -12,14 +12,14 @@ describe("Util: FormUtil", () => {
 	let mockFormControls: FormControl[];
 
 	function getMockFormControl(name: string): FormControl {
-		return jasmine.createSpyObj<FormControl>(name, [
+		return <FormControl>(<unknown>jasmine.createSpyObj<FormControl>(name, [
 			"value",
 			"setValue",
 			"markAsUntouched",
 			"markAsTouched",
 			"markAsPristine",
 			"markAsDirty"
-		]);
+		]));
 	}
 
 	function assertFormControl(formItem: FormControl, newState?: string): void {
@@ -178,13 +178,13 @@ describe("Util: FormUtil", () => {
 	});
 
 	describe("isFormGroup", () => {
-		it("should return TRUE if the form is an instance of an IFormController", () => {
+		it("should return TRUE if the form is an instance of an FormGroup", () => {
 			const result: boolean = StarkFormUtil.isFormGroup(mockFormGroup);
 
 			expect(result).toBe(true);
 		});
 
-		it("should return FALSE if the form is NOT an instance of an IFormController", () => {
+		it("should return FALSE if the form is NOT an instance of an FormGroup", () => {
 			const result: boolean = StarkFormUtil.isFormGroup("this is not a form");
 
 			expect(result).toBe(false);

--- a/packages/stark-ui/src/util/form/form.util.spec.ts
+++ b/packages/stark-ui/src/util/form/form.util.spec.ts
@@ -1,0 +1,209 @@
+import { StarkFormControlState, StarkFormUtil } from "./form.util";
+import { FormControl, FormGroup /*, Validators*/ } from "@angular/forms";
+
+// import Spy = jasmine.Spy;
+
+const _startCase: Function = require("lodash/startCase");
+
+describe("Util: FormUtil", () => {
+	const formItemStates: string[] = ["untouched", "touched", "pristine", "dirty"];
+
+	let mockFormGroup: FormGroup;
+	let mockFormControls: FormControl[];
+
+	function getMockFormControl(name: string): FormControl {
+		return jasmine.createSpyObj<FormControl>(name, [
+			"value",
+			"setValue",
+			"markAsUntouched",
+			"markAsTouched",
+			"markAsPristine",
+			"markAsDirty"
+		]);
+	}
+
+	function assertFormControl(formItem: FormControl, newState?: string): void {
+		if (newState) {
+			const newStateSetter: string = "markAs" + _startCase(newState);
+			expect(formItem[newStateSetter]).toHaveBeenCalledTimes(1);
+		}
+
+		// check that the setters for other states where not called
+		const nonUsedStates: string[] = formItemStates.filter((state: string) => state !== newState);
+		for (const nonUsedState of nonUsedStates) {
+			const nonUsedStateSetter: string = "markAs" + _startCase(nonUsedState);
+			expect(formItem[nonUsedStateSetter]).not.toHaveBeenCalled();
+		}
+	}
+
+	beforeEach(() => {
+		mockFormControls = [getMockFormControl("item1"), getMockFormControl("item2")];
+
+		mockFormGroup = <any>{
+			controls: {
+				formControl0: mockFormControls[0],
+				formControl1: mockFormControls[1]
+			}
+		};
+	});
+
+	describe("setFormChildControlsState", () => {
+		it("should call markAsTouched() on every form control if state to be set is 'touched'", () => {
+			const stateToBeSet: StarkFormControlState = "touched";
+
+			StarkFormUtil.setFormChildControlsState(mockFormGroup, [stateToBeSet]);
+
+			for (const formControl of mockFormControls) {
+				assertFormControl(formControl, stateToBeSet);
+			}
+		});
+
+		it("should call markAsUntouched() on every form control if state to be set is 'untouched'", () => {
+			const stateToBeSet: StarkFormControlState = "untouched";
+
+			StarkFormUtil.setFormChildControlsState(mockFormGroup, [stateToBeSet]);
+
+			for (const formControl of mockFormControls) {
+				assertFormControl(formControl, stateToBeSet);
+			}
+		});
+
+		it("should call markAsPristine() on every form control if state to be set is 'pristine'", () => {
+			const stateToBeSet: StarkFormControlState = "pristine";
+
+			StarkFormUtil.setFormChildControlsState(mockFormGroup, [stateToBeSet]);
+
+			for (const formControl of mockFormControls) {
+				assertFormControl(formControl, stateToBeSet);
+			}
+		});
+
+		it("should call markAsDirty() on every form control if state to be set is 'dirty'", () => {
+			const stateToBeSet: StarkFormControlState = "dirty";
+
+			StarkFormUtil.setFormChildControlsState(mockFormGroup, [stateToBeSet]);
+
+			for (const formControl of mockFormControls) {
+				assertFormControl(formControl, stateToBeSet);
+			}
+		});
+
+		it("should NOT call any method on any form control if state to be set is unknown", () => {
+			const stateToBeSet: any = "unknown state";
+
+			StarkFormUtil.setFormChildControlsState(mockFormGroup, [stateToBeSet]);
+
+			for (const formControl of mockFormControls) {
+				assertFormControl(formControl);
+			}
+		});
+	});
+
+	describe("setFormControlState", () => {
+		let formItem: FormControl;
+
+		beforeEach(() => {
+			formItem = getMockFormControl("dummy item");
+		});
+
+		it("should call markAsTouched() on the given form item if state to be set is 'touched'", () => {
+			const stateToBeSet: StarkFormControlState = "touched";
+
+			StarkFormUtil.setFormControlState(formItem, [stateToBeSet]);
+
+			assertFormControl(formItem, stateToBeSet);
+		});
+
+		it("should call markAsUntouched() on the given form item if state to be set is 'untouched'", () => {
+			const stateToBeSet: StarkFormControlState = "untouched";
+
+			StarkFormUtil.setFormControlState(formItem, [stateToBeSet]);
+
+			assertFormControl(formItem, stateToBeSet);
+		});
+
+		it("should call markAsPristine() on the given form item if state to be set is 'pristine'", () => {
+			const stateToBeSet: StarkFormControlState = "pristine";
+
+			StarkFormUtil.setFormControlState(formItem, [stateToBeSet]);
+
+			assertFormControl(formItem, stateToBeSet);
+		});
+
+		it("should call markAsDirty() on the given form item if state to be set is 'dirty'", () => {
+			const stateToBeSet: StarkFormControlState = "dirty";
+
+			StarkFormUtil.setFormControlState(formItem, [stateToBeSet]);
+
+			assertFormControl(formItem, stateToBeSet);
+		});
+
+		it("should NOT call any method on the given form item if state to be set is unknown", () => {
+			const stateToBeSet: any = "unknown state";
+
+			StarkFormUtil.setFormControlState(formItem, [stateToBeSet]);
+
+			assertFormControl(formItem);
+		});
+	});
+
+	describe("isFormGroupValid", () => {
+		it("should set form state to 'pristine' and return TRUE if the form is valid", () => {
+			spyOn(StarkFormUtil, "setFormChildControlsState");
+
+			const result: boolean = StarkFormUtil.isFormGroupValid(mockFormGroup);
+
+			expect(result).toBe(true);
+			expect(StarkFormUtil.setFormChildControlsState).toHaveBeenCalledTimes(1);
+			expect(StarkFormUtil.setFormChildControlsState).toHaveBeenCalledWith(mockFormGroup, ["pristine"]);
+		});
+
+		it("should set form state to 'touched' and return FALSE if the form is NOT valid", () => {
+			mockFormGroup = <any>{
+				controls: {
+					formControl0: mockFormControls[0],
+					formControl1: mockFormControls[1]
+				},
+				invalid: true
+			};
+
+			spyOn(StarkFormUtil, "setFormChildControlsState");
+
+			const result: boolean = StarkFormUtil.isFormGroupValid(mockFormGroup);
+
+			expect(result).toBe(false);
+			expect(StarkFormUtil.setFormChildControlsState).toHaveBeenCalledTimes(1);
+			expect(StarkFormUtil.setFormChildControlsState).toHaveBeenCalledWith(mockFormGroup, ["touched"]);
+		});
+	});
+
+	describe("isFormGroup", () => {
+		it("should return TRUE if the form is an instance of an IFormController", () => {
+			const result: boolean = StarkFormUtil.isFormGroup(mockFormGroup);
+
+			expect(result).toBe(true);
+		});
+
+		it("should return FALSE if the form is NOT an instance of an IFormController", () => {
+			const result: boolean = StarkFormUtil.isFormGroup("this is not a form");
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe("isFormControl", () => {
+		it("should return TRUE if the form item is an instance of an FormControl", () => {
+			const mockFormItem: FormControl = getMockFormControl("dummy item");
+
+			const result: boolean = StarkFormUtil.isFormControl(mockFormItem);
+
+			expect(result).toBe(true);
+		});
+
+		it("should return FALSE if the form item is NOT an instance of an FormControl", () => {
+			const result: boolean = StarkFormUtil.isFormControl("this is not a form item");
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/packages/stark-ui/src/util/form/form.util.ts
+++ b/packages/stark-ui/src/util/form/form.util.ts
@@ -1,0 +1,122 @@
+import { AbstractControl, FormControl, FormGroup } from "@angular/forms";
+
+export type StarkFormControlState = "untouched" | "touched" | "pristine" | "dirty";
+export type StarkFormState = "untouched" | "pristine" | "submitted" | "dirty";
+
+export class StarkFormUtil {
+	/**
+	 * Set all the fields of the form group to the given state(s)
+	 * @param formGroup - Angular form group object
+	 * @param statesToBeSet - States to be set to the different controls in the form
+	 */
+	public static setFormChildControlsState(formGroup: FormGroup, statesToBeSet: StarkFormControlState[]): void {
+		// Verifying it is indeed an Angular FormController
+		if (StarkFormUtil.isFormGroup(formGroup)) {
+			for (const key of Object.keys(formGroup.controls)) {
+				// filtering just the ngModel child objects of the form
+				const formControl: AbstractControl = formGroup.controls[key];
+				if (StarkFormUtil.isFormControl(formControl)) {
+					this.setFormControlState(formControl, statesToBeSet);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Set the specified form control to the given state(s)
+	 * @param formControl - Angular form control object contained in an Angular form group
+	 * @param statesToBeSet - States to be set to the form control
+	 */
+	public static setFormControlState(formControl: FormControl, statesToBeSet: StarkFormControlState[]): void {
+		for (const formControlState of statesToBeSet) {
+			switch (formControlState) {
+				case "untouched":
+					// control has not lost focus yet
+					formControl.markAsUntouched();
+					break;
+				case "touched":
+					// control has lost focus.
+					formControl.markAsTouched();
+					break;
+				case "pristine":
+					// user has not interacted with the form yet.
+					formControl.markAsPristine();
+					break;
+				case "dirty":
+					// user has already interacted with the form
+					formControl.markAsDirty();
+					break;
+				default:
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Set the form to the given state(s). Possible states: "untouched", "pristine", "dirty", "submitted"
+	 * @param formGroup - Angular form group object
+	 * @param statesToBeSet - States to be set to the form
+	 */
+	public static setFormGroupState(formGroup: FormGroup, statesToBeSet: StarkFormState[]): void {
+		// Verifying it is indeed an Angular FormController
+		if (StarkFormUtil.isFormGroup(formGroup)) {
+			for (const formControlState of statesToBeSet) {
+				switch (formControlState) {
+					case "untouched":
+						// control has not lost focus yet
+						formGroup.markAsUntouched();
+						break;
+					case "pristine":
+						// user has not interacted with the form yet.
+						formGroup.markAsPristine();
+						break;
+					case "dirty":
+						// user has already interacted with the form
+						formGroup.markAsDirty();
+						break;
+					case "submitted":
+						// user has already interacted with the form
+						// FIXME Find alternative to $setSubmitted with ReactiveForm if needed
+						// formGroup.$setSubmitted();
+						break;
+					default:
+						break;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Check whether the form group is valid (all fields are valid).
+	 * If valid, all the form fields will be set to their "pristine" state, otherwise to their "touched" state
+	 * (calling setFormControlState function).
+	 * @param formGroup - Angular form group object
+	 */
+	public static isFormGroupValid(formGroup: FormGroup): boolean {
+		if (formGroup.invalid) {
+			StarkFormUtil.setFormChildControlsState(formGroup, ["touched"]);
+			return false;
+		} else {
+			StarkFormUtil.setFormChildControlsState(formGroup, ["pristine"]);
+			return true;
+		}
+	}
+
+	// type guard
+	/**
+	 * Check that the given form is an actual instance of an Angular form.
+	 * @param formGroup - Angular form object
+	 */
+	public static isFormGroup(formGroup: any): formGroup is FormGroup {
+		return typeof formGroup !== "undefined" && formGroup.hasOwnProperty("controls");
+	}
+
+	// type guard
+	/**
+	 * Check that the given form field object is an actual instance of an Angular form field.
+	 * @param formControl - Angular form field object
+	 */
+	public static isFormControl(formControl: any): formControl is FormControl {
+		return typeof formControl === "object" && typeof formControl["setValue"] !== "undefined";
+	}
+}

--- a/packages/stark-ui/src/util/form/form.util.ts
+++ b/packages/stark-ui/src/util/form/form.util.ts
@@ -10,10 +10,10 @@ export class StarkFormUtil {
 	 * @param statesToBeSet - States to be set to the different controls in the form
 	 */
 	public static setFormChildControlsState(formGroup: FormGroup, statesToBeSet: StarkFormControlState[]): void {
-		// Verifying it is indeed an Angular FormController
+		// Verifying it is indeed an Angular FormGroup
 		if (StarkFormUtil.isFormGroup(formGroup)) {
 			for (const key of Object.keys(formGroup.controls)) {
-				// filtering just the ngModel child objects of the form
+				// filtering just the FormControl objects of the form
 				const formControl: AbstractControl = formGroup.controls[key];
 				if (StarkFormUtil.isFormControl(formControl)) {
 					this.setFormControlState(formControl, statesToBeSet);
@@ -58,7 +58,7 @@ export class StarkFormUtil {
 	 * @param statesToBeSet - States to be set to the form
 	 */
 	public static setFormGroupState(formGroup: FormGroup, statesToBeSet: StarkFormState[]): void {
-		// Verifying it is indeed an Angular FormController
+		// Verifying it is indeed an Angular FormGroup
 		if (StarkFormUtil.isFormGroup(formGroup)) {
 			for (const formControlState of statesToBeSet) {
 				switch (formControlState) {

--- a/showcase/src/app/demo-ui/pages/dropdown/demo-dropdown-page.component.html
+++ b/showcase/src/app/demo-ui/pages/dropdown/demo-dropdown-page.component.html
@@ -3,6 +3,32 @@
 	<h1 translate>SHOWCASE.DEMO.SHARED.EXAMPLE_VIEWER_LIST</h1>
 	<example-viewer
 		[extensions]="['HTML', 'TS']"
+		filesPath="dropdown/reactive-form-dropdown"
+		[exampleTitle]="'SHOWCASE.DEMO.DROPDOWN.REACTIVE_FORM' | translate"
+	>
+		<stark-dropdown
+			dropdownId="reactiveFormDropdown"
+			[options]="serviceDropdownOptions"
+			[dropdownFormControl]="serviceFormControl"
+			placeholder="SHOWCASE.DEMO.DROPDOWN.SELECT_SERVICE"
+			optionIdProperty="id"
+			optionLabelProperty="value"
+			required
+		>
+		</stark-dropdown>
+
+		<div *ngIf="selectedServiceFormControl">
+			{{ "SHOWCASE.DEMO.DROPDOWN.SELECTED_VALUE" | translate }}: {{ selectedServiceFormControl }}
+		</div>
+		<div>
+			<mat-checkbox (change)="toggleDisabledReactiveFormControl()" [(ngModel)]="isDisabledServiceFormControl">
+				isDisabled
+			</mat-checkbox>
+		</div>
+	</example-viewer>
+
+	<example-viewer
+		[extensions]="['HTML', 'TS']"
 		filesPath="dropdown/single-required-selection"
 		[exampleTitle]="'SHOWCASE.DEMO.DROPDOWN.REQUIRED' | translate"
 	>
@@ -13,7 +39,7 @@
 			placeholder="SHOWCASE.DEMO.DROPDOWN.SELECT_SERVICE"
 			optionIdProperty="id"
 			optionLabelProperty="value"
-			(dropdownSelectionChanged)="serviceDropdownOnChange($event)"
+			(selectionChanged)="serviceDropdownOnChange($event)"
 			required
 		>
 		</stark-dropdown>
@@ -31,7 +57,7 @@
 			[options]="[1, 2, 3, 4, 5, 6, 7]"
 			[value]="selectedNumber"
 			placeholder="SHOWCASE.DEMO.DROPDOWN.SELECT_NUMBER"
-			(dropdownSelectionChanged)="numberDropdownOnChange($event)"
+			(selectionChanged)="numberDropdownOnChange($event)"
 			[defaultBlank]="true"
 		>
 		</stark-dropdown>
@@ -50,7 +76,7 @@
 			optionIdProperty="id"
 			optionLabelProperty="value"
 			placeholder="SHOWCASE.DEMO.DROPDOWN.SELECT_SERVICES"
-			(dropdownSelectionChanged)="multipleServicesDropdownOnChange($event)"
+			(selectionChanged)="multipleServicesDropdownOnChange($event)"
 			multiSelect
 		>
 		</stark-dropdown>
@@ -69,7 +95,7 @@
 			optionIdProperty="id"
 			optionLabelProperty="value"
 			placeholder="SHOWCASE.DEMO.DROPDOWN.SELECT_ONE_SERVICE"
-			(dropdownSelectionChanged)="multipleServicesRequiredDropdownOnChange($event)"
+			(selectionChanged)="multipleServicesRequiredDropdownOnChange($event)"
 			multiSelect
 			required
 		>
@@ -109,7 +135,7 @@
 			placeholder="SHOWCASE.DEMO.DROPDOWN.SELECT_SERVICE"
 			optionIdProperty="id"
 			optionLabelProperty="value"
-			(dropdownSelectionChanged)="whiteDropdownOnChange($event)"
+			(selectionChanged)="whiteDropdownOnChange($event)"
 			required
 		>
 		</stark-dropdown>

--- a/showcase/src/app/demo-ui/pages/dropdown/demo-dropdown-page.component.ts
+++ b/showcase/src/app/demo-ui/pages/dropdown/demo-dropdown-page.component.ts
@@ -1,5 +1,7 @@
-import { Component, OnInit, ViewEncapsulation } from "@angular/core";
+import { Component, OnDestroy, OnInit, ViewEncapsulation } from "@angular/core";
 import { ReferenceLink } from "../../../shared/components";
+import { FormControl } from "@angular/forms";
+import { Subscription } from "rxjs";
 
 @Component({
 	selector: "demo-dropdown",
@@ -7,8 +9,12 @@ import { ReferenceLink } from "../../../shared/components";
 	templateUrl: "./demo-dropdown-page.component.html",
 	encapsulation: ViewEncapsulation.None //used here to be able to customize the example-viewer background color
 })
-export class DemoDropdownPageComponent implements OnInit {
+export class DemoDropdownPageComponent implements OnInit, OnDestroy {
+	public isDisabledServiceFormControl: boolean;
 	public selectedService: string;
+	public serviceFormControl: FormControl;
+	public serviceFormControlSubscription: Subscription;
+	public selectedServiceFormControl: string;
 	public selectedServiceWhiteDropdown: string;
 	public selectedServices: string[];
 	public selectedRequiredServices: string[];
@@ -34,6 +40,15 @@ export class DemoDropdownPageComponent implements OnInit {
 				url: "https://stark.nbb.be/api-docs/stark-ui/latest/components/StarkDropdownComponent.html"
 			}
 		];
+
+		this.serviceFormControl = new FormControl();
+		this.serviceFormControlSubscription = this.serviceFormControl.valueChanges.subscribe(
+			(value: any) => this.selectedServiceFormControl = value
+		);
+	}
+
+	public ngOnDestroy(): void {
+		this.serviceFormControlSubscription.unsubscribe();
 	}
 
 	public serviceDropdownOnChange(selectedValue: string): void {
@@ -54,5 +69,13 @@ export class DemoDropdownPageComponent implements OnInit {
 
 	public whiteDropdownOnChange(selectedValue: string): void {
 		this.selectedServiceWhiteDropdown = selectedValue;
+	}
+
+	public toggleDisabledReactiveFormControl(): void {
+		if (this.isDisabledServiceFormControl) {
+			this.serviceFormControl.disable();
+		} else {
+			this.serviceFormControl.enable();
+		}
 	}
 }

--- a/showcase/src/assets/examples/dropdown/multiple-required-selection.html
+++ b/showcase/src/assets/examples/dropdown/multiple-required-selection.html
@@ -5,7 +5,7 @@
 	optionIdProperty="id"
 	optionLabelProperty="value"
 	placeholder="Select at least one service"
-	(dropdownSelectionChanged)="multipleServicesRequiredDropdownOnChange($event)"
+	(selectionChanged)="multipleServicesRequiredDropdownOnChange($event)"
 	multiSelect
 	required
 >

--- a/showcase/src/assets/examples/dropdown/multiple-selection.html
+++ b/showcase/src/assets/examples/dropdown/multiple-selection.html
@@ -5,7 +5,7 @@
 	optionIdProperty="id"
 	optionLabelProperty="value"
 	placeholder="Select one or more services"
-	(dropdownSelectionChanged)="multipleServicesDropdownOnChange($event)"
+	(selectionChanged)="multipleServicesDropdownOnChange($event)"
 	multiSelect
 >
 </stark-dropdown>

--- a/showcase/src/assets/examples/dropdown/reactive-form-dropdown.html
+++ b/showcase/src/assets/examples/dropdown/reactive-form-dropdown.html
@@ -1,0 +1,8 @@
+<stark-dropdown
+	dropdownId="disabledDropdown"
+	[options]="[1, 2, 3, 4, 5, 6, 7]"
+	placeholder="Sorry, it's disabled"
+	[isDisabled]="true"
+	multiSelect
+>
+</stark-dropdown>

--- a/showcase/src/assets/examples/dropdown/reactive-form-dropdown.html
+++ b/showcase/src/assets/examples/dropdown/reactive-form-dropdown.html
@@ -1,8 +1,11 @@
 <stark-dropdown
-	dropdownId="disabledDropdown"
-	[options]="[1, 2, 3, 4, 5, 6, 7]"
-	placeholder="Sorry, it's disabled"
-	[isDisabled]="true"
-	multiSelect
+	dropdownId="reactiveFormDropdown"
+	[options]="serviceDropdownOptions"
+	[dropdownFormControl]="serviceFormControl"
+	placeholder="SHOWCASE.DEMO.DROPDOWN.SELECT_SERVICE"
+	optionIdProperty="id"
+	optionLabelProperty="value"
 >
 </stark-dropdown>
+<div *ngIf="selectedService">Selected value: {{ selectedService }}</div>
+<div><mat-checkbox (change)="toggleDisabling()" [(ngModel)]="isDisabled">isDisabled</mat-checkbox></div>

--- a/showcase/src/assets/examples/dropdown/reactive-form-dropdown.ts
+++ b/showcase/src/assets/examples/dropdown/reactive-form-dropdown.ts
@@ -1,0 +1,7 @@
+import { Component } from "@angular/core";
+
+@Component({
+	selector: "demo-dropdown",
+	templateUrl: "./demo-dropdown.component.html"
+})
+export class DemoDropdownComponent {}

--- a/showcase/src/assets/examples/dropdown/reactive-form-dropdown.ts
+++ b/showcase/src/assets/examples/dropdown/reactive-form-dropdown.ts
@@ -1,7 +1,37 @@
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
+import { FormControl } from "@angular/forms";
 
 @Component({
 	selector: "demo-dropdown",
 	templateUrl: "./demo-dropdown.component.html"
 })
-export class DemoDropdownComponent {}
+export class DemoDropdownComponent implements OnInit {
+	public isDisabled: boolean;
+
+	public selectedService: string;
+
+	public serviceDropdownOptions: any[];
+
+	public serviceFormControl: FormControl;
+	/**
+	 * Component lifecycle hook
+	 */
+	public ngOnInit(): void {
+		this.serviceDropdownOptions = [
+			{ id: "PR", value: "IT application" },
+			{ id: "IO", value: "Informatics infrastructure and operations" },
+			{ id: "CS", value: "IT customer services" }
+		];
+
+		this.serviceFormControl = new FormControl();
+		this.serviceFormControl.valueChanges.subscribe((value: any) => (this.selectedService = value));
+	}
+
+	public toggleDisabling(): void {
+		if (this.isDisabled) {
+			this.serviceFormControl.disable();
+		} else {
+			this.serviceFormControl.enable();
+		}
+	}
+}

--- a/showcase/src/assets/examples/dropdown/single-blank-selection.html
+++ b/showcase/src/assets/examples/dropdown/single-blank-selection.html
@@ -3,7 +3,7 @@
 	[options]="[1, 2, 3, 4, 5, 6, 7]"
 	[value]="selectedNumber"
 	placeholder="Select your lucky number"
-	(dropdownSelectionChanged)="numberDropdownOnChange($event)"
+	(selectionChanged)="numberDropdownOnChange($event)"
 	[defaultBlank]="true"
 >
 </stark-dropdown>

--- a/showcase/src/assets/examples/dropdown/single-required-selection.html
+++ b/showcase/src/assets/examples/dropdown/single-required-selection.html
@@ -5,7 +5,7 @@
 	placeholder="Select Service"
 	optionIdProperty="id"
 	optionLabelProperty="value"
-	(dropdownSelectionChanged)="serviceDropdownOnChange($event)"
+	(selectionChanged)="serviceDropdownOnChange($event)"
 	required
 >
 </stark-dropdown>

--- a/showcase/src/assets/examples/dropdown/white.html
+++ b/showcase/src/assets/examples/dropdown/white.html
@@ -7,7 +7,7 @@
 	placeholder="Select Service"
 	optionIdProperty="id"
 	optionLabelProperty="value"
-	(dropdownSelectionChanged)="whiteDropdownOnChange($event)"
+	(selectionChanged)="whiteDropdownOnChange($event)"
 	required
 >
 </stark-dropdown>

--- a/showcase/src/assets/translations/en.json
+++ b/showcase/src/assets/translations/en.json
@@ -93,6 +93,7 @@
         "IO": "Informatics infrastructure and operations",
         "MULTIPLE": "Multiple selection",
         "MULTIPLE_REQUIRED": "Required multiple selection",
+        "REACTIVE_FORM": "Reactive form",
         "REQUIRED": "Single required selection",
         "SELECTED_VALUE": "Selected value ",
         "SELECTED_VALUES": "Selected values ",

--- a/showcase/src/assets/translations/fr.json
+++ b/showcase/src/assets/translations/fr.json
@@ -93,6 +93,7 @@
         "IO": "Infrastructure et opérations informatiques",
         "MULTIPLE": "Choix multiple",
         "MULTIPLE_REQUIRED": "Choix multiple obligatoire",
+        "REACTIVE_FORM": "Reactive form",
         "REQUIRED": "Choix unique obligatoire",
         "SELECTED_VALUE": "Valeur sélectionnée ",
         "SELECTED_VALUES": "Valeurs sélectionnées ",

--- a/showcase/src/assets/translations/nl.json
+++ b/showcase/src/assets/translations/nl.json
@@ -93,6 +93,7 @@
         "IO": "Informatica-infrastructuur en operaties",
         "MULTIPLE": "Meerdere selectie",
         "MULTIPLE_REQUIRED": "Gewenste meerdere selectie",
+        "REACTIVE_FORM": "Reactive form",
         "REQUIRED": "Dropdown met gewenste keuze",
         "SELECTED_VALUE": "Geselecteerde waarde ",
         "SELECTED_VALUES": "Geselecteerde waarden ",


### PR DESCRIPTION
ISSUES CLOSED: #982 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The dropdown component has no support for Reactive form.

Issue Number: #982 

## What is the new behavior?

Dropdown component is based only on Reactive Form but still accepts `value` + `selectionChanged` tobe able to use it. The developer can define himself the formControl object by passing via the input `dropdownFormControl`.

Form utils have been added to Stark.

## Does this PR introduce a breaking change?
```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information