### PR TITLE
refactor(stark-demo): explicitly enable HTML5 Push State in the config of the UIRouterModule

### DIFF
--- a/showcase/src/app/app.module.ts
+++ b/showcase/src/app/app.module.ts
@@ -193,7 +193,7 @@ export const metaReducers: MetaReducer<State>[] = ENV !== "production" ? [logger
 		EffectsModule.forRoot([StarkErrorHandlingEffects]), // needed to set up the providers required for effects
 		UIRouterModule.forRoot({
 			states: APP_STATES,
-			useHash: !Boolean(history.pushState),
+			useHash: false, // to use Angular's PathLocationStrategy in order to support HTML5 Push State
 			otherwise: "otherwise",
 			config: routerConfigFn
 		}),

--- a/starter/src/app/app.module.ts
+++ b/starter/src/app/app.module.ts
@@ -164,7 +164,7 @@ export const metaReducers: MetaReducer<State>[] = ENV !== "production" ? [logger
 		EffectsModule.forRoot([]), // needed to set up the providers required for effects
 		UIRouterModule.forRoot({
 			states: APP_STATES,
-			useHash: !Boolean(history.pushState),
+			useHash: false, // to use Angular's PathLocationStrategy in order to support HTML5 Push State
 			otherwise: "otherwise",
 			config: routerConfigFn
 		}),


### PR DESCRIPTION
ISSUES CLOSED: #113

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #113


## What is the new behavior?
The `UIRouterModule` in Starter and Showcase is now configured to enable HTML5 Push State always. Before it was enabled based on a condition aimed to support old browsers that don't support HTML5 Push State such as IE lower than 10.

This is no longer relevant since we only targer IE 11 and it does support HTML5 History API.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```