### PR TITLE
fix(build-main): adapt regex pattern to include 'resolved' in package-lock.json replacement

### DIFF
--- a/build-functions.sh
+++ b/build-functions.sh
@@ -416,6 +416,10 @@ adaptNpmPackageDependencies() {
   local PATTERN="\"\@nationalbankbelgium\/$PACKAGE\"\s*\:\s*\".*\""
   local REPLACEMENT="\\\"\@nationalbankbelgium\/$PACKAGE\\\": \\\"$TGZ_PATH\\\""
   
+  logTrace "PATTERN: $PATTERN"
+  logTrace "REPLACEMENT: $REPLACEMENT"
+  logTrace "Package JSON file: $PACKAGE_JSON_FILE"
+
   # Packages will have dependencies between them. They will so have "devDependencies" and "peerDependencies" with different values.
   # We should only replace the value of the devDependency for make it work.
 
@@ -459,8 +463,8 @@ logTrace "Executing function: ${FUNCNAME[0]}" 1
   logTrace "SHA-512: $SHA"
   logTrace "SHA-512 escaped: $ESCAPED_SHA"
   
-  local PATTERN="\\\"\@nationalbankbelgium\/$PACKAGE\\\": \\{(\s*)\\\"version\\\": \\\"(\S*)\\\",(\s*)\\\"integrity\\\": \\\"sha512-(.*)\\\","
-  local REPLACEMENT='"\@nationalbankbelgium\/'$PACKAGE'": {$1"version": "'$TGZ_PATH'",$3"integrity": "sha512-'$ESCAPED_SHA'",'
+  local PATTERN="\\\"\@nationalbankbelgium\/$PACKAGE\\\": \\{(\s*)\\\"version\\\": \\\"(\S*)\\\"(,(\s*)\\\"resolved\\\": \\\"(.*))?,(\s*)\\\"integrity\\\": \\\"sha512-(.*)\\\","
+  local REPLACEMENT='"\@nationalbankbelgium\/'$PACKAGE'": {$1"version": "'$TGZ_PATH'",$4"integrity": "sha512-'$ESCAPED_SHA'",'
   
   logTrace "PATTERN: $PATTERN"
   logTrace "REPLACEMENT: $REPLACEMENT"


### PR DESCRIPTION
ISSUES CLOSED: #1051 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The Travis build for the master branch is currently broken due to the following error during the installation of dependencies in the Starter:

Issue Number: #1051 

```
npm ERR! cipm can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
```

Which means that the `package-lock.json` has different versions than the `package.json`. This change might have been done in a previous commit.

## What is the new behavior?
The build script has been adapted to take "resolved" in the replacement pattern for the package-lock.json. The `npm ci` command should succeed on Travis.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->