### PR TITLE
fix(stark-ui): fix circular dependencies due to wrong import in minimap

### DIFF
--- a/packages/stark-ui/src/modules/minimap/components/minimap.component.spec.ts
+++ b/packages/stark-ui/src/modules/minimap/components/minimap.component.spec.ts
@@ -12,7 +12,7 @@ import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing
 import { Component, EventEmitter, NO_ERRORS_SCHEMA, ViewChild } from "@angular/core";
 import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatTooltipModule } from "@angular/material/tooltip";
-import { ItemVisibility } from "@nationalbankbelgium/stark-ui";
+import { ItemVisibility } from "./item-visibility.intf";
 
 @Component({
 	selector: `host-component`,

--- a/packages/stark-ui/src/modules/minimap/components/minimap.component.ts
+++ b/packages/stark-ui/src/modules/minimap/components/minimap.component.ts
@@ -12,7 +12,10 @@ import {
 	Renderer2,
 	ViewEncapsulation
 } from "@angular/core";
-import { ItemVisibility, StarkDOMUtil, StarkMinimapItemProperties } from "@nationalbankbelgium/stark-ui";
+
+import { ItemVisibility } from "./item-visibility.intf";
+import { StarkMinimapItemProperties } from "./item-properties.intf";
+import { StarkDOMUtil } from "../../../util/dom";
 import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 export type StarkMinimapComponentMode = "compact";


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Warnings are present due to wrong imports in the minimap component.


## What is the new behavior?
Imports in minimap component have been fixed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information