### PR TITLE
chore(stark-all): add @types/node and @angular/flex-layout to ignored libs in greenkeeper.json

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -13,5 +13,5 @@
       "packages": ["showcase/package.json", "starter/package.json"]
     }
   },
-  "ignore": ["class-validator", "typescript"]
+  "ignore": ["@angular/flex-layout", "@types/node", "class-validator", "typescript"]
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Greenkeeper creates PRs to upgrade some libraries that we cannot upgrade right away:
- `@types/node`: we use Node 8 for the moment instead of the latest versions
- `@angular/flex-layout`: latest versions depend on Typescript 3.2, but we are still on 3.1 (due to IntelliJ mainly)

## What is the new behavior?
`@types/node` and `@angular/flex-layout` are now ignored by Greenkeeper.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->