### PR TITLE
refactor(stark-all): improve typings in Mock classes to avoid duplicating method signatures while adding also the Spy typings for better dev experience

### DIFF
--- a/packages/stark-core/src/modules/http/repository/http-abstract-repository.spec.ts
+++ b/packages/stark-core/src/modules/http/repository/http-abstract-repository.spec.ts
@@ -13,17 +13,15 @@ import {
 import { StarkHttpService } from "../services/http.service.intf";
 import { MockStarkHttpService } from "../testing";
 import { MockStarkLoggingService } from "../../logging/testing";
-import { StarkLoggingService } from "../../logging/services";
 import { StarkHttpRequestBuilderImpl } from "../builder";
 import { StarkHttpSerializer, StarkHttpSerializerImpl } from "../serializer";
 import createSpyObj = jasmine.createSpyObj;
-import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;
 
 // tslint:disable-next-line:no-big-function
 describe("Repository: AbstractStarkHttpRepository", () => {
-	let mockStarkHttpService: StarkHttpService<MockResource>;
-	let mockLogger: StarkLoggingService;
+	let mockStarkHttpService: MockStarkHttpService<MockResource>;
+	let mockLogger: MockStarkLoggingService;
 	let mockBackend: SpyObj<StarkBackend>;
 	let mockResourcePath: string;
 	let mockResource: MockResource;
@@ -70,13 +68,13 @@ describe("Repository: AbstractStarkHttpRepository", () => {
 	describe("on create", () => {
 		it("should create a create request using the builder and send it to the starkHttpServiceName", () => {
 			const mockResponse: any = {};
-			(<Spy>mockStarkHttpService.executeSingleItemRequest).and.returnValue(mockResponse);
+			mockStarkHttpService.executeSingleItemRequest.and.returnValue(mockResponse);
 
 			const result: Observable<StarkSingleItemResponseWrapper<MockResource>> = repository.create(mockResource);
 
 			expect(mockStarkHttpService.executeSingleItemRequest).toHaveBeenCalled();
 			const starkHttpRequest: StarkHttpRequest = <StarkHttpRequest>(
-				(<Spy>mockStarkHttpService.executeSingleItemRequest).calls.mostRecent().args[0]
+				mockStarkHttpService.executeSingleItemRequest.calls.mostRecent().args[0]
 			);
 			expect(starkHttpRequest.requestType).toBe(StarkHttpRequestType.CREATE);
 			expect(starkHttpRequest.item).toBe(mockResource);
@@ -87,13 +85,13 @@ describe("Repository: AbstractStarkHttpRepository", () => {
 	describe("on update", () => {
 		it("should create an update request using the builder and send it to the starkHttpServiceName", () => {
 			const mockResponse: any = {};
-			(<Spy>mockStarkHttpService.executeSingleItemRequest).and.returnValue(mockResponse);
+			mockStarkHttpService.executeSingleItemRequest.and.returnValue(mockResponse);
 
 			const result: Observable<StarkSingleItemResponseWrapper<MockResource>> = repository.update(mockResource);
 
 			expect(mockStarkHttpService.executeSingleItemRequest).toHaveBeenCalled();
 			const starkHttpRequest: StarkHttpRequest = <StarkHttpRequest>(
-				(<Spy>mockStarkHttpService.executeSingleItemRequest).calls.mostRecent().args[0]
+				mockStarkHttpService.executeSingleItemRequest.calls.mostRecent().args[0]
 			);
 			expect(starkHttpRequest.requestType).toBe(StarkHttpRequestType.UPDATE);
 			expect(starkHttpRequest.item).toBe(mockResource);
@@ -104,13 +102,13 @@ describe("Repository: AbstractStarkHttpRepository", () => {
 	describe("on delete", () => {
 		it("should create a delete request using the builder and send it to the starkHttpServiceName", () => {
 			const mockResponse: any = {};
-			(<Spy>mockStarkHttpService.executeSingleItemRequest).and.returnValue(mockResponse);
+			mockStarkHttpService.executeSingleItemRequest.and.returnValue(mockResponse);
 
 			const result: Observable<StarkSingleItemResponseWrapper<MockResource>> = repository.delete(mockResource);
 
 			expect(mockStarkHttpService.executeSingleItemRequest).toHaveBeenCalled();
 			const starkHttpRequest: StarkHttpRequest = <StarkHttpRequest>(
-				(<Spy>mockStarkHttpService.executeSingleItemRequest).calls.mostRecent().args[0]
+				mockStarkHttpService.executeSingleItemRequest.calls.mostRecent().args[0]
 			);
 			expect(starkHttpRequest.requestType).toBe(StarkHttpRequestType.DELETE);
 			expect(starkHttpRequest.item).toBe(mockResource);
@@ -121,13 +119,13 @@ describe("Repository: AbstractStarkHttpRepository", () => {
 	describe("on get", () => {
 		it("should create a get request using the builder and send it to the starkHttpServiceName", () => {
 			const mockResponse: any = {};
-			(<Spy>mockStarkHttpService.executeSingleItemRequest).and.returnValue(mockResponse);
+			mockStarkHttpService.executeSingleItemRequest.and.returnValue(mockResponse);
 
 			const result: Observable<StarkSingleItemResponseWrapper<MockResource>> = repository.get(resourceUuid);
 
 			expect(mockStarkHttpService.executeSingleItemRequest).toHaveBeenCalled();
 			const starkHttpRequest: StarkHttpRequest = <StarkHttpRequest>(
-				(<Spy>mockStarkHttpService.executeSingleItemRequest).calls.mostRecent().args[0]
+				mockStarkHttpService.executeSingleItemRequest.calls.mostRecent().args[0]
 			);
 			expect(starkHttpRequest.requestType).toBe(StarkHttpRequestType.GET);
 			expect(starkHttpRequest.item).toBeUndefined();
@@ -138,13 +136,13 @@ describe("Repository: AbstractStarkHttpRepository", () => {
 	describe("on getCollection", () => {
 		it("should create a getCollection request using the builder and send it to the starkHttpServiceName", () => {
 			const mockResponse: any = {};
-			(<Spy>mockStarkHttpService.executeCollectionRequest).and.returnValue(mockResponse);
+			mockStarkHttpService.executeCollectionRequest.and.returnValue(mockResponse);
 
 			const result: Observable<StarkCollectionResponseWrapper<MockResource>> = repository.getCollection(10, 0);
 
 			expect(mockStarkHttpService.executeCollectionRequest).toHaveBeenCalled();
 			const starkHttpRequest: StarkHttpRequest = <StarkHttpRequest>(
-				(<Spy>mockStarkHttpService.executeCollectionRequest).calls.mostRecent().args[0]
+				mockStarkHttpService.executeCollectionRequest.calls.mostRecent().args[0]
 			);
 			expect(starkHttpRequest.requestType).toBe(StarkHttpRequestType.GET_COLLECTION);
 			expect(starkHttpRequest.item).toBeUndefined();
@@ -155,14 +153,14 @@ describe("Repository: AbstractStarkHttpRepository", () => {
 	describe("on search", () => {
 		it("should create a search request using the builder and send it to the starkHttpServiceName", () => {
 			const mockResponse: any = {};
-			(<Spy>mockStarkHttpService.executeCollectionRequest).and.returnValue(mockResponse);
+			mockStarkHttpService.executeCollectionRequest.and.returnValue(mockResponse);
 			const mockCriteria: { [key: string]: any } = { field1: "anything", field2: "whatever" };
 
 			const result: Observable<StarkCollectionResponseWrapper<MockResource>> = repository.search(mockCriteria, 10, 0);
 
 			expect(mockStarkHttpService.executeCollectionRequest).toHaveBeenCalled();
 			const starkHttpRequest: StarkHttpRequest = <StarkHttpRequest>(
-				(<Spy>mockStarkHttpService.executeCollectionRequest).calls.mostRecent().args[0]
+				mockStarkHttpService.executeCollectionRequest.calls.mostRecent().args[0]
 			);
 			expect(starkHttpRequest.requestType).toBe(StarkHttpRequestType.SEARCH);
 			expect(starkHttpRequest.item).toEqual(mockCriteria);
@@ -316,7 +314,7 @@ class AbstractHttpRepositoryTestHelper extends AbstractStarkHttpRepository<MockR
 
 	public constructor(
 		starkHttpService: StarkHttpService<MockResource>,
-		logger: StarkLoggingService,
+		logger: MockStarkLoggingService,
 		backend: StarkBackend,
 		path: string,
 		serializer?: StarkHttpSerializer<MockResource>

--- a/packages/stark-core/src/modules/http/services/http.service.spec.ts
+++ b/packages/stark-core/src/modules/http/services/http.service.spec.ts
@@ -32,16 +32,14 @@ import {
 
 import { StarkHttpHeaders, StarkSortOrder } from "../constants";
 import { StarkHttpStatusCodes } from "../enumerators";
-import { StarkLoggingService } from "../../logging/services";
-import { StarkSessionService } from "../../session/services";
 import { MockStarkLoggingService } from "../../logging/testing";
 import { MockStarkSessionService } from "../../session/testing";
 import { StarkHttpSerializer, StarkHttpSerializerImpl } from "../serializer";
 
 /* tslint:disable:no-big-function no-duplicate-string max-union-size */
 describe("Service: StarkHttpService", () => {
-	let loggerMock: StarkLoggingService;
-	let mockSessionService: StarkSessionService;
+	let loggerMock: MockStarkLoggingService;
+	let mockSessionService: MockStarkSessionService;
 	let mockDevAuthHeaders: Map<string, string>;
 	let httpMock: SpyObj<HttpClient>;
 	let starkHttpService: HttpServiceHelper<MockResource>;
@@ -55,7 +53,7 @@ describe("Service: StarkHttpService", () => {
 	interface StarkHttpServiceSpecVariables {
 		starkHttpService: HttpServiceHelper<MockResource>;
 		httpMock: SpyObj<HttpClient>;
-		loggerMock: StarkLoggingService;
+		loggerMock: MockStarkLoggingService;
 		httpRequest: StarkHttpRequest<MockResource>;
 	}
 
@@ -305,7 +303,7 @@ describe("Service: StarkHttpService", () => {
 			let request: StarkHttpRequest<MockResource>;
 			let httpResponse: Partial<HttpResponse<StarkResource | StarkHttpRawCollectionResponseData<MockResource>>>;
 			let httpClientMock: SpyObj<HttpClient>;
-			let loggingServiceMock: StarkLoggingService;
+			let loggingServiceMock: MockStarkLoggingService;
 			let httpService: HttpServiceHelper<MockResource>;
 			let expectedStatusCode: number = StarkHttpStatusCodes.HTTP_200_OK;
 
@@ -730,7 +728,7 @@ describe("Service: StarkHttpService", () => {
 			let request: StarkHttpRequest<MockResource>;
 			let httpClientMock: SpyObj<HttpClient>;
 			let httpMockMethod: Spy;
-			let loggingServiceMock: StarkLoggingService;
+			let loggingServiceMock: MockStarkLoggingService;
 			let httpService: HttpServiceHelper<MockResource>;
 			let resultObs: Observable<StarkCollectionResponseWrapper<MockResource>>;
 			const mockCustomMetadata: object = {
@@ -799,7 +797,7 @@ describe("Service: StarkHttpService", () => {
 							pagination: mockPaginationMetadata
 						});
 						expect(loggingServiceMock.warn).toHaveBeenCalledTimes(1);
-						expect((<Spy>loggingServiceMock.warn).calls.argsFor(0)[0]).toContain("no 'etags'");
+						expect(loggingServiceMock.warn.calls.argsFor(0)[0]).toContain("no 'etags'");
 					},
 					() => {
 						fail(errorShouldNotBeCalled);
@@ -844,7 +842,7 @@ describe("Service: StarkHttpService", () => {
 							});
 							assertResponseHeaders(result.starkHttpHeaders, httpHeaders);
 							expect(loggingServiceMock.warn).toHaveBeenCalledTimes(1);
-							expect((<Spy>loggingServiceMock.warn).calls.argsFor(0)[0]).toContain("no etag");
+							expect(loggingServiceMock.warn.calls.argsFor(0)[0]).toContain("no etag");
 						},
 						() => {
 							fail(errorShouldNotBeCalled);
@@ -889,7 +887,7 @@ describe("Service: StarkHttpService", () => {
 						});
 						assertResponseHeaders(result.starkHttpHeaders, httpHeaders);
 						expect(loggingServiceMock.warn).toHaveBeenCalledTimes(1);
-						expect((<Spy>loggingServiceMock.warn).calls.argsFor(0)[0]).toContain("no 'items'");
+						expect(loggingServiceMock.warn.calls.argsFor(0)[0]).toContain("no 'items'");
 					},
 					() => {
 						fail(errorShouldNotBeCalled);
@@ -943,7 +941,7 @@ describe("Service: StarkHttpService", () => {
 							});
 							assertResponseHeaders(result.starkHttpHeaders, httpHeaders);
 							expect(loggingServiceMock.warn).toHaveBeenCalledTimes(1);
-							expect((<Spy>loggingServiceMock.warn).calls.argsFor(0)[0]).toContain("it is not an object");
+							expect(loggingServiceMock.warn.calls.argsFor(0)[0]).toContain("it is not an object");
 						},
 						() => {
 							fail(errorShouldNotBeCalled);
@@ -993,7 +991,7 @@ describe("Service: StarkHttpService", () => {
 							});
 							assertResponseHeaders(result.starkHttpHeaders, httpHeaders);
 							expect(loggingServiceMock.warn).toHaveBeenCalledTimes(1);
-							expect((<Spy>loggingServiceMock.warn).calls.argsFor(0)[0]).toContain("no 'uuid' property found in item");
+							expect(loggingServiceMock.warn.calls.argsFor(0)[0]).toContain("no 'uuid' property found in item");
 						},
 						() => {
 							fail(errorShouldNotBeCalled);
@@ -1026,7 +1024,7 @@ describe("Service: StarkHttpService", () => {
 						expect(result.metadata).toBeUndefined();
 						assertResponseHeaders(result.starkHttpHeaders, httpHeaders);
 						expect(loggingServiceMock.warn).toHaveBeenCalledTimes(1);
-						expect((<Spy>loggingServiceMock.warn).calls.argsFor(0)[0]).toContain("no 'metadata'");
+						expect(loggingServiceMock.warn.calls.argsFor(0)[0]).toContain("no 'metadata'");
 					},
 					() => {
 						fail(errorShouldNotBeCalled);
@@ -1534,7 +1532,7 @@ function convertMapIntoObject(map: Map<string, any>): { [param: string]: any } {
 class HttpServiceHelper<P extends StarkResource> extends StarkHttpServiceImpl<P> {
 	public retryDelay: number;
 
-	public constructor(logger: StarkLoggingService, sessionService: StarkSessionService, httpClient: SpyObj<HttpClient>) {
+	public constructor(logger: MockStarkLoggingService, sessionService: MockStarkSessionService, httpClient: SpyObj<HttpClient>) {
 		super(logger, sessionService, <HttpClient>(<unknown>httpClient));
 	}
 

--- a/packages/stark-core/src/modules/http/testing/http.mock.ts
+++ b/packages/stark-core/src/modules/http/testing/http.mock.ts
@@ -1,48 +1,33 @@
-import {
-	StarkCollectionResponseWrapper,
-	StarkHttpRequest,
-	StarkHttpService,
-	StarkSingleItemResponseWrapper
-} from "@nationalbankbelgium/stark-core";
-import { HttpClient } from "@angular/common/http";
-import { Observable } from "rxjs";
+import { StarkHttpService, StarkResource } from "@nationalbankbelgium/stark-core";
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
+import createSpyObj = jasmine.createSpyObj;
 
 /**
  * Mock class of the StarkHttpService interface.
  * @link StarkHttpService
  */
-export class MockStarkHttpService implements StarkHttpService<any> {
+export class MockStarkHttpService<T extends StarkResource> implements SpyObj<StarkHttpService<T>> {
 	/**
 	 * Gets the core Angular HTTP API (HttpClient)
 	 * @returns Angular Http client
 	 */
-	public readonly rawHttpClient: HttpClient = jasmine.createSpyObj("rawHttpClient", [
-		"request",
-		"delete",
-		"get",
-		"head",
-		"jsonp",
-		"options",
-		"patch",
-		"post",
-		"put"
-	]);
+	public readonly rawHttpClient: SpyObj<StarkHttpService<T>["rawHttpClient"]> = createSpyObj<StarkHttpService<T>["rawHttpClient"]>(
+		"rawHttpClient",
+		["request", "delete", "get", "head", "jsonp", "options", "patch", "post", "put"]
+	);
 
 	/**
 	 * Executes requests to fetch a single resource
 	 * @param request - The HTTP request to be executed
 	 * @returns Observable that will emit the single item response wrapper
 	 */
-	public executeSingleItemRequest: (request: StarkHttpRequest) => Observable<StarkSingleItemResponseWrapper<any>> = jasmine.createSpy(
-		"executeSingleItemRequest"
-	);
+	public executeSingleItemRequest: SpyObj<StarkHttpService<T>>["executeSingleItemRequest"] = createSpy("executeSingleItemRequest");
 
 	/**
 	 * Executes requests to fetch an array of resources
 	 * @param request - The HTTP request to be executed
 	 * @returns Observable that will emit the collection response wrapper
 	 */
-	public executeCollectionRequest: (request: StarkHttpRequest) => Observable<StarkCollectionResponseWrapper<any>> = jasmine.createSpy(
-		"executeCollectionRequest"
-	);
+	public executeCollectionRequest: SpyObj<StarkHttpService<T>>["executeCollectionRequest"] = createSpy("executeCollectionRequest");
 }

--- a/packages/stark-core/src/modules/logging/services/logging.service.spec.ts
+++ b/packages/stark-core/src/modules/logging/services/logging.service.spec.ts
@@ -11,7 +11,6 @@ import { StarkLoggingServiceImpl } from "./logging.service";
 import { StarkApplicationConfig, StarkApplicationConfigImpl } from "../../../configuration/entities/application";
 import { StarkLogging, StarkLoggingImpl, StarkLogMessage, StarkLogMessageImpl, StarkLogMessageType } from "../../logging/entities";
 import { StarkBackend } from "../../http/entities/backend";
-import { StarkXSRFService } from "../../xsrf/services";
 import { StarkCoreApplicationState } from "../../../common/store";
 import { StarkError, StarkErrorImpl } from "../../../common/error";
 import { MockStarkXsrfService } from "../../xsrf/testing/xsrf.mock";
@@ -21,7 +20,7 @@ describe("Service: StarkLoggingService", () => {
 	let appConfig: StarkApplicationConfig;
 	let mockStore: SpyObj<Store<StarkCoreApplicationState>>;
 	let mockInjectorService: SpyObj<Injector>;
-	let mockXSRFService: StarkXSRFService;
+	let mockXSRFService: MockStarkXsrfService;
 	let loggingService: LoggingServiceHelper;
 	const loggingBackend: StarkBackend = {
 		name: "logging",
@@ -58,7 +57,7 @@ describe("Service: StarkLoggingService", () => {
 		};
 		mockStore.pipe.and.returnValue(of(mockStarkLogging));
 		/* tslint:disable-next-line:deprecation */
-		(<Spy>mockInjectorService.get).and.returnValue(mockXSRFService);
+		mockInjectorService.get.and.returnValue(mockXSRFService);
 		loggingService = new LoggingServiceHelper(mockStore, appConfig, mockInjectorService);
 		// reset the calls counter because there is a log in the constructor
 		mockStore.dispatch.calls.reset();

--- a/packages/stark-core/src/modules/logging/testing/logging.mock.ts
+++ b/packages/stark-core/src/modules/logging/testing/logging.mock.ts
@@ -1,35 +1,37 @@
 import { StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
 
 /**
  * Mock class of the StarkLoggingService interface.
  * @link StarkLoggingService
  */
-export class MockStarkLoggingService implements StarkLoggingService {
+export class MockStarkLoggingService implements SpyObj<StarkLoggingService> {
 	/**
 	 * Gets the current correlationId. In fact when the logging service is created, it gets a unique correlation Id.
 	 * This value can be used while displaying a generic error message.
 	 */
-	public correlationId: string;
-	public correlationIdHttpHeaderName: string;
+	public correlationId: StarkLoggingService["correlationId"];
+	public correlationIdHttpHeaderName: StarkLoggingService["correlationIdHttpHeaderName"];
 
 	/**
 	 * Logs debug messages to be used only in development to track issues.
 	 * The debug messages are only logged (and afterwards stored in the Redux store) only when the debugLoggingEnabled configuration setting from the StarkApplicationConfig is set to true.
 	 * @param args - the arguments to log
 	 */
-	public debug: () => void = jasmine.createSpy("debug");
+	public debug: SpyObj<StarkLoggingService>["debug"] = createSpy("debug");
 
 	/**
 	 * Logs information messages. These messages are also stored in the Redux store.
 	 * @param args - the arguments to log
 	 */
-	public info: () => void = jasmine.createSpy("info");
+	public info: SpyObj<StarkLoggingService>["info"] = createSpy("info");
 
 	/**
 	 * Logs warning messages. Warning messages can, for instance, indicate a non blocking problem in the software. These messages are also stored in the Redux store.
 	 * @param args - the arguments to log
 	 */
-	public warn: () => void = jasmine.createSpy("warn");
+	public warn: SpyObj<StarkLoggingService>["warn"] = createSpy("warn");
 
 	/**
 	 * Logs error messages. Error messages should be logged when there was an unexpected error while executing the code.
@@ -37,12 +39,12 @@ export class MockStarkLoggingService implements StarkLoggingService {
 	 * @param message - the message to log
 	 * @param error - the arguments to log
 	 */
-	public error: () => void = jasmine.createSpy("error");
+	public error: SpyObj<StarkLoggingService>["error"] = createSpy("error");
 
 	/**
 	 * Method to generate a new correlationId.
 	 */
-	public generateNewCorrelationId: () => string = jasmine.createSpy("generateNewCorrelationId");
+	public generateNewCorrelationId: SpyObj<StarkLoggingService>["generateNewCorrelationId"] = createSpy("generateNewCorrelationId");
 
 	public constructor(
 		correlationId: string = "dummyCorrelationId",

--- a/packages/stark-core/src/modules/routing/services/routing.service.spec.ts
+++ b/packages/stark-core/src/modules/routing/services/routing.service.spec.ts
@@ -8,7 +8,6 @@ import { catchError, switchMap, tap } from "rxjs/operators";
 import { throwError } from "rxjs";
 import { Store } from "@ngrx/store";
 import { StarkRoutingServiceImpl } from "./routing.service";
-import { StarkLoggingService } from "../../logging/services";
 import { StarkApplicationConfig, StarkApplicationConfigImpl } from "../../../configuration/entities/application";
 import { StarkStateConfigWithParams } from "./state-config-with-params.intf";
 import { StarkRoutingTransitionHook } from "./routing-transition-hook.constants";
@@ -16,7 +15,6 @@ import { StarkRoutingActionTypes } from "../actions";
 import { MockStarkLoggingService } from "../../logging/testing";
 import { StarkCoreApplicationState } from "../../../common/store";
 import { StarkErrorHandler } from "../../error-handling";
-import { StarkXSRFService } from "../../xsrf/services";
 import { MockStarkXsrfService } from "../../xsrf/testing/xsrf.mock";
 import CallInfo = jasmine.CallInfo;
 import Spy = jasmine.Spy;
@@ -32,10 +30,10 @@ describe("Service: StarkRoutingService", () => {
 	let $state: StateService;
 	let router: UIRouter;
 	let mockInjectorService: SpyObj<Injector>;
-	let mockXSRFService: StarkXSRFService;
+	let mockXSRFService: MockStarkXsrfService;
 	let errorHandler: StarkErrorHandler;
 	let routingService: StarkRoutingServiceImpl;
-	let mockLogger: StarkLoggingService;
+	let mockLogger: MockStarkLoggingService;
 	let appConfig: StarkApplicationConfig;
 	const mockStore: SpyObj<Store<StarkCoreApplicationState>> = jasmine.createSpyObj<Store<StarkCoreApplicationState>>("storeSpy", [
 		"dispatch"
@@ -360,7 +358,7 @@ describe("Service: StarkRoutingService", () => {
 		mockInjectorService = jasmine.createSpyObj<Injector>("injector,", ["get"]);
 		mockXSRFService = new MockStarkXsrfService();
 		/* tslint:disable-next-line:deprecation */
-		(<Spy>mockInjectorService.get).and.returnValue(mockXSRFService);
+		mockInjectorService.get.and.returnValue(mockXSRFService);
 	});
 
 	const starkRoutingServiceFactory: Function = (state: StateService, transitions: TransitionService) => {
@@ -405,9 +403,9 @@ describe("Service: StarkRoutingService", () => {
 		$state = router.stateService;
 		routingService = _routingService;
 
-		(<Spy>mockLogger.warn).calls.reset();
-		(<Spy>mockLogger.debug).calls.reset();
-		(<Spy>mockLogger.error).calls.reset();
+		mockLogger.warn.calls.reset();
+		mockLogger.debug.calls.reset();
+		mockLogger.error.calls.reset();
 		mockStore.dispatch.calls.reset();
 	}));
 
@@ -1028,7 +1026,7 @@ describe("Service: StarkRoutingService", () => {
 					}),
 					tap((enteredState: StateObject) => {
 						expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-						const message: string = (<Spy>mockLogger.warn).calls.argsFor(0)[0];
+						const message: string = mockLogger.warn.calls.argsFor(0)[0];
 						expect(message).toMatch(/Route transition ignored/);
 
 						expect(enteredState).toBeDefined();
@@ -1056,7 +1054,7 @@ describe("Service: StarkRoutingService", () => {
 					}),
 					tap((enteredState: StateObject) => {
 						expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-						const message: string = (<Spy>mockLogger.warn).calls.argsFor(0)[0];
+						const message: string = mockLogger.warn.calls.argsFor(0)[0];
 						expect(message).toMatch(/Route transition superseded/);
 
 						expect(enteredState).toBeDefined();
@@ -1083,7 +1081,7 @@ describe("Service: StarkRoutingService", () => {
 				.pipe(
 					catchError((error: any) => {
 						expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-						const message: string = (<Spy>mockLogger.warn).calls.argsFor(0)[0];
+						const message: string = mockLogger.warn.calls.argsFor(0)[0];
 						expect(message).toMatch(/Route transition rejected/);
 						return throwError(errorPrefix + error);
 					})
@@ -1101,7 +1099,7 @@ describe("Service: StarkRoutingService", () => {
 				.pipe(
 					catchError((error: any) => {
 						expect(mockLogger.error).toHaveBeenCalledTimes(1);
-						const message: string = (<Spy>mockLogger.error).calls.argsFor(0)[0];
+						const message: string = mockLogger.error.calls.argsFor(0)[0];
 						expect(message).toMatch(/Error during route transition/);
 						return throwError(errorPrefix + error);
 					})
@@ -1119,7 +1117,7 @@ describe("Service: StarkRoutingService", () => {
 				.pipe(
 					catchError((error: any) => {
 						expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-						const message: string = (<Spy>mockLogger.warn).calls.argsFor(0)[0];
+						const message: string = mockLogger.warn.calls.argsFor(0)[0];
 						expect(message).toMatch(/transition aborted/);
 						return throwError(errorPrefix + error);
 					})
@@ -1137,7 +1135,7 @@ describe("Service: StarkRoutingService", () => {
 				.pipe(
 					catchError((error: any) => {
 						expect(mockLogger.error).toHaveBeenCalledTimes(1);
-						const message: string = (<Spy>mockLogger.error).calls.argsFor(0)[0];
+						const message: string = mockLogger.error.calls.argsFor(0)[0];
 						expect(message).toMatch(/An error occurred with a resolve in the new state/);
 						return throwError(errorPrefix + error);
 					})
@@ -1151,7 +1149,7 @@ describe("Service: StarkRoutingService", () => {
 				.pipe(
 					catchError((error: any) => {
 						expect(mockLogger.error).toHaveBeenCalledTimes(1);
-						const message: string = (<Spy>mockLogger.error).calls.argsFor(0)[0];
+						const message: string = mockLogger.error.calls.argsFor(0)[0];
 						expect(message).toMatch(/The target state does NOT exist/);
 						return throwError(errorPrefix + error);
 					})

--- a/packages/stark-core/src/modules/routing/testing/routing.mock.ts
+++ b/packages/stark-core/src/modules/routing/testing/routing.mock.ts
@@ -1,44 +1,32 @@
-import { StarkRoutingService, StarkStateConfigWithParams } from "@nationalbankbelgium/stark-core";
-import { Observable } from "rxjs";
-import { HookFn, HookMatchCriteria, HookRegOptions, RawParams, StateDeclaration, StateObject, TransitionOptions } from "@uirouter/core";
+import { StarkRoutingService } from "@nationalbankbelgium/stark-core";
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
 
 /**
  * @ignore
  */
-export class MockStarkRoutingService implements StarkRoutingService {
-	public navigateTo: (newState: string, params?: RawParams, options?: TransitionOptions) => Observable<any> = jasmine.createSpy(
-		"navigateTo"
-	);
-	public navigateToHome: (params?: RawParams) => Observable<any> = jasmine.createSpy("navigateToHome");
-	public navigateToPrevious: () => Observable<any> = jasmine.createSpy("navigateToPrevious");
-	public reload: () => Observable<any> = jasmine.createSpy("reload");
-	public getCurrentStateName: () => string = jasmine.createSpy("getCurrentStateName");
-	public getCurrentState: () => StateObject = jasmine.createSpy("getCurrentState");
-	public getCurrentStateConfig: () => StateDeclaration = jasmine.createSpy("getCurrentStateConfig");
-	public getStatesConfig: () => StateDeclaration[] = jasmine.createSpy("getStatesConfig");
-	public getStateConfigByUrlPath: (urlPath: string) => StarkStateConfigWithParams | undefined = jasmine.createSpy(
-		"getStateConfigByUrlPath"
-	);
-	public getStateDeclarationByStateName: (stateName: string) => StateDeclaration | undefined = jasmine.createSpy(
+export class MockStarkRoutingService implements SpyObj<StarkRoutingService> {
+	public navigateTo: SpyObj<StarkRoutingService>["navigateTo"] = createSpy("navigateTo");
+	public navigateToHome: SpyObj<StarkRoutingService>["navigateToHome"] = createSpy("navigateToHome");
+	public navigateToPrevious: SpyObj<StarkRoutingService>["navigateToPrevious"] = createSpy("navigateToPrevious");
+	public reload: SpyObj<StarkRoutingService>["reload"] = createSpy("reload");
+	public getCurrentStateName: SpyObj<StarkRoutingService>["getCurrentStateName"] = createSpy("getCurrentStateName");
+	public getCurrentState: SpyObj<StarkRoutingService>["getCurrentState"] = createSpy("getCurrentState");
+	public getCurrentStateConfig: SpyObj<StarkRoutingService>["getCurrentStateConfig"] = createSpy("getCurrentStateConfig");
+	public getStatesConfig: SpyObj<StarkRoutingService>["getStatesConfig"] = createSpy("getStatesConfig");
+	public getStateConfigByUrlPath: SpyObj<StarkRoutingService>["getStateConfigByUrlPath"] = createSpy("getStateConfigByUrlPath");
+	public getStateDeclarationByStateName: SpyObj<StarkRoutingService>["getStateDeclarationByStateName"] = createSpy(
 		"getStateDeclarationByStateName"
 	);
-	// tslint:disable-next-line:bool-param-default
-	public getCurrentStateParams: (includeInherited?: boolean) => RawParams = jasmine.createSpy("getCurrentStateParams");
-	public getStateTreeParams: () => Map<string, any> = jasmine.createSpy("getStateTreeParams");
-	public getStateTreeResolves: () => Map<string, any> = jasmine.createSpy("getStateTreeResolves");
-	public getStateTreeData: () => Map<string, any> = jasmine.createSpy("getStateTreeData");
-	public isCurrentUiState: (stateName: string, stateParams?: RawParams) => boolean = jasmine.createSpy("isCurrentUiState");
-	public isCurrentUiStateIncludedIn: (stateName: string, stateParams?: RawParams) => boolean = jasmine.createSpy("includesState");
-	public addKnownNavigationRejectionCause: (rejectionCause: string) => void = jasmine.createSpy("addKnownNavigationRejectionCause");
-	public addTransitionHook: (
-		lifecycleHook: string,
-		matchCriteria: HookMatchCriteria,
-		callback: HookFn,
-		options?: HookRegOptions
-	) => Function = jasmine.createSpy("addTransitionHook");
-	public getTranslationKeyFromState: (stateName: string) => string = jasmine.createSpy("getTranslationKeyFromState");
-
-	public constructor() {
-		// empty constructor
-	}
+	public getCurrentStateParams: SpyObj<StarkRoutingService>["getCurrentStateParams"] = createSpy("getCurrentStateParams");
+	public getStateTreeParams: SpyObj<StarkRoutingService>["getStateTreeParams"] = createSpy("getStateTreeParams");
+	public getStateTreeResolves: SpyObj<StarkRoutingService>["getStateTreeResolves"] = createSpy("getStateTreeResolves");
+	public getStateTreeData: SpyObj<StarkRoutingService>["getStateTreeData"] = createSpy("getStateTreeData");
+	public isCurrentUiState: SpyObj<StarkRoutingService>["isCurrentUiState"] = createSpy("isCurrentUiState");
+	public isCurrentUiStateIncludedIn: SpyObj<StarkRoutingService>["isCurrentUiStateIncludedIn"] = createSpy("includesState");
+	public addKnownNavigationRejectionCause: SpyObj<StarkRoutingService>["addKnownNavigationRejectionCause"] = createSpy(
+		"addKnownNavigationRejectionCause"
+	);
+	public addTransitionHook: SpyObj<StarkRoutingService>["addTransitionHook"] = createSpy("addTransitionHook");
+	public getTranslationKeyFromState: SpyObj<StarkRoutingService>["getTranslationKeyFromState"] = createSpy("getTranslationKeyFromState");
 }

--- a/packages/stark-core/src/modules/session/testing/session.mock.ts
+++ b/packages/stark-core/src/modules/session/testing/session.mock.ts
@@ -1,20 +1,23 @@
 import { StarkSessionService } from "@nationalbankbelgium/stark-core";
-import { Observable } from "rxjs";
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
 
 /**
  * @ignore
  */
-export class MockStarkSessionService implements StarkSessionService {
-	public devAuthenticationHeaders: Map<string, string>;
+export class MockStarkSessionService implements SpyObj<StarkSessionService> {
+	public devAuthenticationHeaders: SpyObj<StarkSessionService>["devAuthenticationHeaders"];
 
-	public getCurrentUser: () => Observable<any> = jasmine.createSpy("getCurrentLanguage");
-	public getCurrentLanguage: () => Observable<string> = jasmine.createSpy("getCurrentLanguage");
-	public setCurrentLanguage: () => void = jasmine.createSpy("setCurrentLanguage");
-	public login: () => void = jasmine.createSpy("login");
-	public logout: () => void = jasmine.createSpy("logout");
-	public pauseUserActivityTracking: () => void = jasmine.createSpy("pauseUserActivityTracking");
-	public resumeUserActivityTracking: () => void = jasmine.createSpy("resumeUserActivityTracking");
-	public setDevAuthenticationHeaders: () => void = jasmine.createSpy("setDevAuthenticationHeaders");
+	public getCurrentUser: SpyObj<StarkSessionService>["getCurrentUser"] = createSpy("getCurrentLanguage");
+	public getCurrentLanguage: SpyObj<StarkSessionService>["getCurrentLanguage"] = createSpy("getCurrentLanguage");
+	public setCurrentLanguage: SpyObj<StarkSessionService>["setCurrentLanguage"] = createSpy("setCurrentLanguage");
+	public login: SpyObj<StarkSessionService>["login"] = createSpy("login");
+	public logout: SpyObj<StarkSessionService>["logout"] = createSpy("logout");
+	public pauseUserActivityTracking: SpyObj<StarkSessionService>["pauseUserActivityTracking"] = createSpy("pauseUserActivityTracking");
+	public resumeUserActivityTracking: SpyObj<StarkSessionService>["resumeUserActivityTracking"] = createSpy("resumeUserActivityTracking");
+	public setDevAuthenticationHeaders: SpyObj<StarkSessionService>["setDevAuthenticationHeaders"] = createSpy(
+		"setDevAuthenticationHeaders"
+	);
 
 	public constructor(devAuthenticationHeaders?: Map<string, string>) {
 		if (!devAuthenticationHeaders) {

--- a/packages/stark-core/src/modules/settings/effects/settings.effects.spec.ts
+++ b/packages/stark-core/src/modules/settings/effects/settings.effects.spec.ts
@@ -1,9 +1,9 @@
 /*tslint:disable:completed-docs*/
-import Spy = jasmine.Spy;
+import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
 import { StarkSettingsEffects } from "./settings.effects";
 import { StarkSetPreferredLanguage } from "../actions";
-import { STARK_SESSION_SERVICE, StarkSessionService } from "../../session/services";
+import { STARK_SESSION_SERVICE } from "../../session/services";
 import { MockStarkSessionService } from "../../session/testing";
 import { TestBed } from "@angular/core/testing";
 import { Observable, Observer, ReplaySubject } from "rxjs";
@@ -12,7 +12,7 @@ import { provideMockActions } from "@ngrx/effects/testing";
 describe("Effect: StarkSettingsEffects", () => {
 	let settingsEffects: StarkSettingsEffects;
 
-	let mockSessionService: StarkSessionService;
+	let mockSessionService: MockStarkSessionService;
 	let actions: Observable<any>;
 
 	// Inject module dependencies
@@ -35,8 +35,8 @@ describe("Effect: StarkSettingsEffects", () => {
 
 	describe("On setPreferredLanguage$", () => {
 		it("Should set the language successfully", () => {
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
-			(<Spy>mockSessionService.setCurrentLanguage).and.returnValue({});
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			mockSessionService.setCurrentLanguage.and.returnValue({});
 
 			const subject: ReplaySubject<any> = new ReplaySubject(1);
 			actions = subject.asObservable();
@@ -47,7 +47,7 @@ describe("Effect: StarkSettingsEffects", () => {
 
 			expect(mockSessionService.setCurrentLanguage).toHaveBeenCalledWith("NL");
 			expect(mockObserver.next).toHaveBeenCalledTimes(1);
-			const effectResult: any = (<Spy>mockObserver.next).calls.mostRecent().args[0];
+			const effectResult: any = mockObserver.next.calls.mostRecent().args[0];
 			expect(effectResult).toBeDefined();
 			expect(mockObserver.error).not.toHaveBeenCalled();
 			expect(mockObserver.complete).not.toHaveBeenCalled(); // effects should never complete!

--- a/packages/stark-core/src/modules/settings/services/settings.service.spec.ts
+++ b/packages/stark-core/src/modules/settings/services/settings.service.spec.ts
@@ -1,8 +1,6 @@
 /*tslint:disable:completed-docs*/
 import { Store } from "@ngrx/store";
-import { StarkLoggingService } from "../../logging/services";
 import { MockStarkLoggingService } from "../../logging/testing";
-import { StarkSessionService } from "../../session/services";
 import { MockStarkSessionService } from "../../session/testing";
 import {
 	StarkApplicationConfig,
@@ -18,16 +16,15 @@ import { StarkSettingsServiceImpl } from "./settings.service";
 import { StarkSetPreferredLanguage } from "../actions";
 import { StarkUser } from "../../user/entities";
 import { of } from "rxjs";
-import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;
 
 describe("Service: StarkSettingsService", () => {
 	let mockStore: SpyObj<Store<StarkCoreApplicationState>>;
-	let mockLogger: StarkLoggingService;
+	let mockLogger: MockStarkLoggingService;
 	let appConfig: StarkApplicationConfig;
 	let appMetadata: StarkApplicationMetadata;
 	let settingsService: StarkSettingsServiceImpl;
-	let mockSessionService: StarkSessionService;
+	let mockSessionService: MockStarkSessionService;
 	let mockUser: StarkUser;
 	let browserLanguageCode: string;
 
@@ -51,7 +48,7 @@ describe("Service: StarkSettingsService", () => {
 		};
 
 		mockSessionService = new MockStarkSessionService();
-		(<Spy>mockSessionService.getCurrentUser).and.returnValue(of(mockUser));
+		mockSessionService.getCurrentUser.and.returnValue(of(mockUser));
 
 		settingsService = new StarkSettingsServiceImpl(mockLogger, mockSessionService, appMetadata, appConfig, <
 			Store<StarkCoreApplicationState>
@@ -121,19 +118,19 @@ describe("Service: StarkSettingsService", () => {
 		it("should set browser language as preferred language if user language is undefined OR null", () => {
 			// tslint:disable-next-line:no-null-keyword */
 			mockUser.language = <any>null;
-			(<Spy>mockSessionService.getCurrentUser).and.returnValue(of(mockUser));
+			mockSessionService.getCurrentUser.and.returnValue(of(mockUser));
 			settingsService.initializeSettings();
 			expect(settingsService.preferredLanguage).toEqual(browserLanguageCode);
 
 			mockUser.language = undefined;
-			(<Spy>mockSessionService.getCurrentUser).and.returnValue(of(mockUser));
+			mockSessionService.getCurrentUser.and.returnValue(of(mockUser));
 			settingsService.initializeSettings();
 			expect(settingsService.preferredLanguage).toEqual(browserLanguageCode);
 		});
 
 		it("should set browser language as preferred language if user language is NOT in supported languages", () => {
 			mockUser.language = "NL";
-			(<Spy>mockSessionService.getCurrentUser).and.returnValue(of(mockUser));
+			mockSessionService.getCurrentUser.and.returnValue(of(mockUser));
 			settingsService.initializeSettings();
 			expect(settingsService.preferredLanguage).toEqual(browserLanguageCode);
 		});

--- a/packages/stark-core/src/modules/user/services/user.service.spec.ts
+++ b/packages/stark-core/src/modules/user/services/user.service.spec.ts
@@ -17,7 +17,6 @@ import {
 import { StarkUser } from "../entities";
 import { StarkUserService } from "./user.service.intf";
 import { StarkUserServiceImpl } from "./user.service";
-import { StarkLoggingService } from "../../logging/services/logging.service.intf";
 import { MockStarkLoggingService } from "../../logging/testing";
 import { StarkUserRepository } from "../repository";
 import {
@@ -42,7 +41,7 @@ describe("Service: StarkUserService", () => {
 	let userService: StarkUserService;
 	let mockStore: SpyObj<Store<StarkCoreApplicationState>>;
 	let mockUserRepository: SpyObj<StarkUserRepository>;
-	let mockLogger: StarkLoggingService;
+	let mockLogger: MockStarkLoggingService;
 
 	let mockData: StarkMockData;
 	let mockUsers: StarkUserWithCustomData[];
@@ -97,9 +96,7 @@ describe("Service: StarkUserService", () => {
 		mockUserInstances = [Deserialize(mockUsers[0], StarkUser), Deserialize(mockUsers[1], StarkUser)];
 		mockObserver = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
-		userService = new StarkUserServiceImpl(mockLogger, mockUserRepository, mockData, <Store<StarkCoreApplicationState>>(
-			<unknown>mockStore
-		));
+		userService = new StarkUserServiceImpl(mockLogger, mockUserRepository, mockData, mockStore);
 	});
 
 	describe("getAllUsers", () => {

--- a/packages/stark-core/src/modules/user/testing/user.mock.ts
+++ b/packages/stark-core/src/modules/user/testing/user.mock.ts
@@ -1,14 +1,10 @@
-import { StarkUser, StarkUserService } from "@nationalbankbelgium/stark-core";
-import { Observable } from "rxjs";
+import { StarkUserService } from "@nationalbankbelgium/stark-core";
+import SpyObj = jasmine.SpyObj;
 
 /**
  * @ignore
  */
-export class MockStarkUserService implements StarkUserService {
-	public fetchUserProfile: () => Observable<StarkUser> = jasmine.createSpy("fetchUserProfile");
-	public getAllUsers: () => StarkUser[] = jasmine.createSpy("getAllUsers");
-
-	public constructor() {
-		// empty constructor
-	}
+export class MockStarkUserService implements SpyObj<StarkUserService> {
+	public fetchUserProfile: SpyObj<StarkUserService>["fetchUserProfile"] = jasmine.createSpy("fetchUserProfile");
+	public getAllUsers: SpyObj<StarkUserService>["getAllUsers"] = jasmine.createSpy("getAllUsers");
 }

--- a/packages/stark-core/src/modules/xsrf/services/xsrf.service.spec.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf.service.spec.ts
@@ -4,7 +4,6 @@ import { fakeAsync, tick } from "@angular/core/testing";
 import { Injector } from "@angular/core";
 import { Observable, of, Subject, throwError } from "rxjs";
 import { StarkHttpHeaders } from "../../http/constants";
-import { StarkLoggingService } from "../../logging/services";
 import { StarkXSRFServiceImpl } from "./xsrf.service";
 import { StarkXSRFConfig } from "./xsrf-config.intf";
 import { StarkApplicationConfig, StarkApplicationConfigImpl } from "../../../configuration/entities";
@@ -23,7 +22,7 @@ describe("Service: StarkXSRFService", () => {
 	let mockInjectorService: SpyObj<Injector>;
 	let mockXsrfConfig: StarkXSRFConfig;
 
-	const mockLogger: StarkLoggingService = new MockStarkLoggingService();
+	const mockLogger: MockStarkLoggingService = new MockStarkLoggingService();
 	const httpMock: SpyObj<HttpClient> = createSpyObj<HttpClient>("HttpClient", ["get"]);
 	const mockXSRFToken: string = "dummy xsrf token";
 	const dummyHeader: string = "X-DUMMY-HEADER";
@@ -38,8 +37,6 @@ describe("Service: StarkXSRFService", () => {
 	const mockBackend2: StarkBackend = { ...mockBackend1, name: "dummy backend 2", url: "other/url" };
 	const mockBackend3: StarkBackend = { ...mockBackend1, name: "dummy backend 3", url: "another/url" };
 
-	// FIXME: this tslint disable flag is due to a bug in 'no-element-overwrite' rule. Remove it once it is solved
-	/* tslint:disable:no-element-overwrite */
 	beforeEach(() => {
 		appConfig = new StarkApplicationConfigImpl();
 		appConfig.backends = new Map<string, StarkBackend>();
@@ -50,13 +47,12 @@ describe("Service: StarkXSRFService", () => {
 		mockInjectorService = jasmine.createSpyObj<Injector>("injector,", ["get"]);
 		mockXsrfConfig = {};
 
-		(<Spy>mockLogger.error).calls.reset();
-		(<Spy>mockLogger.warn).calls.reset();
+		mockLogger.error.calls.reset();
+		mockLogger.warn.calls.reset();
 		httpMock.get.calls.reset();
 
 		xsrfService = new StarkXSRFServiceHelper(appConfig, mockLogger, httpMock, <any>mockDocument, mockInjectorService, mockXsrfConfig);
 	});
-	/* tslint:enable:no-element-overwrite */
 
 	describe("configureXHR", () => {
 		it("should add the necessary options to the XHR object in order to enable XSRF protection", () => {
@@ -217,7 +213,7 @@ describe("Service: StarkXSRFService", () => {
 
 			expect(xsrfToken).toBeUndefined();
 			expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-			const warningMessage: string = (<Spy>mockLogger.warn).calls.argsFor(0)[0];
+			const warningMessage: string = mockLogger.warn.calls.argsFor(0)[0];
 			expect(warningMessage).toContain("no XSRF token found");
 		});
 	});
@@ -311,7 +307,7 @@ describe("Service: StarkXSRFService", () => {
 			});
 
 			expect(mockLogger.error).toHaveBeenCalledTimes(failingBackends.length);
-			const logErrorCalls: CallInfo[] = (<Spy>mockLogger.error).calls.all();
+			const logErrorCalls: CallInfo[] = mockLogger.error.calls.all();
 			let logErrorCallIdx: number = 0;
 
 			for (const failingBackend of failingBackends) {
@@ -339,7 +335,7 @@ describe("Service: StarkXSRFService", () => {
 	class StarkXSRFServiceHelper extends StarkXSRFServiceImpl {
 		public constructor(
 			applicationConfig: StarkApplicationConfig,
-			logger: StarkLoggingService,
+			logger: MockStarkLoggingService,
 			httpClient: SpyObj<HttpClient>,
 			document: Document,
 			injector: Injector,

--- a/packages/stark-core/src/modules/xsrf/testing/xsrf.mock.ts
+++ b/packages/stark-core/src/modules/xsrf/testing/xsrf.mock.ts
@@ -1,18 +1,19 @@
-import { HttpRequest } from "@angular/common/http";
 import { StarkXSRFService } from "@nationalbankbelgium/stark-core";
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
 
 /**
  * Mock class of the StarkXSRFService interface.
  * @link StarkXSRFService
  */
-export class MockStarkXsrfService implements StarkXSRFService {
-	public configureHttpRequest: (request: HttpRequest<any>) => HttpRequest<any> = jasmine.createSpy("configureHttpRequest");
+export class MockStarkXsrfService implements SpyObj<StarkXSRFService> {
+	public configureHttpRequest: SpyObj<StarkXSRFService>["configureHttpRequest"] = createSpy("configureHttpRequest");
 
-	public configureXHR: (xhr: XMLHttpRequest) => void = jasmine.createSpy("configureXHR");
+	public configureXHR: SpyObj<StarkXSRFService>["configureXHR"] = createSpy("configureXHR");
 
-	public getXSRFToken: () => string | undefined = jasmine.createSpy("getXSRFToken");
+	public getXSRFToken: SpyObj<StarkXSRFService>["getXSRFToken"] = createSpy("getXSRFToken");
 
-	public pingBackends: () => void = jasmine.createSpy("pingBackends");
+	public pingBackends: SpyObj<StarkXSRFService>["pingBackends"] = createSpy("pingBackends");
 
-	public storeXSRFToken: () => void = jasmine.createSpy("storeXSRFToken");
+	public storeXSRFToken: SpyObj<StarkXSRFService>["storeXSRFToken"] = createSpy("storeXSRFToken");
 }

--- a/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.spec.ts
+++ b/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.spec.ts
@@ -8,7 +8,6 @@ import { MatListModule } from "@angular/material/list";
 import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE } from "@nationalbankbelgium/stark-core";
 import { MockStarkLoggingService, MockStarkRoutingService } from "@nationalbankbelgium/stark-core/testing";
 import { StarkAppMenuItemComponent } from "./app-menu-item.component";
-import Spy = jasmine.Spy;
 
 describe("StarkAppMenuItemComponent", () => {
 	let component: StarkAppMenuItemComponent;
@@ -51,7 +50,7 @@ describe("StarkAppMenuItemComponent", () => {
 		};
 		component.level = 1;
 		fixture.detectChanges();
-		(<Spy>mockRoutingService.navigateTo).calls.reset();
+		mockRoutingService.navigateTo.calls.reset();
 	});
 
 	describe("Simple menu item", () => {

--- a/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.spec.ts
+++ b/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.spec.ts
@@ -6,16 +6,10 @@ import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 import { BreakpointObserver, BreakpointState } from "@angular/cdk/layout";
 import { MatSidenavModule } from "@angular/material/sidenav";
 import { HookMatchCriteria, TransitionHookFn, TransitionStateHookFn } from "@uirouter/core";
-import {
-	STARK_LOGGING_SERVICE,
-	STARK_ROUTING_SERVICE,
-	StarkLoggingService,
-	StarkRoutingService,
-	StarkRoutingTransitionHook
-} from "@nationalbankbelgium/stark-core";
+import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE, StarkRoutingTransitionHook } from "@nationalbankbelgium/stark-core";
 import { MockStarkLoggingService, MockStarkRoutingService } from "@nationalbankbelgium/stark-core/testing";
 import { StarkAppSidebarComponent } from "./app-sidebar.component";
-import { STARK_APP_SIDEBAR_SERVICE, StarkAppSidebarService } from "../services/app-sidebar.service.intf";
+import { STARK_APP_SIDEBAR_SERVICE } from "../services/app-sidebar.service.intf";
 import { MockAppSidebarService } from "../testing/app-sidebar.mock";
 
 // Definitions
@@ -43,16 +37,16 @@ let fixture: ComponentFixture<StarkAppSidebarComponent>;
 let component: StarkAppSidebarComponent;
 
 // Mocked services
-let mockStarkLoggingService: jasmine.SpyObj<StarkLoggingService>;
-let mockStarkAppSideBarService: jasmine.SpyObj<StarkAppSidebarService>;
-let mockStarkRoutingService: jasmine.SpyObj<StarkRoutingService>;
+let mockStarkLoggingService: MockStarkLoggingService;
+let mockStarkAppSideBarService: MockAppSidebarService;
+let mockStarkRoutingService: MockStarkRoutingService;
 let mockBreakPointObserver: jasmine.SpyObj<BreakpointObserver>;
 
 describe("AppSidebarComponent", () => {
 	beforeEach(() => {
-		mockStarkLoggingService = new MockStarkLoggingService() as jasmine.SpyObj<MockStarkLoggingService>;
-		mockStarkAppSideBarService = new MockAppSidebarService() as jasmine.SpyObj<MockAppSidebarService>;
-		mockStarkRoutingService = new MockStarkRoutingService() as jasmine.SpyObj<MockStarkRoutingService>;
+		mockStarkLoggingService = new MockStarkLoggingService();
+		mockStarkAppSideBarService = new MockAppSidebarService();
+		mockStarkRoutingService = new MockStarkRoutingService();
 		// add functionality to the `addTransitionHook` Spy
 		mockStarkRoutingService.addTransitionHook.and.callFake(
 			(lifecycleHook: string, matchCriteria: HookMatchCriteria, callback: TransitionHookFn | TransitionStateHookFn): Function => {

--- a/packages/stark-ui/src/modules/app-sidebar/testing/app-sidebar.mock.ts
+++ b/packages/stark-ui/src/modules/app-sidebar/testing/app-sidebar.mock.ts
@@ -1,5 +1,7 @@
-import { Subject } from "rxjs";
 import { StarkAppSidebarOpenEvent, StarkAppSidebarService } from "@nationalbankbelgium/stark-ui";
+import { Subject } from "rxjs";
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
 
 /**
  * Mock class of the {@link StarkAppSidebarService|StarkAppSidebarService}.
@@ -30,7 +32,7 @@ import { StarkAppSidebarOpenEvent, StarkAppSidebarService } from "@nationalbankb
  * }
  * ```
  */
-export class MockAppSidebarService implements StarkAppSidebarService {
+export class MockAppSidebarService implements SpyObj<StarkAppSidebarService> {
 	/**
 	 * Observable subscribed by components to catch close events
 	 */
@@ -49,25 +51,25 @@ export class MockAppSidebarService implements StarkAppSidebarService {
 	/**
 	 * Close all sidebars
 	 */
-	public close: () => void = jasmine.createSpy("close");
+	public close: SpyObj<StarkAppSidebarService>["close"] = createSpy("close");
 
 	/**
 	 * Open sidebar's menu
 	 */
-	public openMenu: () => void = jasmine.createSpy("openMenu");
+	public openMenu: SpyObj<StarkAppSidebarService>["openMenu"] = createSpy("openMenu");
 
 	/**
 	 * Open the left sidebar
 	 */
-	public openLeft: () => void = jasmine.createSpy("openLeft");
+	public openLeft: SpyObj<StarkAppSidebarService>["openLeft"] = createSpy("openLeft");
 
 	/**
 	 * Open the right sidebar
 	 */
-	public openRight: () => void = jasmine.createSpy("openRight");
+	public openRight: SpyObj<StarkAppSidebarService>["openRight"] = createSpy("openRight");
 
 	/**
 	 * Toggle the menu
 	 */
-	public toggleMenu: () => void = jasmine.createSpy("toggleMenu");
+	public toggleMenu: SpyObj<StarkAppSidebarService>["toggleMenu"] = createSpy("toggleMenu");
 }

--- a/packages/stark-ui/src/modules/dropdown/components/dropdown.component.spec.ts
+++ b/packages/stark-ui/src/modules/dropdown/components/dropdown.component.spec.ts
@@ -281,12 +281,10 @@ describe("DropdownComponent", () => {
 		describe("on change", () => {
 			it("should assign right value to isMultiSelectEnabled when multiSelect changes", () => {
 				hostComponent.multiSelect = "true";
-				// hostComponent.value = [];
 				hostFixture.detectChanges();
 				expect(component.isMultiSelectEnabled).toBe(true);
 
 				hostComponent.multiSelect = "false";
-				// hostComponent.value = undefined;
 				hostFixture.detectChanges();
 				expect(component.isMultiSelectEnabled).toBe(false);
 			});

--- a/packages/stark-ui/src/modules/generic-search/classes/abstract-search-component.spec.ts
+++ b/packages/stark-ui/src/modules/generic-search/classes/abstract-search-component.spec.ts
@@ -1,38 +1,40 @@
 /* tslint:disable:completed-docs no-identical-functions */
-import { Observer, Observable, Subject, Subscriber, of, throwError } from "rxjs";
+import { Observable, Observer, of, Subject, Subscriber, throwError } from "rxjs";
 import { AbstractStarkSearchComponent, StarkGenericSearchService } from "../classes";
 import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
-import Spy = jasmine.Spy;
-import { StarkLoggingService, StarkResource } from "@nationalbankbelgium/stark-core";
+import { StarkResource } from "@nationalbankbelgium/stark-core";
 import { FormGroup } from "@angular/forms";
 import { StarkSearchState } from "../entities";
-import { StarkProgressIndicatorService } from "../../progress-indicator/services";
 import { MockStarkProgressIndicatorService } from "../../progress-indicator/testing";
+import Spy = jasmine.Spy;
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
+import createSpyObj = jasmine.createSpyObj;
 
 /* tslint:disable:no-big-function */
 describe("AbstractSearchComponent", () => {
 	let component: SearchComponentHelper;
-	let genericSearchService: StarkGenericSearchService<MockResource, SearchCriteria>;
-	let mockLogger: StarkLoggingService;
+	let genericSearchService: SpyObj<StarkGenericSearchService<MockResource, SearchCriteria>>;
+	let mockLogger: MockStarkLoggingService;
 
-	let mockProgressService: StarkProgressIndicatorService;
+	let mockProgressService: MockStarkProgressIndicatorService;
 
 	let originalSearchCriteria: SearchCriteria;
 	let getSearchStateObsTeardown: Spy;
 	let searchObsTeardown: Spy;
-	let mockObserver: Observer<any>;
+	let mockObserver: SpyObj<Observer<any>>;
 
 	beforeEach(() => {
-		genericSearchService = jasmine.createSpyObj("genericSearchService", ["getSearchState", "resetSearchState", "createNew", "search"]);
+		genericSearchService = createSpyObj("genericSearchService", ["getSearchState", "resetSearchState", "createNew", "search"]);
 		mockLogger = new MockStarkLoggingService();
 
 		mockProgressService = new MockStarkProgressIndicatorService();
 
 		component = new SearchComponentHelper(genericSearchService, mockLogger, mockProgressService);
-		getSearchStateObsTeardown = jasmine.createSpy("getSearchStateObsTeardown");
-		searchObsTeardown = jasmine.createSpy("searchObsTeardown");
+		getSearchStateObsTeardown = createSpy("getSearchStateObsTeardown");
+		searchObsTeardown = createSpy("searchObsTeardown");
 		originalSearchCriteria = { uuid: "3" };
-		(<Spy>genericSearchService.getSearchState).and.returnValue(
+		genericSearchService.getSearchState.and.returnValue(
 			createObservableOf<StarkSearchState<SearchCriteria>>(
 				{
 					criteria: originalSearchCriteria,
@@ -42,14 +44,14 @@ describe("AbstractSearchComponent", () => {
 			)
 		);
 
-		mockObserver = jasmine.createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+		mockObserver = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 	});
 	describe("ngOnInit", () => {
 		it("should clone the searchCriteria as originalCopy and search again if hasBeenSearched is TRUE", () => {
 			const expectedResult: MockResource[] = [{ uuid: "1", name: "first" }, { uuid: "2", name: "second" }];
 
-			(<Spy>genericSearchService.search).and.returnValue(of(expectedResult));
-			(<Spy>genericSearchService.getSearchState).and.returnValue(
+			genericSearchService.search.and.returnValue(of(expectedResult));
+			genericSearchService.getSearchState.and.returnValue(
 				of({
 					criteria: originalSearchCriteria,
 					hasBeenSearched: true
@@ -71,7 +73,7 @@ describe("AbstractSearchComponent", () => {
 		});
 
 		it("should set the searchCriteria as original copy and DON'T search if hasBeenSearched is FALSE", () => {
-			(<Spy>genericSearchService.getSearchState).and.returnValue(
+			genericSearchService.getSearchState.and.returnValue(
 				of({
 					criteria: originalSearchCriteria,
 					hasBeenSearched: false
@@ -97,8 +99,8 @@ describe("AbstractSearchComponent", () => {
 			const mockCriteria1: SearchCriteria = { uuid: "dummy uuid" };
 			const mockCriteria2: SearchCriteria = { uuid: "another uuid" };
 
-			(<Spy>genericSearchService.search).and.returnValue(of("dummy search result"));
-			(<Spy>genericSearchService.getSearchState).and.returnValue(searchState$);
+			genericSearchService.search.and.returnValue(of("dummy search result"));
+			genericSearchService.getSearchState.and.returnValue(searchState$);
 
 			component.ngOnInit();
 
@@ -112,7 +114,7 @@ describe("AbstractSearchComponent", () => {
 			expect(component.getWorkingCopy()).toEqual(mockCriteria1);
 			expect(component.getOriginalCopy()).not.toBe(component.getWorkingCopy());
 
-			(<Spy>mockObserver.next).calls.reset();
+			mockObserver.next.calls.reset();
 			searchState$.next({
 				criteria: mockCriteria2,
 				hasBeenSearched: true
@@ -130,7 +132,7 @@ describe("AbstractSearchComponent", () => {
 
 	describe("ngOnDestroy", () => {
 		it("should cancel the subscription of the searchState", () => {
-			(<Spy>genericSearchService.getSearchState).and.returnValue(
+			genericSearchService.getSearchState.and.returnValue(
 				createObservableOf<StarkSearchState<SearchCriteria>>(
 					{
 						criteria: originalSearchCriteria,
@@ -205,7 +207,7 @@ describe("AbstractSearchComponent", () => {
 	describe("performSearch", () => {
 		it("should call genericSearchService.search() passing the working copy if no searchCriteria defined", () => {
 			const expectedResult: MockResource[] = [{ uuid: "1", name: "first" }, { uuid: "2", name: "second" }];
-			(<Spy>genericSearchService.search).and.returnValue(createObservableOf<MockResource[]>(expectedResult, searchObsTeardown));
+			genericSearchService.search.and.returnValue(createObservableOf<MockResource[]>(expectedResult, searchObsTeardown));
 
 			component.ngOnInit();
 			component.performSearch();
@@ -224,7 +226,7 @@ describe("AbstractSearchComponent", () => {
 		it("should call genericSearchService.search() passing the given searchCriteria", () => {
 			const expectedResult: MockResource[] = [{ uuid: "1", name: "first" }, { uuid: "2", name: "second" }];
 			const customCriteria: SearchCriteria = { uuid: "11" };
-			(<Spy>genericSearchService.search).and.returnValue(createObservableOf<MockResource[]>(expectedResult, searchObsTeardown));
+			genericSearchService.search.and.returnValue(createObservableOf<MockResource[]>(expectedResult, searchObsTeardown));
 
 			component.ngOnInit();
 			component.performSearch(customCriteria);
@@ -246,8 +248,8 @@ describe("AbstractSearchComponent", () => {
 
 			const expectedResult: MockResource[] = [{ uuid: "1", name: "first" }, { uuid: "2", name: "second" }];
 			const customCriteria: SearchCriteria = { uuid: "11" };
-			(<Spy>genericSearchService.search).and.returnValue(createObservableOf<MockResource[]>(expectedResult, searchObsTeardown));
-			(<Spy>genericSearchService.getSearchState).and.returnValue(searchState$);
+			genericSearchService.search.and.returnValue(createObservableOf<MockResource[]>(expectedResult, searchObsTeardown));
+			genericSearchService.getSearchState.and.returnValue(searchState$);
 
 			component.ngOnInit();
 
@@ -264,7 +266,7 @@ describe("AbstractSearchComponent", () => {
 			expect(mockObserver.complete).not.toHaveBeenCalled();
 
 			expect(genericSearchService.search).not.toHaveBeenCalled();
-			(<Spy>mockObserver.next).calls.reset();
+			mockObserver.next.calls.reset();
 
 			// perform first manual search
 			component.performSearch(customCriteria);
@@ -278,7 +280,7 @@ describe("AbstractSearchComponent", () => {
 			expect(genericSearchService.search).toHaveBeenCalledTimes(1);
 			expect(genericSearchService.search).toHaveBeenCalledWith(customCriteria);
 
-			(<Spy>genericSearchService.search).calls.reset();
+			genericSearchService.search.calls.reset();
 
 			// simulating searchState change due to first manual search => hasBeenSearched = true
 			searchState$.next({
@@ -291,7 +293,7 @@ describe("AbstractSearchComponent", () => {
 
 		it("should call progressService show/hide methods passing the progressTopic defined before and after performing the search", () => {
 			const expectedResult: MockResource[] = [{ uuid: "1", name: "first" }, { uuid: "2", name: "second" }];
-			(<Spy>genericSearchService.search).and.returnValue(of(expectedResult));
+			genericSearchService.search.and.returnValue(of(expectedResult));
 
 			const dummyTopic: string = "dummyTopic";
 			component.setProgressTopic(dummyTopic);
@@ -312,7 +314,7 @@ describe("AbstractSearchComponent", () => {
 		});
 
 		it("should call progressService show/hide methods passing the progressTopic defined before and after performing a failing search", () => {
-			(<Spy>genericSearchService.search).and.returnValue(throwError("search failed"));
+			genericSearchService.search.and.returnValue(throwError("search failed"));
 
 			const dummyTopic: string = "dummyTopic";
 			component.setProgressTopic(dummyTopic);
@@ -330,7 +332,7 @@ describe("AbstractSearchComponent", () => {
 
 		it("should NOT call progressService show/hide methods before and after performing the search in case no progressTopic is defined", () => {
 			const expectedResult: MockResource[] = [{ uuid: "1", name: "first" }, { uuid: "2", name: "second" }];
-			(<Spy>genericSearchService.search).and.returnValue(of(expectedResult));
+			genericSearchService.search.and.returnValue(of(expectedResult));
 
 			component.setProgressTopic("");
 			component.ngOnInit();
@@ -357,7 +359,7 @@ describe("AbstractSearchComponent", () => {
 
 		it("should return the results from the latest search that was performed as long as the preserveLatestResults option is enabled", () => {
 			const expectedResult: MockResource[] = [{ uuid: "1", name: "first" }, { uuid: "2", name: "second" }];
-			(<Spy>genericSearchService.search).and.returnValue(of(expectedResult));
+			genericSearchService.search.and.returnValue(of(expectedResult));
 
 			component.enablePreserveLatestResults(true);
 			component.ngOnInit();
@@ -368,7 +370,7 @@ describe("AbstractSearchComponent", () => {
 
 		it("should return undefined regardless of any search that was performed when the preserveLatestResults option is disabled", () => {
 			const expectedResult: MockResource[] = [{ uuid: "1", name: "first" }, { uuid: "2", name: "second" }];
-			(<Spy>genericSearchService.search).and.returnValue(of(expectedResult));
+			genericSearchService.search.and.returnValue(of(expectedResult));
 
 			component.enablePreserveLatestResults(false);
 			component.ngOnInit();
@@ -397,8 +399,8 @@ function createObservableOf<T>(value: T, teardown: Function): Observable<T> {
 class SearchComponentHelper extends AbstractStarkSearchComponent<MockResource, SearchCriteria> {
 	public constructor(
 		_genericSearchService_: StarkGenericSearchService<MockResource, SearchCriteria>,
-		logger: StarkLoggingService,
-		progressService: StarkProgressIndicatorService
+		logger: MockStarkLoggingService,
+		progressService: MockStarkProgressIndicatorService
 	) {
 		super(_genericSearchService_, logger, progressService);
 	}

--- a/packages/stark-ui/src/modules/language-selector/components/language-selector.component.spec.ts
+++ b/packages/stark-ui/src/modules/language-selector/components/language-selector.component.spec.ts
@@ -13,8 +13,7 @@ import {
 	STARK_SESSION_SERVICE,
 	StarkApplicationMetadata,
 	StarkApplicationMetadataImpl,
-	StarkLanguages,
-	StarkSessionService
+	StarkLanguages
 } from "@nationalbankbelgium/stark-core";
 
 import { MockStarkLoggingService, MockStarkSessionService } from "@nationalbankbelgium/stark-core/testing";
@@ -22,7 +21,6 @@ import { MockStarkLoggingService, MockStarkSessionService } from "@nationalbankb
 import { StarkLanguageSelectorComponent, StarkLanguageSelectorMode } from "./language-selector.component";
 import { StarkDropdownModule } from "../../dropdown";
 import { of, throwError } from "rxjs";
-import Spy = jasmine.Spy;
 
 /***
  * To be able to test changes to the input fields, the Language-Selector component is hosted inside the TestComponentHost class.
@@ -50,8 +48,8 @@ describe("LanguageSelectorComponent", () => {
 	appMetadata.supportedLanguages = [StarkLanguages.EN_US, StarkLanguages.FR_BE, StarkLanguages.NL_BE];
 
 	describe("on initialization", () => {
-		const mockSessionService: StarkSessionService = new MockStarkSessionService();
-		(<Spy>mockSessionService.getCurrentLanguage).and.returnValue(of("fr"));
+		const mockSessionService: MockStarkSessionService = new MockStarkSessionService();
+		mockSessionService.getCurrentLanguage.and.returnValue(of("fr"));
 
 		beforeEach(async(() => {
 			return compileComponent(mockSessionService);
@@ -77,8 +75,8 @@ describe("LanguageSelectorComponent", () => {
 	});
 
 	describe("on failing initialization", () => {
-		const mockSessionService: StarkSessionService = new MockStarkSessionService();
-		(<Spy>mockSessionService.getCurrentLanguage).and.returnValue(throwError("dummy-error"));
+		const mockSessionService: MockStarkSessionService = new MockStarkSessionService();
+		mockSessionService.getCurrentLanguage.and.returnValue(throwError("dummy-error"));
 
 		beforeEach(async(() => {
 			return compileComponent(mockSessionService);
@@ -95,8 +93,8 @@ describe("LanguageSelectorComponent", () => {
 	});
 
 	describe("on changeLanguage", () => {
-		const mockSessionService: StarkSessionService = new MockStarkSessionService();
-		(<Spy>mockSessionService.getCurrentLanguage).and.returnValue(of("fr"));
+		const mockSessionService: MockStarkSessionService = new MockStarkSessionService();
+		mockSessionService.getCurrentLanguage.and.returnValue(of("fr"));
 
 		beforeEach(async(() => {
 			return compileComponent(mockSessionService);
@@ -123,7 +121,7 @@ describe("LanguageSelectorComponent", () => {
 	 * This function contains the component compilation code
 	 * Instead of repeating the code, it is placed in a separate function
 	 */
-	function compileComponent(mockSessionService: StarkSessionService): Promise<any> {
+	function compileComponent(mockSessionService: MockStarkSessionService): Promise<any> {
 		return TestBed.configureTestingModule({
 			imports: [CommonModule, MatButtonToggleModule, StarkDropdownModule, TranslateModule.forRoot()],
 			declarations: [StarkLanguageSelectorComponent, TestHostComponent],

--- a/packages/stark-ui/src/modules/message-pane/components/message-pane.component.spec.ts
+++ b/packages/stark-ui/src/modules/message-pane/components/message-pane.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:completed-docs no-commented-code no-big-function no-duplicate-string max-union-size no-identical-functions */
+/* tslint:disable:completed-docs no-big-function no-duplicate-string max-union-size no-identical-functions */
 
 /* angular imports */
 import { async, ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
@@ -17,7 +17,7 @@ import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 /* stark-ui imports */
 import { StarkMessagePaneComponent, StarkMessagePaneNavItem } from "./message-pane.component";
-import { STARK_MESSAGE_PANE_SERVICE, StarkMessagePaneService } from "../services";
+import { STARK_MESSAGE_PANE_SERVICE } from "../services";
 import { MockStarkMessagePaneService } from "../testing/message-pane.mock";
 import { StarkMessageCollection } from "../entities";
 import {
@@ -29,7 +29,7 @@ import { StarkMessage, StarkMessageType } from "../../../common/message";
 import { StarkDOMUtil } from "../../../util/dom/dom.util";
 
 /* jasmine imports */
-import Spy = jasmine.Spy;
+import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
 
 /***
@@ -58,7 +58,7 @@ describe("MessagePaneComponent", () => {
 	const mockDefaultAlign: "center" | "left" | "right" | undefined = "right";
 	const mockCenterAlign: "center" | "left" | "right" | undefined = "center";
 
-	const mockMessagePaneService: StarkMessagePaneService = new MockStarkMessagePaneService();
+	const mockMessagePaneService: MockStarkMessagePaneService = new MockStarkMessagePaneService();
 	let mockMessages: StarkMessageCollection;
 	let messageCollection$: BehaviorSubject<StarkMessageCollection>;
 
@@ -202,7 +202,7 @@ describe("MessagePaneComponent", () => {
 			errorMessages: []
 		};
 		messageCollection$ = new BehaviorSubject<StarkMessageCollection>(mockMessages);
-		(<Spy>mockMessagePaneService.getAll).and.returnValue(messageCollection$);
+		mockMessagePaneService.getAll.and.returnValue(messageCollection$);
 	});
 
 	describe("on initialization", () => {
@@ -262,7 +262,7 @@ describe("MessagePaneComponent", () => {
 		}));
 
 		it("when called right after hidePane(), it should wait fot the panel to be hidden before re-showing the pane", fakeAsync(() => {
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			component.ngOnInit();
 			component.renderer.addClass(component.elementRef.nativeElement, starkMessagePaneDisplayAnimatedClass);
@@ -295,7 +295,7 @@ describe("MessagePaneComponent", () => {
 			expect(debugElementComponent.classes[starkMessagePaneDisplayAnimatedClass]).toBe(false);
 
 			expect(mockObserver.next).toHaveBeenCalledTimes(1);
-			expect((<Spy>mockObserver.next).calls.argsFor(0)[0]).toContain("pane hidden");
+			expect(mockObserver.next.calls.argsFor(0)[0]).toContain("pane hidden");
 			expect(mockObserver.error).not.toHaveBeenCalled();
 			expect(mockObserver.complete).toHaveBeenCalledTimes(1);
 
@@ -323,7 +323,7 @@ describe("MessagePaneComponent", () => {
 		}));
 
 		it("should create a new hide$ Subject that should emit once the hide process has finished", fakeAsync(() => {
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			component.ngOnInit();
 			component.renderer.addClass(component.elementRef.nativeElement, starkMessagePaneDisplayAnimatedClass);
@@ -349,7 +349,7 @@ describe("MessagePaneComponent", () => {
 			expect(debugElementComponent.classes[starkMessagePaneDisplayedClass]).toBe(false);
 
 			expect(mockObserver.next).toHaveBeenCalledTimes(1);
-			expect((<Spy>mockObserver.next).calls.argsFor(0)[0]).toContain("pane hidden");
+			expect(mockObserver.next.calls.argsFor(0)[0]).toContain("pane hidden");
 			expect(mockObserver.error).not.toHaveBeenCalled();
 			expect(mockObserver.complete).toHaveBeenCalledTimes(1);
 		}));
@@ -407,7 +407,7 @@ describe("MessagePaneComponent", () => {
 
 		describe("Collapse, expand and hide the message pane", () => {
 			beforeEach(fakeAsync(() => {
-				(<Spy>mockMessagePaneService.clearAll).and.callFake(() => {
+				mockMessagePaneService.clearAll.and.callFake(() => {
 					const emptyMessageCollection: StarkMessageCollection = {
 						infoMessages: [],
 						warningMessages: [],
@@ -490,7 +490,7 @@ describe("MessagePaneComponent", () => {
 				messageCollection$.next(mockMessages);
 				hostFixture.detectChanges(); // trigger changes in data binding (it does not execute ngOnInit again -> it remembers!)
 
-				(<Spy>mockMessagePaneService.remove).and.callFake((messagesToRemove: StarkMessage[]) => {
+				mockMessagePaneService.remove.and.callFake((messagesToRemove: StarkMessage[]) => {
 					for (const message of messagesToRemove) {
 						let messageArray: StarkMessage[];
 						switch (message.type) {

--- a/packages/stark-ui/src/modules/message-pane/effects/message-pane.effects.spec.ts
+++ b/packages/stark-ui/src/modules/message-pane/effects/message-pane.effects.spec.ts
@@ -5,16 +5,16 @@ import { Observable, Observer, ReplaySubject } from "rxjs";
 import { provideMockActions } from "@ngrx/effects/testing";
 
 import { StarkMessagePaneEffects } from "./message-pane.effects";
-import { STARK_MESSAGE_PANE_SERVICE, StarkMessagePaneService } from "../services";
+import { STARK_MESSAGE_PANE_SERVICE } from "../services";
 import { StarkNavigateSuccess } from "@nationalbankbelgium/stark-core";
 import { MockStarkMessagePaneService } from "../testing/message-pane.mock";
-
+import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
 
 describe("Effect: StarkMessagePaneEffects", () => {
 	let messagePaneEffects: StarkMessagePaneEffects;
 
-	let mockMessagePaneService: StarkMessagePaneService;
+	let mockMessagePaneService: MockStarkMessagePaneService;
 	let actions: Observable<any>;
 
 	// Inject module dependencies
@@ -38,7 +38,7 @@ describe("Effect: StarkMessagePaneEffects", () => {
 	describe("On clearOnNavigationSuccess$", () => {
 		it("Should clear and hide the message pane", () => {
 			mockMessagePaneService.clearOnNavigation = true;
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			const subject: ReplaySubject<any> = new ReplaySubject(1);
 			actions = subject.asObservable();
@@ -55,7 +55,7 @@ describe("Effect: StarkMessagePaneEffects", () => {
 
 		it("Should not clear and hide the message pane when the 'clearOnNavigation' option is not set", () => {
 			mockMessagePaneService.clearOnNavigation = false;
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			const subject: ReplaySubject<any> = new ReplaySubject(1);
 			actions = subject.asObservable();

--- a/packages/stark-ui/src/modules/message-pane/reducers/messages-pane.reducer.spec.ts
+++ b/packages/stark-ui/src/modules/message-pane/reducers/messages-pane.reducer.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:completed-docs no-commented-code no-big-function no-duplicate-string max-union-size no-identical-functions */
+/* tslint:disable:completed-docs no-big-function no-duplicate-string max-union-size no-identical-functions */
 import { StarkMessage, StarkMessageType } from "../../../common/message";
 
 import { StarkAddMessages, StarkClearMessages, StarkRemoveMessages } from "../actions";

--- a/packages/stark-ui/src/modules/message-pane/services/message-pane.service.spec.ts
+++ b/packages/stark-ui/src/modules/message-pane/services/message-pane.service.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:completed-docs no-commented-code no-big-function no-duplicate-string max-union-size */
+/* tslint:disable:completed-docs no-big-function no-duplicate-string max-union-size */
 import { BehaviorSubject, Observable, Observer } from "rxjs";
 
 import { Store } from "@ngrx/store";
@@ -14,7 +14,6 @@ import { StarkMessageCollection } from "../entities";
 import { StarkAddMessages, StarkClearMessages, StarkGetAllMessages, StarkRemoveMessages } from "../actions";
 import { StarkMessageImpl } from "../../../common/message/message.entity";
 
-import Spy = jasmine.Spy;
 import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
 
@@ -57,7 +56,7 @@ describe("MessagePaneService", () => {
 		};
 
 		appMessagesState$ = new BehaviorSubject(mockMessageCollection);
-		(<Spy>mockStore.pipe).and.returnValue(appMessagesState$);
+		mockStore.pipe.and.returnValue(appMessagesState$);
 
 		messagePaneService = new MessagePaneServiceHelper(mockLogger, <Store<StarkUIApplicationState>>(<unknown>mockStore));
 	});
@@ -71,7 +70,7 @@ describe("MessagePaneService", () => {
 			expect(mockStore.pipe).toHaveBeenCalledTimes(1);
 			expect(messagePaneService.messages$).toBeDefined();
 
-			const mockMessagesObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockMessagesObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			messagePaneService.messages$.subscribe(mockMessagesObserver);
 
@@ -164,7 +163,7 @@ describe("MessagePaneService", () => {
 		it("should dispatch the GET_ALL_MESSAGES action passing the given messages in the payload", () => {
 			expect(messagePaneService.messages$).toBeDefined();
 
-			const mockMessagesObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockMessagesObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			const getAll$: Observable<StarkMessageCollection> = messagePaneService.getAll();
 			expect(getAll$).toBe(messagePaneService.messages$);

--- a/packages/stark-ui/src/modules/message-pane/testing/message-pane.mock.ts
+++ b/packages/stark-ui/src/modules/message-pane/testing/message-pane.mock.ts
@@ -1,38 +1,39 @@
-import { Observable } from "rxjs";
-import { StarkMessage, StarkMessageCollection, StarkMessagePaneService } from "@nationalbankbelgium/stark-ui";
+import { StarkMessagePaneService } from "@nationalbankbelgium/stark-ui";
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
 
 /**
  * Mock class of the StarkMessagePaneService interface.
  * @link StarkMessagePaneService
  */
-export class MockStarkMessagePaneService implements StarkMessagePaneService {
+export class MockStarkMessagePaneService implements SpyObj<StarkMessagePaneService> {
 	/**
 	 * Flag to specify whether all messages should be cleared on navigation
 	 */
-	public clearOnNavigation: boolean;
+	public clearOnNavigation: SpyObj<StarkMessagePaneService>["clearOnNavigation"];
 
 	/**
 	 * Add messages to the message pane
 	 */
-	public add: (messages: StarkMessage[]) => void = jasmine.createSpy("add");
+	public add: SpyObj<StarkMessagePaneService>["add"] = createSpy("add");
 
 	/**
 	 * Add a single message to the message pane
 	 */
-	public addOne: (message: StarkMessage) => void = jasmine.createSpy("addOne");
+	public addOne: SpyObj<StarkMessagePaneService>["addOne"] = createSpy("addOne");
 
 	/**
 	 * Get all messages currently displayed in the message pane
 	 */
-	public getAll: () => Observable<StarkMessageCollection> = jasmine.createSpy("getAll");
+	public getAll: SpyObj<StarkMessagePaneService>["getAll"] = createSpy("getAll");
 
 	/**
 	 * Remove messages from the message pane
 	 */
-	public remove: (messages: StarkMessage[]) => void = jasmine.createSpy("remove");
+	public remove: SpyObj<StarkMessagePaneService>["remove"] = createSpy("remove");
 
 	/**
 	 * Remove all messages
 	 */
-	public clearAll: () => void = jasmine.createSpy("clearAll");
+	public clearAll: SpyObj<StarkMessagePaneService>["clearAll"] = createSpy("clearAll");
 }

--- a/packages/stark-ui/src/modules/minimap/components/minimap.component.spec.ts
+++ b/packages/stark-ui/src/modules/minimap/components/minimap.component.spec.ts
@@ -1,4 +1,4 @@
-// tslint:disable:no-commented-code completed-docs
+// tslint:disable:completed-docs
 import { StarkMinimapComponent } from "./minimap.component";
 import { StarkMinimapItemProperties } from "./item-properties.intf";
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";

--- a/packages/stark-ui/src/modules/progress-indicator/services/progress-indicator.service.spec.ts
+++ b/packages/stark-ui/src/modules/progress-indicator/services/progress-indicator.service.spec.ts
@@ -1,5 +1,5 @@
 /* tslint:disable:completed-docs*/
-import Spy = jasmine.Spy;
+import SpyObj = jasmine.SpyObj;
 import { StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import {
 	progressIndicatorReducer,
@@ -16,7 +16,7 @@ import { StarkProgressIndicatorActions } from "../actions/progress-indicator.act
 
 // tslint:disable:no-big-function
 describe("Service: StarkProgressIndicatorService", () => {
-	let mockStore: Store<StarkUIApplicationState>;
+	let mockStore: SpyObj<Store<StarkUIApplicationState>>;
 	let progressIndicatorService: ProgressIndicatorServiceHelper;
 	const mockLogger: MockStarkLoggingService = new MockStarkLoggingService();
 	let mockProgressIndicatorMap: Map<string, StarkProgressIndicatorConfig>;
@@ -29,11 +29,11 @@ describe("Service: StarkProgressIndicatorService", () => {
 		mockStore = jasmine.createSpyObj("store", ["dispatch", "pipe"]);
 		mockProgressIndicatorMap = new Map<string, StarkProgressIndicatorConfig>();
 		progressIndicatorState$ = new BehaviorSubject(mockProgressIndicatorMap);
-		(<Spy>mockStore.pipe).and.returnValue(progressIndicatorState$);
+		mockStore.pipe.and.returnValue(progressIndicatorState$);
 
 		progressIndicatorService = new ProgressIndicatorServiceHelper(mockLogger, mockStore);
 
-		(<Spy>mockStore.dispatch).and.callFake((action: StarkProgressIndicatorActions) => {
+		mockStore.dispatch.and.callFake((action: StarkProgressIndicatorActions) => {
 			// reducer
 			progressIndicatorService.progressIndicatorMap = progressIndicatorReducer(progressIndicatorService.progressIndicatorMap, action);
 		});
@@ -60,7 +60,7 @@ describe("Service: StarkProgressIndicatorService", () => {
 				progressIndicatorService.progressIndicatorMap.get(dummyTopic)
 			);
 
-			expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toEqual("PROGRESS_INDICATOR_REGISTER");
+			expect(mockStore.dispatch.calls.argsFor(0)[0].type).toEqual("PROGRESS_INDICATOR_REGISTER");
 
 			expect(progressIndicatorConfig.topic).toBe(dummyTopic);
 			expect(progressIndicatorConfig.type).toBe(dummyType);
@@ -80,7 +80,7 @@ describe("Service: StarkProgressIndicatorService", () => {
 				progressIndicatorService.progressIndicatorMap.get(dummyTopic)
 			);
 
-			expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+			expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
 
 			expect(progressIndicatorConfig.topic).toBe(dummyTopic);
 			expect(progressIndicatorConfig.type).toBe(dummyType);
@@ -102,8 +102,8 @@ describe("Service: StarkProgressIndicatorService", () => {
 
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
 
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
 
 				const progressIndicatorConfig: StarkProgressIndicatorConfig = <StarkProgressIndicatorConfig>(
 					progressIndicatorService.progressIndicatorMap.get(dummyTopic)
@@ -132,8 +132,8 @@ describe("Service: StarkProgressIndicatorService", () => {
 
 			setTimeout(() => {
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
 
 				const progressIndicatorConfig: StarkProgressIndicatorConfig = <StarkProgressIndicatorConfig>(
 					progressIndicatorService.progressIndicatorMap.get(dummyTopic)
@@ -160,10 +160,10 @@ describe("Service: StarkProgressIndicatorService", () => {
 			setTimeout(() => {
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(4);
 
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
 
 				expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(true);
 
@@ -193,9 +193,9 @@ describe("Service: StarkProgressIndicatorService", () => {
 			setTimeout(() => {
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(3);
 
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
 
 				const progressIndicatorConfig: StarkProgressIndicatorConfig = <StarkProgressIndicatorConfig>(
 					progressIndicatorService.progressIndicatorMap.get(dummyTopic)
@@ -223,11 +223,11 @@ describe("Service: StarkProgressIndicatorService", () => {
 			setTimeout(() => {
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(5);
 
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
 
 				const progressIndicatorConfig: StarkProgressIndicatorConfig = <StarkProgressIndicatorConfig>(
 					progressIndicatorService.progressIndicatorMap.get(dummyTopic)
@@ -260,9 +260,9 @@ describe("Service: StarkProgressIndicatorService", () => {
 				expect(progressIndicatorConfig.pendingListenersCount).toEqual(0);
 
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(3);
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
 
 				expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(true);
 
@@ -286,8 +286,8 @@ describe("Service: StarkProgressIndicatorService", () => {
 				expect(progressIndicatorConfig.pendingListenersCount).toEqual(1);
 
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
 
 				expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(true);
 
@@ -302,8 +302,8 @@ describe("Service: StarkProgressIndicatorService", () => {
 			progressIndicatorService.deregister(dummyTopic);
 
 			expect(mockStore.dispatch).toHaveBeenCalledTimes(2);
-			expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-			expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
+			expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+			expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
 
 			expect(mockStore.dispatch).toHaveBeenCalledWith(new StarkProgressIndicatorDeregister(dummyTopic));
 			expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(false);
@@ -315,9 +315,9 @@ describe("Service: StarkProgressIndicatorService", () => {
 			progressIndicatorService.deregister(dummyTopic);
 
 			expect(mockStore.dispatch).toHaveBeenCalledTimes(3);
-			expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-			expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-			expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
+			expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+			expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+			expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
 
 			expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(true);
 
@@ -353,10 +353,10 @@ describe("Service: StarkProgressIndicatorService", () => {
 
 			setTimeout(() => {
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(4);
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+				expect(mockStore.dispatch.calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
 
 				expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(false);
 				done();
@@ -381,11 +381,11 @@ describe("Service: StarkProgressIndicatorService", () => {
 				);
 
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(5);
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+				expect(mockStore.dispatch.calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
 
 				expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(true);
 				expect(progressIndicatorConfig.topic).toBe(dummyTopic);
@@ -419,12 +419,12 @@ describe("Service: StarkProgressIndicatorService", () => {
 
 					expect(mockStore.dispatch).toHaveBeenCalledTimes(6);
 
-					expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-					expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-					expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-					expect((<Spy>mockStore.dispatch).calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-					expect((<Spy>mockStore.dispatch).calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
-					expect((<Spy>mockStore.dispatch).calls.argsFor(5)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
+					expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+					expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+					expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+					expect(mockStore.dispatch.calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+					expect(mockStore.dispatch.calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+					expect(mockStore.dispatch.calls.argsFor(5)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
 
 					expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(true);
 
@@ -458,13 +458,13 @@ describe("Service: StarkProgressIndicatorService", () => {
 			setTimeout(() => {
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(7);
 
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(5)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(6)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+				expect(mockStore.dispatch.calls.argsFor(5)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+				expect(mockStore.dispatch.calls.argsFor(6)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
 
 				expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(true);
 				done();
@@ -487,14 +487,14 @@ describe("Service: StarkProgressIndicatorService", () => {
 			setTimeout(() => {
 				expect(mockStore.dispatch).toHaveBeenCalledTimes(8);
 
-				expect((<Spy>mockStore.dispatch).calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(5)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(6)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
-				expect((<Spy>mockStore.dispatch).calls.argsFor(6)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
+				expect(mockStore.dispatch.calls.argsFor(0)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(1)[0].type).toBe("PROGRESS_INDICATOR_REGISTER");
+				expect(mockStore.dispatch.calls.argsFor(2)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(3)[0].type).toBe("PROGRESS_INDICATOR_SHOW");
+				expect(mockStore.dispatch.calls.argsFor(4)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+				expect(mockStore.dispatch.calls.argsFor(5)[0].type).toBe("PROGRESS_INDICATOR_HIDE");
+				expect(mockStore.dispatch.calls.argsFor(6)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
+				expect(mockStore.dispatch.calls.argsFor(6)[0].type).toBe("PROGRESS_INDICATOR_DEREGISTER");
 
 				expect(progressIndicatorService.progressIndicatorMap.has(dummyTopic)).toBe(false);
 				done();

--- a/packages/stark-ui/src/modules/progress-indicator/testing/progress-indicator.mock.ts
+++ b/packages/stark-ui/src/modules/progress-indicator/testing/progress-indicator.mock.ts
@@ -1,5 +1,6 @@
-import { Observable } from "rxjs";
-import { StarkProgressIndicatorService, StarkProgressIndicatorType } from "@nationalbankbelgium/stark-ui";
+import { StarkProgressIndicatorService } from "@nationalbankbelgium/stark-ui";
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
 
 /**
  * Mock class of the {@link StarkProgressIndicatorService|StarkProgressIndicatorService}.
@@ -30,32 +31,32 @@ import { StarkProgressIndicatorService, StarkProgressIndicatorType } from "@nati
  * }
  * ```
  */
-export class MockStarkProgressIndicatorService implements StarkProgressIndicatorService {
+export class MockStarkProgressIndicatorService implements SpyObj<StarkProgressIndicatorService> {
 	/**
 	 * registers a new progress indicator in the application state. Each registered progress indicator is identified by a topic,
 	 * a unique identifier associated with it.
 	 * @param topic - The topic of the progress indicator to be registered.
 	 * @param type - Type of progress indicator (i.e. spinner)
 	 */
-	public register: (topic: string, type: StarkProgressIndicatorType) => void = jasmine.createSpy("register");
+	public register: SpyObj<StarkProgressIndicatorService>["register"] = createSpy("register");
 
 	/**
 	 * Deregister a progress indicator already existing in the application state.
 	 * @param topic - The topic of the progress indicator to be deregistered
 	 */
-	public deregister: (topic: string) => void = jasmine.createSpy("deregister");
+	public deregister: SpyObj<StarkProgressIndicatorService>["deregister"] = createSpy("deregister");
 
 	/**
 	 * Shows the designated progress indicator
 	 * @param topic - The topic that needs to be shown
 	 */
-	public show: (topic: string) => void = jasmine.createSpy("show");
+	public show: SpyObj<StarkProgressIndicatorService>["show"] = createSpy("show");
 
 	/**
 	 * Hides the progress indicator.
 	 * @param topic - The topic that needs to be hidden
 	 */
-	public hide: (topic: string) => void = jasmine.createSpy("hide");
+	public hide: SpyObj<StarkProgressIndicatorService>["hide"] = createSpy("hide");
 
 	/**
 	 * Return the latest status of the progress indicator for the given topic (whether is shown or hidden).
@@ -63,5 +64,5 @@ export class MockStarkProgressIndicatorService implements StarkProgressIndicator
 	 * @returns Observable that will emit a boolean value whenever the status of the progress indicator changes: false if it is hidden,
 	 * true if it is shown or undefined in case there is no progress indicator for the given topic.
 	 */
-	public isVisible: (topic: string) => Observable<boolean | undefined> = jasmine.createSpy("isVisible");
+	public isVisible: SpyObj<StarkProgressIndicatorService>["isVisible"] = createSpy("isVisible");
 }

--- a/packages/stark-ui/src/modules/route-search/components/route-search.component.spec.ts
+++ b/packages/stark-ui/src/modules/route-search/components/route-search.component.spec.ts
@@ -14,20 +14,13 @@ import { MatOptionModule } from "@angular/material/core";
 import { HAMMER_LOADER } from "@angular/platform-browser";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { Ng2StateDeclaration, StateDeclaration } from "@uirouter/angular";
-import {
-	STARK_LOGGING_SERVICE,
-	STARK_ROUTING_SERVICE,
-	StarkLocale,
-	StarkLoggingService,
-	StarkRoutingService
-} from "@nationalbankbelgium/stark-core";
+import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE, StarkLocale } from "@nationalbankbelgium/stark-core";
 import { MockStarkLoggingService, MockStarkRoutingService } from "@nationalbankbelgium/stark-core/testing";
 import { StarkRouteSearchComponent } from "./route-search.component";
 import { StarkRouteSearchEntry } from "../components/route-search-entry.intf";
 import { StarkMenuConfig, StarkMenuGroup } from "../../app-menu";
 import { of, Subject, throwError } from "rxjs";
 import { mergeUiTranslations } from "../../../common/translations/merge-translations";
-import Spy = jasmine.Spy;
 
 @Component({
 	selector: `host-component`,
@@ -49,8 +42,8 @@ describe("RouteSearchComponent", () => {
 	let hostFixture: ComponentFixture<TestHostComponent>;
 	let translateService: TranslateService;
 
-	const mockRoutingService: StarkRoutingService = new MockStarkRoutingService();
-	const mockLoggingService: StarkLoggingService = new MockStarkLoggingService();
+	const mockRoutingService: MockStarkRoutingService = new MockStarkRoutingService();
+	const mockLoggingService: MockStarkLoggingService = new MockStarkLoggingService();
 
 	const moduleTranslationsEn: any = {
 		PATH: {
@@ -227,11 +220,11 @@ describe("RouteSearchComponent", () => {
 
 	describe("redirect", () => {
 		beforeEach(() => {
-			(<Spy>mockRoutingService.navigateTo).calls.reset();
+			mockRoutingService.navigateTo.calls.reset();
 		});
 
 		it("should redirect to the entry.targetState when the redirect method is called", () => {
-			(<Spy>mockRoutingService.navigateTo).and.returnValue(of("redirection succeeded"));
+			mockRoutingService.navigateTo.and.returnValue(of("redirection succeeded"));
 			const entry: StarkRouteSearchEntry = { label: "URL 1", targetState: "url1" };
 
 			component.redirect(entry);
@@ -241,7 +234,7 @@ describe("RouteSearchComponent", () => {
 		it("should clear the input text as soon as the redirection finishes", () => {
 			const searchFieldValue: string = "test";
 			component.searchField.setValue(searchFieldValue);
-			(<Spy>mockRoutingService.navigateTo).and.returnValue(of("redirection succeeded"));
+			mockRoutingService.navigateTo.and.returnValue(of("redirection succeeded"));
 			const entry: StarkRouteSearchEntry = { label: "URL 1", targetState: "url1" };
 			expect(component.searchField.value).toBe(searchFieldValue);
 
@@ -253,7 +246,7 @@ describe("RouteSearchComponent", () => {
 		it("should NOT clear the input text if the redirection failed", () => {
 			const searchFieldValue: string = "test";
 			component.searchField.setValue(searchFieldValue);
-			(<Spy>mockRoutingService.navigateTo).and.returnValue(throwError("redirection failed"));
+			mockRoutingService.navigateTo.and.returnValue(throwError("redirection failed"));
 			const entry: StarkRouteSearchEntry = { label: "URL 1", targetState: "url1" };
 			expect(component.searchField.value).toBe(searchFieldValue);
 
@@ -456,8 +449,8 @@ describe("RouteSearchComponent", () => {
 				}
 			];
 
-			(<Spy>mockRoutingService.getStatesConfig).and.returnValue(mockStates);
-			(<Spy>mockRoutingService.getTranslationKeyFromState).and.callFake((stateName: string) => {
+			mockRoutingService.getStatesConfig.and.returnValue(mockStates);
+			mockRoutingService.getTranslationKeyFromState.and.callFake((stateName: string) => {
 				return stateName.toUpperCase();
 			});
 
@@ -507,12 +500,17 @@ describe("RouteSearchComponent", () => {
 				}
 			];
 
-			(<Spy>mockRoutingService.getStatesConfig).and.returnValue(mockStates);
-			(<Spy>mockRoutingService.getTranslationKeyFromState).and.callFake((stateName: string) => {
+			mockRoutingService.getStatesConfig.and.returnValue(mockStates);
+			mockRoutingService.getTranslationKeyFromState.and.callFake((stateName: string) => {
 				return stateName.toUpperCase();
 			});
 
-			const expectedRouteEntries: StarkRouteSearchEntry[] = [{ label: "PAGE-01-01-01-01-01", targetState: "page-01-01-01-01-01" }];
+			const expectedRouteEntries: StarkRouteSearchEntry[] = [
+				{
+					label: "PAGE-01-01-01-01-01",
+					targetState: "page-01-01-01-01-01"
+				}
+			];
 			component.menuConfig = undefined;
 			const result: StarkRouteSearchEntry[] = component.constructRouteEntriesFromRouterStates();
 

--- a/packages/stark-ui/src/modules/session-ui/components/session-timeout-warning-dialog.component.spec.ts
+++ b/packages/stark-ui/src/modules/session-ui/components/session-timeout-warning-dialog.component.spec.ts
@@ -6,7 +6,7 @@ import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing
 import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
 import { StarkSessionTimeoutWarningDialogComponent } from "./session-timeout-warning-dialog.component";
 import { Observer } from "rxjs";
-import Spy = jasmine.Spy;
+import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
 
 describe("SessionTimeoutWarningDialogComponent", () => {
@@ -34,12 +34,12 @@ describe("SessionTimeoutWarningDialogComponent", () => {
 		mockDialogRef = TestBed.get(MatDialogRef);
 		component = fixture.componentInstance;
 
-		(<Spy>mockLogger.debug).calls.reset();
+		mockLogger.debug.calls.reset();
 	});
 
 	describe("ngOnInit", () => {
 		it("should set the countdown and decrement it every second", fakeAsync(() => {
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			component.ngOnInit();
 			component.countdown$.subscribe(mockObserver);

--- a/packages/stark-ui/src/modules/session-ui/effects/session-timeout-warning.effect.spec.ts
+++ b/packages/stark-ui/src/modules/session-ui/effects/session-timeout-warning.effect.spec.ts
@@ -19,12 +19,12 @@ import { StarkSessionTimeoutWarningDialogComponent } from "../components/session
 import { StarkSessionTimeoutWarningDialogEffects } from "../effects/session-timeout-warning.effects";
 import { STARK_SESSION_UI_CONFIG, StarkSessionUiConfig } from "../entities/stark-session-ui-config";
 import createSpyObj = jasmine.createSpyObj;
-import Spy = jasmine.Spy;
+import SpyObj = jasmine.SpyObj;
 
 describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 	let effectsClass: StarkSessionTimeoutWarningDialogEffects;
 	let mockSessionService: StarkSessionService;
-	let mockDialogService: MatDialog;
+	let mockDialogService: SpyObj<MatDialog>;
 	let mockSessionUiConfig: StarkSessionUiConfig;
 	let actions: Observable<any>;
 
@@ -67,13 +67,13 @@ describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 			const afterClosedResult: string = "keep-logged";
 			const afterClosed$: Subject<string> = new Subject();
 
-			(<Spy>mockDialogService.open).and.returnValue({
+			mockDialogService.open.and.returnValue({
 				afterClosed: () => {
 					return afterClosed$;
 				}
 			});
 
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 			const subject: ReplaySubject<any> = new ReplaySubject(1);
 			actions = subject.asObservable();
 
@@ -101,7 +101,7 @@ describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 
 	describe("On StarkSessionTimeoutWarningClose$", () => {
 		it("Should close the dialog when the countdown finishes", () => {
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			const subject: ReplaySubject<any> = new ReplaySubject(1);
 			actions = subject.asObservable();
@@ -121,7 +121,7 @@ describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 
 	describe("On ngrxOnRunEffects", () => {
 		it("Should stop the effects immediately when the option timeoutWarningDialogDisabled is true", () => {
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			const actions$: ReplaySubject<any> = new ReplaySubject(1);
 			actions = actions$.asObservable();
@@ -137,7 +137,7 @@ describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 
 			resolvedEffectsObservable.subscribe(mockObserver);
 
-			(<Spy>mockObserver.next).calls.reset();
+			mockObserver.next.calls.reset();
 
 			actions$.next("dummy acton");
 			actions$.next("another dummy acton");
@@ -151,7 +151,7 @@ describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 		});
 
 		it("Should run the effects immediately when the option timeoutWarningDialogDisabled is false", () => {
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			const actions$: ReplaySubject<any> = new ReplaySubject(1);
 			actions = actions$.asObservable();
@@ -174,7 +174,7 @@ describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 			expect(mockObserver.error).not.toHaveBeenCalled();
 			expect(mockObserver.complete).not.toHaveBeenCalled();
 
-			(<Spy>mockObserver.next).calls.reset();
+			mockObserver.next.calls.reset();
 
 			// the effects should keep on running with any action
 			actions$.next("dummy action1");
@@ -186,7 +186,7 @@ describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 		});
 
 		it("Should run the effects immediately when the option timeoutWarningDialogDisabled is undefined", () => {
-			const mockObserver: Observer<any> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
 
 			const actions$: ReplaySubject<any> = new ReplaySubject(1);
 			actions = actions$.asObservable();
@@ -209,7 +209,7 @@ describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 			expect(mockObserver.error).not.toHaveBeenCalled();
 			expect(mockObserver.complete).not.toHaveBeenCalled();
 
-			(<Spy>mockObserver.next).calls.reset();
+			mockObserver.next.calls.reset();
 
 			// the effects should keep on running with any action
 			actions$.next("dummy action1");

--- a/packages/stark-ui/src/modules/session-ui/pages/login/login-page.component.spec.ts
+++ b/packages/stark-ui/src/modules/session-ui/pages/login/login-page.component.spec.ts
@@ -6,10 +6,7 @@ import {
 	STARK_ROUTING_SERVICE,
 	STARK_SESSION_SERVICE,
 	STARK_USER_SERVICE,
-	StarkRoutingService,
-	StarkSessionService,
-	StarkUser,
-	StarkUserService
+	StarkUser
 } from "@nationalbankbelgium/stark-core";
 import {
 	MockStarkLoggingService,
@@ -20,16 +17,15 @@ import {
 import { TranslateModule } from "@ngx-translate/core";
 import { RawParams } from "@uirouter/core";
 import { StarkLoginPageComponent } from "./login-page.component";
-import Spy = jasmine.Spy;
 
 describe("LoginPageComponent", () => {
 	let component: StarkLoginPageComponent;
 	let fixture: ComponentFixture<StarkLoginPageComponent>;
 
 	const mockLogger: MockStarkLoggingService = new MockStarkLoggingService();
-	const mockUserService: StarkUserService = new MockStarkUserService();
-	const mockSessionService: StarkSessionService = new MockStarkSessionService();
-	const mockRoutingService: StarkRoutingService = new MockStarkRoutingService();
+	const mockUserService: MockStarkUserService = new MockStarkUserService();
+	const mockSessionService: MockStarkSessionService = new MockStarkSessionService();
+	const mockRoutingService: MockStarkRoutingService = new MockStarkRoutingService();
 	const mockUser: StarkUser = { firstName: "John", lastName: "Doe", username: "jdoe", uuid: "mock-uuid", roles: [] };
 
 	const mockUserWithRoles: StarkUser = {
@@ -57,9 +53,9 @@ describe("LoginPageComponent", () => {
 		fixture = TestBed.createComponent(StarkLoginPageComponent);
 		component = fixture.componentInstance;
 
-		(<Spy>mockSessionService.login).calls.reset();
-		(<Spy>mockRoutingService.navigateTo).calls.reset();
-		(<Spy>mockRoutingService.navigateToHome).calls.reset();
+		mockSessionService.login.calls.reset();
+		mockRoutingService.navigateTo.calls.reset();
+		mockRoutingService.navigateToHome.calls.reset();
 	});
 
 	describe("on initialization", () => {
@@ -111,8 +107,8 @@ describe("LoginPageComponent", () => {
 			expect(mockRoutingService.navigateTo).not.toHaveBeenCalled();
 			expect(mockRoutingService.navigateToHome).toHaveBeenCalledTimes(1);
 
-			(<Spy>mockSessionService.login).calls.reset();
-			(<Spy>mockRoutingService.navigateToHome).calls.reset();
+			mockSessionService.login.calls.reset();
+			mockRoutingService.navigateToHome.calls.reset();
 			const mockState: string = "mock-state";
 			const mockStateParams: RawParams = {
 				param: "mock-state-param"

--- a/packages/stark-ui/src/modules/session-ui/pages/preloading/preloading-page.component.spec.ts
+++ b/packages/stark-ui/src/modules/session-ui/pages/preloading/preloading-page.component.spec.ts
@@ -6,10 +6,7 @@ import {
 	STARK_ROUTING_SERVICE,
 	STARK_SESSION_SERVICE,
 	STARK_USER_SERVICE,
-	StarkRoutingService,
-	StarkSessionService,
-	StarkUser,
-	StarkUserService
+	StarkUser
 } from "@nationalbankbelgium/stark-core";
 import {
 	MockStarkLoggingService,
@@ -21,7 +18,6 @@ import { TranslateModule } from "@ngx-translate/core";
 import { MatButtonModule } from "@angular/material/button";
 import { of, throwError } from "rxjs";
 import { StarkPreloadingPageComponent } from "./preloading-page.component";
-import Spy = jasmine.Spy;
 
 describe("PreloadingPageComponent", () => {
 	let component: StarkPreloadingPageComponent;
@@ -29,9 +25,9 @@ describe("PreloadingPageComponent", () => {
 
 	const mockUser: StarkUser = { firstName: "John", lastName: "Doe", username: "jdoe", uuid: "mock-uuid", roles: [] };
 	const mockLogger: MockStarkLoggingService = new MockStarkLoggingService();
-	const mockUserService: StarkUserService = new MockStarkUserService();
-	const mockSessionService: StarkSessionService = new MockStarkSessionService();
-	const mockRoutingService: StarkRoutingService = new MockStarkRoutingService();
+	const mockUserService: MockStarkUserService = new MockStarkUserService();
+	const mockSessionService: MockStarkSessionService = new MockStarkSessionService();
+	const mockRoutingService: MockStarkRoutingService = new MockStarkRoutingService();
 
 	beforeEach(async(() => {
 		return TestBed.configureTestingModule({
@@ -50,10 +46,10 @@ describe("PreloadingPageComponent", () => {
 		fixture = TestBed.createComponent(StarkPreloadingPageComponent);
 		component = fixture.componentInstance;
 
-		(<Spy>mockUserService.fetchUserProfile).calls.reset();
-		(<Spy>mockSessionService.login).calls.reset();
-		(<Spy>mockRoutingService.navigateTo).calls.reset();
-		(<Spy>mockRoutingService.navigateToHome).calls.reset();
+		mockUserService.fetchUserProfile.calls.reset();
+		mockSessionService.login.calls.reset();
+		mockRoutingService.navigateTo.calls.reset();
+		mockRoutingService.navigateToHome.calls.reset();
 	});
 
 	describe("on initialization", () => {
@@ -71,7 +67,7 @@ describe("PreloadingPageComponent", () => {
 
 	describe("ngOnInit", () => {
 		it("should log the user in automatically after fetching the user profile successfully", fakeAsync(() => {
-			(<Spy>mockUserService.fetchUserProfile).and.returnValue(of(mockUser));
+			mockUserService.fetchUserProfile.and.returnValue(of(mockUser));
 			component.loginDelay = 1; // override login delay to make unit tests faster
 
 			component.ngOnInit();
@@ -84,7 +80,7 @@ describe("PreloadingPageComponent", () => {
 		}));
 
 		it("should navigate to home or the target state if defined after fetching the user profile successfully", fakeAsync(() => {
-			(<Spy>mockUserService.fetchUserProfile).and.returnValue(of(mockUser));
+			mockUserService.fetchUserProfile.and.returnValue(of(mockUser));
 			component.loginDelay = 1; // override login delay to make unit tests faster
 
 			component.ngOnInit();
@@ -93,7 +89,7 @@ describe("PreloadingPageComponent", () => {
 			expect(mockRoutingService.navigateToHome).toHaveBeenCalledTimes(1);
 			expect(mockRoutingService.navigateTo).not.toHaveBeenCalled();
 
-			(<Spy>mockRoutingService.navigateToHome).calls.reset();
+			mockRoutingService.navigateToHome.calls.reset();
 			component.targetState = "dummy state";
 			component.targetStateParams = { someParam: "dummy param" };
 			component.ngOnInit();
@@ -105,7 +101,7 @@ describe("PreloadingPageComponent", () => {
 		}));
 
 		it("should NOT do anything when the user profile cannot be fetched", fakeAsync(() => {
-			(<Spy>mockUserService.fetchUserProfile).and.returnValue(throwError("could not fetch user profile"));
+			mockUserService.fetchUserProfile.and.returnValue(throwError("could not fetch user profile"));
 			component.loginDelay = 1; // override login delay to make unit tests faster
 
 			component.ngOnInit();

--- a/packages/stark-ui/src/modules/toast-notification/testing/toast-notification.mock.ts
+++ b/packages/stark-ui/src/modules/toast-notification/testing/toast-notification.mock.ts
@@ -1,5 +1,6 @@
-import { Observable } from "rxjs";
-import { StarkToastMessage, StarkToastNotificationResult, StarkToastNotificationService } from "@nationalbankbelgium/stark-ui";
+import { StarkToastNotificationService } from "@nationalbankbelgium/stark-ui";
+import SpyObj = jasmine.SpyObj;
+import createSpy = jasmine.createSpy;
 
 /**
  * Mock class of the {@link StarkToastNotificationService|StarkToastNotificationService}.
@@ -30,17 +31,17 @@ import { StarkToastMessage, StarkToastNotificationResult, StarkToastNotification
  * }
  * ```
  */
-export class MockStarkToastNotificationService implements StarkToastNotificationService {
+export class MockStarkToastNotificationService implements SpyObj<StarkToastNotificationService> {
 	/**
 	 * Returns an observable that will emit one of the possible StarkToastNotificationResult after the toast is closed
 	 * @param message - Message to be shown in the toast.
 	 * @returns Observable that will emit the result value as soon as the toast is closed.
 	 */
-	public show: (message: StarkToastMessage) => Observable<StarkToastNotificationResult> = jasmine.createSpy("show");
+	public show: SpyObj<StarkToastNotificationService>["show"] = createSpy("show");
 
 	/**
 	 * Hides the current toast and emits the corresponding result in the observable returned by the show() method
 	 * @param result - Result to be sent to the subscribers of the show method's observable
 	 */
-	public hide: (result?: StarkToastNotificationResult) => void = jasmine.createSpy("hide");
+	public hide: SpyObj<StarkToastNotificationService>["hide"] = createSpy("hide");
 }


### PR DESCRIPTION
ISSUES CLOSED: #1081

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1081


## What is the new behavior?
- The signature of every method in the Mock classes is now taken from the interface that it implements so there is no duplication anymore.
- On top of that, every method also has the Spy type so there is no need to cast those methods to use the Spy API in the unit tests.
- Adapted affected unit tests to simplify the code.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->