### PR TITLE
fix(stark-ui): close sidebar after navigation. Keep sidebar scroll position

### DIFF
--- a/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.html
+++ b/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.html
@@ -10,6 +10,7 @@
 		(openedChange)="toggleClassesOnOpen($event)"
 		(openedStart)="setClassOnOpenStart()"
 		(closedStart)="setClassOnCloseStart()"
+		[autoFocus]="false"
 	>
 		<ng-container *ngIf="sidenavLeftType === 'regular'">
 			<ng-content class="regular" select="[stark-app-sidenav-left]"></ng-content>


### PR DESCRIPTION
feat(stark-ui): add option to close sidebar after navigation

  - Added property `closeOnNavigate` to `stark-app-sidebar`, when this is set to true the sidebar will automatically close after navigating on smaller devices.
  - Added tests for new feature

ISSUES CLOSED: #995

fix(stark-ui): keep scroll position after closing sidenav

  - set `autofocus` of `mat-sidenav` to `false`

ISSUES CLOSED: #750

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #995 & #750 


## What is the new behavior?
If `closeOnNavigate` is set to `true` (default) the sidebar will automatically close on smaller devices after navigation.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->