### PR TITLE
fix(stark-core): adapt code to fix typings issue with Rxjs 6.4.0

### DIFF
--- a/packages/stark-core/src/modules/session/services/session.service.spec.ts
+++ b/packages/stark-core/src/modules/session/services/session.service.spec.ts
@@ -271,12 +271,12 @@ describe("Service: StarkSessionService", () => {
 			sessionService.registerTransitionHook();
 
 			expect((<Spy>mockRoutingService.addTransitionHook).calls.argsFor(0)[0]).toBe(StarkRoutingTransitionHook.ON_BEFORE);
-			const onBeforeHookCallback: Function = (<Spy>mockRoutingService.addTransitionHook).calls.argsFor(0)[2];
+			const onBeforeHookCallback: () => Promise<boolean> = (<Spy>mockRoutingService.addTransitionHook).calls.argsFor(0)[2];
 
 			sessionService.session$ = of(mockSession);
 
 			// trigger the onBefore hook callback
-			defer<boolean>(() => onBeforeHookCallback()).subscribe(
+			defer(() => onBeforeHookCallback()).subscribe(
 				(result: boolean) => {
 					expect(result).toBe(true);
 				},


### PR DESCRIPTION
ISSUES CLOSED: #1091

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the `session.service.spec.ts` file the following code produces a TS compilation error on the latest version of Rxjs (6.4.0) due to a [change in the typings of `defer`](https://github.com/reactivex/rxjs/commit/5aea50e):

```typescript
defer<boolean>(() => onBeforeHookCallback()).subscribe(
	(result: boolean) => {
		expect(result).toBe(true);
	},
	() => {
		fail("The 'error' function should not be called in case of success");
	}
);
```


## What is the new behavior?
The code has been adapted to make it work with the latest version (6.4.0) and also the previous ones (6.3.x).

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->