### PR TITLE
feat(stark-ui): add component util method to check if an Output is wired up

### DIFF
--- a/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.spec.ts
+++ b/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.spec.ts
@@ -8,6 +8,9 @@ import { MatListModule } from "@angular/material/list";
 import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE } from "@nationalbankbelgium/stark-core";
 import { MockStarkLoggingService, MockStarkRoutingService } from "@nationalbankbelgium/stark-core/testing";
 import { StarkAppMenuItemComponent } from "./app-menu-item.component";
+import { Observer } from "rxjs";
+import createSpyObj = jasmine.createSpyObj;
+import SpyObj = jasmine.SpyObj;
 
 describe("StarkAppMenuItemComponent", () => {
 	let component: StarkAppMenuItemComponent;
@@ -88,17 +91,23 @@ describe("StarkAppMenuItemComponent", () => {
 		});
 
 		it("should dispatch activated event", () => {
-			spyOn(component.activated, "emit");
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			component.activated.subscribe(mockObserver);
 			component.isActive = true;
 			fixture.detectChanges();
-			expect(component.activated.emit).toHaveBeenCalledTimes(1);
+			expect(mockObserver.next).toHaveBeenCalledTimes(1);
+			expect(mockObserver.error).not.toHaveBeenCalled();
+			expect(mockObserver.complete).not.toHaveBeenCalled();
 		});
 
 		it("should dispatch deactivated event", () => {
-			spyOn(component.deactivated, "emit");
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			component.deactivated.subscribe(mockObserver);
 			component.isActive = false;
 			fixture.detectChanges();
-			expect(component.deactivated.emit).toHaveBeenCalledTimes(1);
+			expect(mockObserver.next).toHaveBeenCalledTimes(1);
+			expect(mockObserver.error).not.toHaveBeenCalled();
+			expect(mockObserver.complete).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.ts
+++ b/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.ts
@@ -22,6 +22,7 @@ import {
 } from "@nationalbankbelgium/stark-core";
 import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 import { StarkMenuGroup } from "./app-menu-group.intf";
+import { StarkComponentUtil } from "../../../util/component";
 
 /**
  * Name of the component
@@ -82,9 +83,13 @@ export class StarkAppMenuItemComponent extends AbstractStarkUiComponent implemen
 		}
 
 		if (isActive) {
-			this.activated.emit();
+			if (StarkComponentUtil.isOutputWiredUp(this.activated)) {
+				this.activated.emit();
+			}
 		} else {
-			this.deactivated.emit();
+			if (StarkComponentUtil.isOutputWiredUp(this.deactivated)) {
+				this.deactivated.emit();
+			}
 		}
 	}
 

--- a/packages/stark-ui/src/modules/collapsible/components/collapsible.component.ts
+++ b/packages/stark-ui/src/modules/collapsible/components/collapsible.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, EventEmitter, Inject, Input, OnInit, Output, Renderer2, ViewEncapsulation } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
+import { StarkComponentUtil } from "../../../util/component";
 
 /**
  * Name of the component
@@ -84,6 +85,8 @@ export class StarkCollapsibleComponent extends AbstractStarkUiComponent implemen
 	 */
 	public toggleCollapsible(): void {
 		this.isExpanded = !this.isExpanded;
-		this.isExpandedChange.emit(this.isExpanded);
+		if (StarkComponentUtil.isOutputWiredUp(this.isExpandedChange)) {
+			this.isExpandedChange.emit(this.isExpanded);
+		}
 	}
 }

--- a/packages/stark-ui/src/modules/date-picker/components/date-picker.component.ts
+++ b/packages/stark-ui/src/modules/date-picker/components/date-picker.component.ts
@@ -3,6 +3,7 @@ import { MatDatepicker, MatDatepickerInput, MatDatepickerInputEvent } from "@ang
 import moment from "moment";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
+import { StarkComponentUtil } from "../../../util/component";
 
 export type StarkDatePickerFilter = "OnlyWeekends" | "OnlyWeekdays" | ((date: Date) => boolean) | undefined;
 
@@ -170,7 +171,7 @@ export class StarkDatePickerComponent extends AbstractStarkUiComponent implement
 	 * @param event - The MatDatepickerInputEvent to re-emit
 	 */
 	public onDateChange(event: MatDatepickerInputEvent<moment.Moment>): void {
-		if (event.value) {
+		if (event.value && StarkComponentUtil.isOutputWiredUp(this.dateChanged)) {
 			this.dateChanged.emit(event.value.toDate());
 		}
 	}

--- a/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker.component.ts
+++ b/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker.component.ts
@@ -4,6 +4,7 @@ import moment from "moment";
 import { StarkDatePickerComponent, StarkDatePickerFilter } from "../../date-picker/components/date-picker.component";
 import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 import { StarkDateRangePickerEvent } from "./date-range-picker-event.intf";
+import { StarkComponentUtil } from "../../../util/component";
 
 /**
  * Name of the component
@@ -161,9 +162,11 @@ export class StarkDateRangePickerComponent extends AbstractStarkUiComponent impl
 			this.endDate = undefined;
 			this.endPicker.pickerInput.value = undefined;
 		}
-		this.dateRangeChanged.emit({
-			startDate: this.startDate,
-			endDate: this.endDate
-		});
+		if (StarkComponentUtil.isOutputWiredUp(this.dateRangeChanged)) {
+			this.dateRangeChanged.emit({
+				startDate: this.startDate,
+				endDate: this.endDate
+			});
+		}
 	}
 }

--- a/packages/stark-ui/src/modules/dropdown/components/dropdown.component.ts
+++ b/packages/stark-ui/src/modules/dropdown/components/dropdown.component.ts
@@ -138,7 +138,7 @@ export class StarkDropdownComponent extends AbstractStarkUiComponent implements 
 	 * This will emit the newly selected value.
 	 */
 	@Output()
-	public selectionChanged?: EventEmitter<any> = new EventEmitter<any>();
+	public selectionChanged: EventEmitter<any> = new EventEmitter<any>();
 
 	/**
 	 * Whether the multiple row selection is enabled.
@@ -201,7 +201,7 @@ export class StarkDropdownComponent extends AbstractStarkUiComponent implements 
 					distinctUntilChanged()
 				)
 				.subscribe((value: any) => {
-					if (this.selectionChanged) {
+					if (StarkComponentUtil.isOutputWiredUp(this.selectionChanged)) {
 						this.selectionChanged.emit(value);
 					}
 				});

--- a/packages/stark-ui/src/modules/generic-search/components/generic-search/generic-search.component.ts
+++ b/packages/stark-ui/src/modules/generic-search/components/generic-search/generic-search.component.ts
@@ -31,6 +31,7 @@ import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium
 import { FormGroup } from "@angular/forms";
 import { animate, AnimationTriggerMetadata, state, style, transition, trigger } from "@angular/animations";
 import { AbstractStarkUiComponent } from "../../../../common/classes/abstract-component";
+import { StarkComponentUtil } from "../../../../util/component";
 
 /**
  * @ignore
@@ -185,7 +186,7 @@ export class StarkGenericSearchComponent extends AbstractStarkUiComponent implem
 	 * A boolean is passed as parameter to indicate whether the generic form is visible or not.
 	 */
 	@Output()
-	public formVisibilityChanged?: EventEmitter<boolean> = new EventEmitter<boolean>();
+	public formVisibilityChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
 
 	/**
 	 * Reference to the child search form component. Such component is looked up by the `searchForm` template reference variable.
@@ -482,7 +483,9 @@ export class StarkGenericSearchComponent extends AbstractStarkUiComponent implem
 			id: "search-action-bar",
 			isVisible: true,
 			actionCall: (): void => {
-				this.searchTriggered.emit(this.genericForm);
+				if (StarkComponentUtil.isOutputWiredUp(this.searchTriggered)) {
+					this.searchTriggered.emit(this.genericForm);
+				}
 			}
 		};
 
@@ -497,7 +500,7 @@ export class StarkGenericSearchComponent extends AbstractStarkUiComponent implem
 			className: predefinedResetAction.className,
 			id: "undo-action-bar",
 			actionCall: (): void => {
-				if (this.resetTriggered) {
+				if (StarkComponentUtil.isOutputWiredUp(this.resetTriggered)) {
 					this.resetTriggered.emit(this.genericForm);
 				}
 			}
@@ -514,7 +517,7 @@ export class StarkGenericSearchComponent extends AbstractStarkUiComponent implem
 			className: predefinedNewAction.className,
 			id: "new-action-bar",
 			actionCall: (): void => {
-				if (this.newTriggered) {
+				if (StarkComponentUtil.isOutputWiredUp(this.newTriggered)) {
 					this.newTriggered.emit();
 				}
 			}
@@ -530,7 +533,9 @@ export class StarkGenericSearchComponent extends AbstractStarkUiComponent implem
 	 * Emit the form through "searchTriggered" event emitter then hide the search form based on hideOnSearch variable
 	 */
 	public triggerSearch(): void {
-		this.searchTriggered.emit(this.genericForm);
+		if (StarkComponentUtil.isOutputWiredUp(this.searchTriggered)) {
+			this.searchTriggered.emit(this.genericForm);
+		}
 		if (this.hideOnSearch) {
 			this.hideForm();
 		}
@@ -544,7 +549,7 @@ export class StarkGenericSearchComponent extends AbstractStarkUiComponent implem
 			this.isFormHidden = true;
 
 			// by the moment, the callback is called only when the form is hidden
-			if (this.formVisibilityChanged) {
+			if (StarkComponentUtil.isOutputWiredUp(this.formVisibilityChanged)) {
 				this.formVisibilityChanged.emit(!this.isFormHidden);
 			}
 		}

--- a/packages/stark-ui/src/modules/minimap/components/minimap.component.ts
+++ b/packages/stark-ui/src/modules/minimap/components/minimap.component.ts
@@ -1,6 +1,7 @@
 import { Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewEncapsulation } from "@angular/core";
 import { StarkMinimapItemProperties } from "./item-properties.intf";
 import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
+import { StarkComponentUtil } from "../../../util/component";
 
 export type StarkMinimapComponentMode = "compact";
 
@@ -69,7 +70,9 @@ export class StarkMinimapComponent extends AbstractStarkUiComponent {
 	public handleCheckboxClick(event: Event, item: StarkMinimapItemProperties): void {
 		event.stopPropagation();
 		event.preventDefault();
-		this.showHideItem.emit(item);
+		if (StarkComponentUtil.isOutputWiredUp(this.showHideItem)) {
+			this.showHideItem.emit(item);
+		}
 	}
 
 	/**

--- a/packages/stark-ui/src/modules/pagination/components/pagination.component.ts
+++ b/packages/stark-ui/src/modules/pagination/components/pagination.component.ts
@@ -18,6 +18,7 @@ import { MatPaginator, MatPaginatorIntl, PageEvent } from "@angular/material/pag
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkPaginationConfig } from "./pagination-config.intf";
 import { StarkPaginateEvent } from "./paginate-event.intf";
+import { StarkComponentUtil } from "../../../util/component";
 
 /**
  * @ignore
@@ -276,10 +277,12 @@ export class StarkPaginationComponent extends MatPaginator implements OnInit, On
 			typeof this.paginationConfig.page === "number" &&
 			typeof this.paginationConfig.itemsPerPage === "number"
 		) {
-			this.paginated.emit({
-				page: this.paginationConfig.page,
-				itemsPerPage: this.paginationConfig.itemsPerPage
-			});
+			if (StarkComponentUtil.isOutputWiredUp(this.paginated)) {
+				this.paginated.emit({
+					page: this.paginationConfig.page,
+					itemsPerPage: this.paginationConfig.itemsPerPage
+				});
+			}
 
 			this.setMatPaginatorProperties(this.paginationConfig);
 			this.emitMatPaginationEvent();

--- a/packages/stark-ui/src/modules/slider/components/slider.component.spec.ts
+++ b/packages/stark-ui/src/modules/slider/components/slider.component.spec.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:completed-docs max-inline-declarations */
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
-import { Component, EventEmitter, ViewChild } from "@angular/core";
+import { Component, ViewChild } from "@angular/core";
 import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE } from "@nationalbankbelgium/stark-core";
 import { MockStarkLoggingService, MockStarkRoutingService } from "@nationalbankbelgium/stark-core/testing";
 import { StarkSliderComponent } from "./slider.component";
@@ -82,7 +82,7 @@ describe("SliderComponent", () => {
 
 		spyOn(component.noUiSliderLibrary, "create").and.callThrough();
 		spyOn(component, "updateSliderInstanceValues").and.callThrough();
-		spyOn(<EventEmitter<number[]>>component.changed, "emit").and.callThrough();
+		spyOn(component.changed, "emit").and.callThrough();
 
 		/***
 		 * The stage
@@ -177,8 +177,8 @@ describe("SliderComponent", () => {
 
 			expect(component.values).toEqual(dummyUnencodedValues);
 			expect(component.latestUnencodedValues).toBe(dummyUnencodedValues);
-			expect((<EventEmitter<number[]>>component.changed).emit).toHaveBeenCalledTimes(1);
-			expect((<EventEmitter<number[]>>component.changed).emit).toHaveBeenCalledWith(component.values);
+			expect(component.changed.emit).toHaveBeenCalledTimes(1);
+			expect(component.changed.emit).toHaveBeenCalledWith(component.values);
 		});
 
 		it("should not update the slider instance when the same values are used", () => {
@@ -202,7 +202,7 @@ describe("SliderComponent", () => {
 
 			expect(component.values).toBe(mockValues);
 			expect(component.latestUnencodedValues).toBeUndefined();
-			expect((<EventEmitter<number[]>>component.changed).emit).not.toHaveBeenCalled();
+			expect(component.changed.emit).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/stark-ui/src/modules/slider/components/slider.component.ts
+++ b/packages/stark-ui/src/modules/slider/components/slider.component.ts
@@ -17,7 +17,7 @@ import * as noUiSliderLibrary from "nouislider";
 
 import { STARK_LOGGING_SERVICE, STARK_ROUTING_SERVICE, StarkLoggingService, StarkRoutingService } from "@nationalbankbelgium/stark-core";
 
-import { StarkDOMUtil } from "../../../util/dom/dom.util";
+import { StarkDOMUtil, StarkComponentUtil } from "../../../util";
 import { StarkSliderConfig } from "./slider-config.intf";
 import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
@@ -74,7 +74,7 @@ export class StarkSliderComponent extends AbstractStarkUiComponent implements Af
 	 * Event to be emitted when the slider's value(s) change.
 	 */
 	@Output()
-	public changed?: EventEmitter<number[]> = new EventEmitter();
+	public changed: EventEmitter<number[]> = new EventEmitter<number[]>();
 
 	/**
 	 * Stores the latest value, to be able to see if values have been changed
@@ -162,7 +162,7 @@ export class StarkSliderComponent extends AbstractStarkUiComponent implements Af
 				this.values = unencodedValues;
 				this.latestUnencodedValues = unencodedValues;
 
-				if (this.changed) {
+				if (StarkComponentUtil.isOutputWiredUp(this.changed)) {
 					this.changed.emit(this.values);
 				}
 			}

--- a/packages/stark-ui/src/modules/table/components/column.component.ts
+++ b/packages/stark-ui/src/modules/table/components/column.component.ts
@@ -19,6 +19,7 @@ import { AbstractStarkUiComponent } from "../../../common/classes/abstract-compo
 import { FormControl } from "@angular/forms";
 import { distinctUntilChanged } from "rxjs/operators";
 import { StarkColumnFilterChangedOutput, StarkColumnSortChangedOutput, StarkTableColumnSortingDirection } from "../entities";
+import { StarkComponentUtil } from "../../../util/component";
 
 /**
  * @ignore
@@ -201,10 +202,7 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent implemen
 
 		this._filterFormCtrl.valueChanges.pipe(distinctUntilChanged()).subscribe((value?: string | null) => {
 			this.filterValue = value === null ? undefined : value;
-			this.filterChanged.emit({
-				filterValue: this.filterValue,
-				name: this.name
-			});
+			this.onFilterChange();
 		});
 	}
 
@@ -283,19 +281,26 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent implemen
 	 * Called whenever the value of the filter input changes
 	 */
 	public onFilterChange(): void {
-		this.filterChanged.emit(this);
+		if (StarkComponentUtil.isOutputWiredUp(this.filterChanged)) {
+			this.filterChanged.emit({
+				filterValue: this.filterValue,
+				name: this.name
+			});
+		}
 	}
 
 	/**
 	 * Called whenever the sorting of the column changes
 	 */
 	public onSortChange(): void {
-		this.sortChanged.emit({
-			name: this.name,
-			sortable: this.sortable,
-			sortDirection: this.sortDirection,
-			sortPriority: this.sortPriority
-		});
+		if (StarkComponentUtil.isOutputWiredUp(this.sortChanged)) {
+			this.sortChanged.emit({
+				name: this.name,
+				sortable: this.sortable,
+				sortDirection: this.sortDirection,
+				sortPriority: this.sortPriority
+			});
+		}
 	}
 
 	/**

--- a/packages/stark-ui/src/modules/table/components/table.component.spec.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.spec.ts
@@ -16,14 +16,16 @@ import { HAMMER_LOADER } from "@angular/platform-browser";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { STARK_LOGGING_SERVICE } from "@nationalbankbelgium/stark-core";
 import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
-import { Subject } from "rxjs";
+import { Observer, Subject } from "rxjs";
 import { StarkTableMultisortDialogComponent } from "./dialogs/multisort.component";
 import { StarkTableComponent } from "./table.component";
 import { StarkTableColumnComponent } from "./column.component";
 import { StarkPaginationComponent } from "../../pagination/components";
 import { StarkTableColumnFilter, StarkTableColumnProperties, StarkTableFilter, StarkTableRowActions } from "../entities";
-import Spy = jasmine.Spy;
 import createSpy = jasmine.createSpy;
+import createSpyObj = jasmine.createSpyObj;
+import Spy = jasmine.Spy;
+import SpyObj = jasmine.SpyObj;
 
 @Component({
 	selector: `host-component`,
@@ -1092,7 +1094,8 @@ describe("TableComponent", () => {
 		});
 
 		it("should emit event when row is selected", () => {
-			spyOn(component.selectChanged, "emit");
+			const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+			component.selectChanged.subscribe(mockObserver);
 
 			const checkboxElement: HTMLElement | null = hostFixture.nativeElement.querySelector("table tbody tr input[type=checkbox]");
 			if (!checkboxElement) {
@@ -1102,7 +1105,10 @@ describe("TableComponent", () => {
 			triggerClick(checkboxElement);
 			hostFixture.detectChanges();
 
-			expect(component.selectChanged.emit).toHaveBeenCalledWith([dummyData[0]]);
+			expect(mockObserver.next).toHaveBeenCalledTimes(1);
+			expect(mockObserver.next).toHaveBeenCalledWith([dummyData[0]]);
+			expect(mockObserver.error).not.toHaveBeenCalled();
+			expect(mockObserver.complete).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/stark-ui/src/modules/table/components/table.component.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.ts
@@ -43,7 +43,7 @@ import { StarkPaginateEvent } from "../../pagination/components/paginate-event.i
 import { StarkComponentUtil } from "../../../util/component";
 import { FormControl } from "@angular/forms";
 import { distinctUntilChanged } from "rxjs/operators";
-import { StarkMinimapComponentMode, StarkMinimapItemProperties } from "@nationalbankbelgium/stark-ui";
+import { StarkMinimapComponentMode, StarkMinimapItemProperties } from "../../minimap";
 
 /**
  * Name of the component
@@ -392,7 +392,9 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 
 		this._globalFilterFormCtrl.valueChanges.pipe(distinctUntilChanged()).subscribe((value?: string | null) => {
 			this.filter.globalFilterValue = value === null ? undefined : value;
-			this.filterChanged.emit(this.filter);
+			if (StarkComponentUtil.isOutputWiredUp(this.filterChanged)) {
+				this.filterChanged.emit(this.filter);
+			}
 
 			if (value) {
 				this.dataSource.filter = value.trim().toLowerCase();
@@ -411,7 +413,9 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 	public ngOnChanges(changes: SimpleChanges): void {
 		if (changes["data"] && !changes["data"].isFirstChange()) {
 			if (this.resetFilterValueOnDataChange()) {
-				this.filterChanged.emit(this.filter);
+				if (StarkComponentUtil.isOutputWiredUp(this.filterChanged)) {
+					this.filterChanged.emit(this.filter);
+				}
 				this.applyFilter();
 			}
 
@@ -530,7 +534,9 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 		// so we just re-emit the event from the Stark Pagination component (online mode)
 		if (this.paginationChanged.observers.length > 0) {
 			this.starkPaginator.paginated.subscribe((paginateEvent: StarkPaginateEvent) => {
-				this.paginationChanged.emit(paginateEvent);
+				if (StarkComponentUtil.isOutputWiredUp(this.paginationChanged)) {
+					this.paginationChanged.emit(paginateEvent);
+				}
 			});
 		} else {
 			// if there are no observers, then the data will be paginated internally in the MatTable via the Stark paginator event (offline mode)
@@ -653,7 +659,9 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 				}
 			}
 
-			this.filterChanged.emit(this.filter);
+			if (StarkComponentUtil.isOutputWiredUp(this.filterChanged)) {
+				this.filterChanged.emit(this.filter);
+			}
 		}
 	}
 
@@ -728,7 +736,9 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 		}
 		this._selectionSub = this.selection.changed.subscribe((change: SelectionChange<object>) => {
 			const selected: object[] = change.source.selected;
-			this.selectChanged.emit(selected);
+			if (StarkComponentUtil.isOutputWiredUp(this.selectChanged)) {
+				this.selectChanged.emit(selected);
+			}
 		});
 	}
 
@@ -907,7 +917,7 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 	 * @param row - The data object passed to the row
 	 */
 	public onRowClick(row: object): void {
-		if (this.rowClicked.observers.length > 0) {
+		if (StarkComponentUtil.isOutputWiredUp(this.rowClicked)) {
 			// If there is an observer, emit an event
 			this.rowClicked.emit(row);
 		} else if (this.rowsSelectable) {

--- a/packages/stark-ui/src/util/component/component.util.spec.ts
+++ b/packages/stark-ui/src/util/component/component.util.spec.ts
@@ -1,6 +1,8 @@
 import { StarkComponentUtil } from "./component.util";
+import { Component, EventEmitter, Output, ViewChild } from "@angular/core";
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 
-/* tslint:disable:no-big-function */
+/* tslint:disable:no-big-function completed-docs */
 describe("Util: ComponentUtil", () => {
 	describe("isInputEnabled", () => {
 		it("shouldReturnTrue", () => {
@@ -26,4 +28,70 @@ describe("Util: ComponentUtil", () => {
 			expect(result).toBe(false);
 		});
 	});
+
+	describe("isOutputWiredUp", () => {
+		let component: TestComponent;
+
+		beforeEach(async(() => {
+			return TestBed.configureTestingModule({
+				declarations: [TestHostWiredUpComponent, TestHostNotWiredUpComponent, TestComponent]
+			}).compileComponents();
+		}));
+
+		it("should return TRUE when there are observers on the passed event emitter", () => {
+			const hostFixture: ComponentFixture<TestHostWiredUpComponent> = TestBed.createComponent(TestHostWiredUpComponent);
+			const hostComponent: TestHostWiredUpComponent = hostFixture.componentInstance;
+			hostFixture.detectChanges(); // trigger initial data binding
+			component = hostComponent.testComponent;
+
+			expect(StarkComponentUtil.isOutputWiredUp(component.eventEmitter)).toBe(true);
+		});
+
+		it("should return FALSE when there is NO observer on the passed event emitter", () => {
+			const hostFixture: ComponentFixture<TestHostNotWiredUpComponent> = TestBed.createComponent(TestHostNotWiredUpComponent);
+			const hostComponent: TestHostNotWiredUpComponent = hostFixture.componentInstance;
+			hostFixture.detectChanges(); // trigger initial data binding
+
+			component = hostComponent.testComponent;
+
+			expect(StarkComponentUtil.isOutputWiredUp(component.eventEmitter)).toBe(false);
+		});
+	});
 });
+
+@Component({
+	selector: "test-component",
+	template: `
+		<span>Test component</span>
+	`
+})
+class TestComponent {
+	@Output()
+	public eventEmitter: EventEmitter<string> = new EventEmitter<string>();
+}
+
+@Component({
+	selector: "host-wired-up-component",
+	template: `
+		<test-component (eventEmitter)="wiredMethod()"></test-component>
+	`
+})
+class TestHostWiredUpComponent {
+	@ViewChild(TestComponent)
+	public testComponent: TestComponent;
+
+	public wiredMethod(): void {
+		console.log("Event emitted !");
+	}
+}
+
+@Component({
+	selector: "host-not-wired-up-component",
+	template: `
+		<test-component></test-component>
+	`
+})
+class TestHostNotWiredUpComponent {
+	@ViewChild(TestComponent)
+	public testComponent: TestComponent;
+}

--- a/packages/stark-ui/src/util/component/component.util.ts
+++ b/packages/stark-ui/src/util/component/component.util.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "@angular/core";
+
 /**
  * Stark specific Component commands
  */
@@ -8,5 +10,14 @@ export class StarkComponentUtil {
 	 */
 	public static isInputEnabled(input?: string): boolean {
 		return typeof input === "boolean" ? input : input === "true" || input === "";
+	}
+
+	/**
+	 * Check if passed eventEmitter is wired up or not.
+	 * That means if there is a method linked to this Output or not.
+	 * @param eventEmitter - EventEmitter to be checked
+	 */
+	public static isOutputWiredUp(eventEmitter: EventEmitter<any>): boolean {
+		return eventEmitter.observers.length > 0;
 	}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We emitted values through the Output of our components even if they were not used.

Issue Number: N/A


## What is the new behavior?

Thanks to a util method, we can check if an event emitter has observer and it is needed to emit on it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information