### PR TITLE
feat(stark-ui): implement Material dialogs presets: alert, confirm and prompt

### DIFF
--- a/packages/stark-ui/assets/stark-ui-bundle.scss
+++ b/packages/stark-ui/assets/stark-ui-bundle.scss
@@ -25,6 +25,11 @@
 @import "../src/modules/collapsible/components/collapsible.component";
 @import "../src/modules/collapsible/components/collapsible-theme";
 @import "../src/modules/date-range-picker/components/date-range-picker.component";
+@import "../src/modules/dialogs/components/alert-dialog-theme";
+@import "../src/modules/dialogs/components/alert-dialog.component";
+@import "../src/modules/dialogs/components/confirm-dialog-theme";
+@import "../src/modules/dialogs/components/prompt-dialog.component";
+@import "../src/modules/dialogs/components/prompt-dialog-theme";
 @import "../src/modules/generic-search/components/generic-search/generic-search.component";
 @import "../src/modules/language-selector/components/language-selector.component";
 @import "../src/modules/message-pane/components/message-pane.component";

--- a/packages/stark-ui/assets/styles/_material-fixes.scss
+++ b/packages/stark-ui/assets/styles/_material-fixes.scss
@@ -32,3 +32,12 @@
 .mat-button-wrapper .mat-icon {
   margin-top: -2.5px;
 }
+
+// FIXME: remove as soon as the MatDialogActions is adapted to align with Material Design guidelines: https://github.com/angular/material2/issues/14736
+mat-dialog-actions,
+[mat-dialog-actions],
+[matDialogActions] {
+  justify-content: flex-end;
+  align-items: flex-end;
+  margin-right: -16px;
+}

--- a/packages/stark-ui/src/modules.ts
+++ b/packages/stark-ui/src/modules.ts
@@ -9,6 +9,7 @@ export * from "./modules/breadcrumb";
 export * from "./modules/collapsible";
 export * from "./modules/date-picker";
 export * from "./modules/date-range-picker";
+export * from "./modules/dialogs";
 export * from "./modules/dropdown";
 export * from "./modules/generic-search";
 export * from "./modules/input-mask-directives";

--- a/packages/stark-ui/src/modules/dialogs.ts
+++ b/packages/stark-ui/src/modules/dialogs.ts
@@ -1,0 +1,2 @@
+export * from "./dialogs/dialogs.module";
+export * from "./dialogs/components";

--- a/packages/stark-ui/src/modules/dialogs/components.ts
+++ b/packages/stark-ui/src/modules/dialogs/components.ts
@@ -1,0 +1,6 @@
+export * from "./components/alert-dialog.component";
+export * from "./components/alert-dialog-content.intf";
+export * from "./components/confirm-dialog.component";
+export * from "./components/confirm-dialog-content.intf";
+export * from "./components/prompt-dialog.component";
+export * from "./components/prompt-dialog-content.intf";

--- a/packages/stark-ui/src/modules/dialogs/components/alert-dialog-content.intf.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/alert-dialog-content.intf.ts
@@ -1,0 +1,6 @@
+import { StarkBaseDialogContent } from "./dialog-content.intf";
+
+/**
+ * Content that can be shown in the {@link StarkAlertDialogComponent}
+ */
+export interface StarkAlertDialogContent extends StarkBaseDialogContent {}

--- a/packages/stark-ui/src/modules/dialogs/components/alert-dialog-theme.scss
+++ b/packages/stark-ui/src/modules/dialogs/components/alert-dialog-theme.scss
@@ -1,0 +1,9 @@
+.stark-alert-dialog {
+  [mat-dialog-title] {
+    color: mat-color($alert-palette, 500);
+  }
+  .button-ok {
+    background-color: mat-color($alert-palette, 500); 
+    color: mat-contrast($alert-palette, 500);
+  }
+}

--- a/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.html
+++ b/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.html
@@ -1,0 +1,10 @@
+<h2 mat-dialog-title>
+	<mat-icon svgIcon="alert" starkSvgViewBox></mat-icon>&nbsp;
+	<span>{{ content.title || "" | translate }}</span>
+</h2>
+
+<div mat-dialog-content>{{ content.textContent || "" | translate }}</div>
+
+<div mat-dialog-actions>
+	<button mat-raised-button (click)="onOk()" class="button-ok">{{ content.ok || "OK" | translate }}</button>
+</div>

--- a/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.scss
+++ b/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.scss
@@ -1,0 +1,6 @@
+.stark-alert-dialog {
+  h2 {
+    display: flex;
+    align-items: center;
+  }
+}

--- a/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.spec.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.spec.ts
@@ -1,0 +1,194 @@
+/* tslint:disable:completed-docs no-big-function */
+import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from "@angular/core/testing";
+import { CommonModule } from "@angular/common";
+import { Component, ComponentFactoryResolver, NO_ERRORS_SCHEMA } from "@angular/core";
+import { MatDialog, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { BrowserDynamicTestingModule } from "@angular/platform-browser-dynamic/testing";
+import { OverlayContainer } from "@angular/cdk/overlay";
+import { ESCAPE } from "@angular/cdk/keycodes";
+import { TranslateModule } from "@ngx-translate/core";
+import { Observer } from "rxjs";
+import { StarkAlertDialogContent } from "./alert-dialog-content.intf";
+import { StarkAlertDialogComponent, StarkAlertDialogResult } from "./alert-dialog.component";
+import createSpyObj = jasmine.createSpyObj;
+import SpyObj = jasmine.SpyObj;
+
+@Component({
+	selector: `host-component`,
+	template: `
+		no content
+	`
+})
+class TestHostComponent {}
+
+describe("AlertDialogComponent", () => {
+	let hostFixture: ComponentFixture<TestHostComponent>;
+	let hostComponent: TestHostComponent;
+	let dialogService: MatDialog;
+	let overlayContainer: OverlayContainer;
+	let overlayContainerElement: HTMLElement;
+	let dialogComponentSelector: string;
+	let mockObserver: SpyObj<Observer<StarkAlertDialogResult>>;
+
+	const dummyDialogContent: StarkAlertDialogContent = {
+		title: "This is the dialog title",
+		textContent: "Here goes the content",
+		ok: "Ok button label"
+	};
+
+	const matDialogSelector: string = "mat-dialog-container";
+	const matDialogTitleSelector: string = "[mat-dialog-title]";
+	const matDialogContentSelector: string = "[mat-dialog-content]";
+	const matDialogActionsSelector: string = "[mat-dialog-actions]";
+
+	function openDialog(dialogData: StarkAlertDialogContent): MatDialogRef<StarkAlertDialogComponent, StarkAlertDialogResult> {
+		return dialogService.open<StarkAlertDialogComponent, StarkAlertDialogContent, StarkAlertDialogResult>(StarkAlertDialogComponent, {
+			data: dialogData
+		});
+	}
+
+	function triggerClick(element: HTMLElement): void {
+		element.click();
+	}
+
+	/**
+	 * Angular Material dialogs listen to the Escape key on the keydown event
+	 */
+	function triggerKeydownEscape(element: HTMLElement): void {
+		// more verbose way to create and trigger an event (the only way it works in IE)
+		// https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events
+		const keydownEvent: Event = document.createEvent("Event");
+		keydownEvent.initEvent("keydown", true, true);
+		keydownEvent["key"] = "Escape";
+		keydownEvent["keyCode"] = ESCAPE;
+		element.dispatchEvent(keydownEvent);
+	}
+
+	beforeEach(async(() => {
+		return TestBed.configureTestingModule({
+			declarations: [TestHostComponent, StarkAlertDialogComponent],
+			imports: [CommonModule, NoopAnimationsModule, MatDialogModule, TranslateModule.forRoot()],
+			providers: [],
+			schemas: [NO_ERRORS_SCHEMA] // to avoid errors due to "mat-icon" directive not known (which we don't want to add in these tests)
+		})
+			.overrideModule(BrowserDynamicTestingModule, {
+				// add entryComponent to TestingModule (suggested in https://github.com/angular/angular/issues/12079)
+				set: { entryComponents: [StarkAlertDialogComponent] }
+			})
+			.compileComponents();
+	}));
+
+	beforeEach(inject(
+		[MatDialog, OverlayContainer, ComponentFactoryResolver],
+		(d: MatDialog, oc: OverlayContainer, cfr: ComponentFactoryResolver) => {
+			dialogService = d;
+			overlayContainer = oc;
+			overlayContainerElement = oc.getContainerElement();
+			dialogComponentSelector = cfr.resolveComponentFactory(StarkAlertDialogComponent).selector;
+		}
+	));
+
+	afterEach(() => {
+		overlayContainer.ngOnDestroy();
+	});
+
+	beforeEach(() => {
+		hostFixture = TestBed.createComponent(TestHostComponent);
+		hostComponent = hostFixture.componentInstance;
+		hostFixture.detectChanges();
+
+		mockObserver = createSpyObj<Observer<StarkAlertDialogResult>>("observerSpy", ["next", "error", "complete"]);
+	});
+
+	it("should be correctly opened via the MatDialog service", () => {
+		expect(hostComponent).toBeDefined();
+		expect(dialogService).toBeDefined();
+
+		const dialogRef: MatDialogRef<StarkAlertDialogComponent, StarkAlertDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		expect(dialogRef.componentInstance instanceof StarkAlertDialogComponent).toBe(true);
+
+		const dialogElement: HTMLElement | null = overlayContainerElement.querySelector<HTMLElement>(
+			matDialogSelector + " " + dialogComponentSelector
+		);
+
+		const dialogTitleElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogTitleSelector);
+		expect(dialogTitleElement).toBeDefined();
+		expect((<HTMLElement>dialogTitleElement).innerHTML).toContain(<string>dummyDialogContent.title);
+
+		const dialogContentElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogContentSelector);
+		expect(dialogContentElement).toBeDefined();
+		expect((<HTMLElement>dialogContentElement).innerHTML).toBe(<string>dummyDialogContent.textContent);
+
+		const dialogActionsElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogActionsSelector);
+		expect(dialogActionsElement).toBeDefined();
+		const dialogButtonElements: NodeListOf<HTMLElement> = (<HTMLElement>dialogActionsElement).querySelectorAll("button");
+		expect(dialogButtonElements.length).toBe(1);
+		expect(dialogButtonElements[0].innerHTML).toBe(<string>dummyDialogContent.ok);
+	});
+
+	it("should return 'ok' as result when the 'Ok' button is clicked", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkAlertDialogComponent, StarkAlertDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		const dialogElement: HTMLElement | null = overlayContainerElement.querySelector<HTMLElement>(
+			matDialogSelector + " " + dialogComponentSelector
+		);
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		const dialogActionsElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogActionsSelector);
+		expect(dialogActionsElement).toBeDefined();
+		const dialogButtonElements: NodeListOf<HTMLElement> = (<HTMLElement>dialogActionsElement).querySelectorAll("button");
+		expect(dialogButtonElements.length).toBe(1);
+
+		triggerClick(dialogButtonElements[0]);
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith("ok");
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+
+	it("should return undefined as result when it is cancelled by clicking outside of the dialog", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkAlertDialogComponent, StarkAlertDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		triggerClick(<HTMLElement>overlayContainerElement.querySelector(".cdk-overlay-backdrop")); // clicking on the backdrop
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith(undefined);
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+
+	it("should return undefined as result when it is cancelled by pressing the ESC key", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkAlertDialogComponent, StarkAlertDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		triggerKeydownEscape(overlayContainerElement); // pressing Esc key in the overlay
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith(undefined);
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+});

--- a/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.ts
@@ -1,0 +1,43 @@
+import { Component, Inject, ViewEncapsulation } from "@angular/core";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { StarkAlertDialogContent } from "./alert-dialog-content.intf";
+
+/**
+ * Possible results of the {@link StarkAlertDialogComponent} after being closed.
+ *
+ * - "ok": The user clicked on the "Ok" button
+ * - `undefined`: The dialog was cancelled by either clicking outside of dialog or by pressing the ESC key
+ */
+export type StarkAlertDialogResult = "ok" | undefined;
+
+/**
+ * Alert dialog component to be opened via the Angular Material's {@link MatDialog} service
+ */
+@Component({
+	selector: "stark-alert-dialog",
+	templateUrl: "./alert-dialog.component.html",
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: "stark-alert-dialog"
+	}
+})
+export class StarkAlertDialogComponent {
+	/**
+	 * Class constructor
+	 * @param dialogRef - Reference this dialog instance
+	 * @param content - Content to be shown in the alert dialog (dynamically translated via the Translate service if the
+	 * provided text is defined in the translation keys)
+	 */
+	public constructor(
+		public dialogRef: MatDialogRef<StarkAlertDialogComponent, StarkAlertDialogResult>,
+		@Inject(MAT_DIALOG_DATA) public content: StarkAlertDialogContent
+	) {}
+
+	/**
+	 * Callback method to be triggered when the "Ok" button is clicked
+	 */
+	public onOk(): void {
+		this.dialogRef.close("ok");
+	}
+}

--- a/packages/stark-ui/src/modules/dialogs/components/confirm-dialog-content.intf.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/confirm-dialog-content.intf.ts
@@ -1,0 +1,11 @@
+import { StarkBaseDialogContent } from "./dialog-content.intf";
+
+/**
+ * Content that can be shown in the {@link StarkConfirmDialogComponent}
+ */
+export interface StarkConfirmDialogContent extends StarkBaseDialogContent {
+	/**
+	 * Label to be set in the "Cancel" button.
+	 */
+	cancel?: string;
+}

--- a/packages/stark-ui/src/modules/dialogs/components/confirm-dialog-theme.scss
+++ b/packages/stark-ui/src/modules/dialogs/components/confirm-dialog-theme.scss
@@ -1,0 +1,6 @@
+.stark-confirm-dialog {
+  .button-ok {
+    background-color: mat-color($primary-palette, 500);
+    color: mat-contrast($primary-palette, 500);
+  }
+}

--- a/packages/stark-ui/src/modules/dialogs/components/confirm-dialog.component.html
+++ b/packages/stark-ui/src/modules/dialogs/components/confirm-dialog.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>{{ content.title || "" | translate }}</h2>
+
+<div mat-dialog-content>{{ content.textContent || "" | translate }}</div>
+
+<div mat-dialog-actions>
+	<button mat-button class="button-cancel" (click)="onCancel()">{{ content.cancel || "CANCEL" | translate }}</button>
+	<button mat-raised-button class="button-ok" cdkFocusInitial (click)="onOk()">{{ content.ok || "OK" | translate }}</button>
+</div>

--- a/packages/stark-ui/src/modules/dialogs/components/confirm-dialog.component.spec.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/confirm-dialog.component.spec.ts
@@ -1,0 +1,225 @@
+/* tslint:disable:completed-docs no-big-function no-identical-functions */
+import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from "@angular/core/testing";
+import { CommonModule } from "@angular/common";
+import { Component, ComponentFactoryResolver } from "@angular/core";
+import { MatDialog, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { BrowserDynamicTestingModule } from "@angular/platform-browser-dynamic/testing";
+import { OverlayContainer } from "@angular/cdk/overlay";
+import { ESCAPE } from "@angular/cdk/keycodes";
+import { TranslateModule } from "@ngx-translate/core";
+import { Observer } from "rxjs";
+import { StarkConfirmDialogContent } from "./confirm-dialog-content.intf";
+import { StarkConfirmDialogComponent, StarkConfirmDialogResult } from "./confirm-dialog.component";
+import createSpyObj = jasmine.createSpyObj;
+import SpyObj = jasmine.SpyObj;
+
+@Component({
+	selector: `host-component`,
+	template: `
+		no content
+	`
+})
+class TestHostComponent {}
+
+describe("ConfirmDialogComponent", () => {
+	let hostFixture: ComponentFixture<TestHostComponent>;
+	let hostComponent: TestHostComponent;
+	let dialogService: MatDialog;
+	let overlayContainer: OverlayContainer;
+	let overlayContainerElement: HTMLElement;
+	let dialogComponentSelector: string;
+	let mockObserver: SpyObj<Observer<StarkConfirmDialogResult>>;
+
+	const dummyDialogContent: StarkConfirmDialogContent = {
+		title: "This is the dialog title",
+		textContent: "Here goes the content",
+		ok: "Ok button label",
+		cancel: "Cancel button label"
+	};
+
+	const matDialogSelector: string = "mat-dialog-container";
+	const matDialogTitleSelector: string = "[mat-dialog-title]";
+	const matDialogContentSelector: string = "[mat-dialog-content]";
+	const matDialogActionsSelector: string = "[mat-dialog-actions]";
+
+	function openDialog(dialogData: StarkConfirmDialogContent): MatDialogRef<StarkConfirmDialogComponent, StarkConfirmDialogResult> {
+		return dialogService.open<StarkConfirmDialogComponent, StarkConfirmDialogContent, StarkConfirmDialogResult>(
+			StarkConfirmDialogComponent,
+			{
+				data: dialogData
+			}
+		);
+	}
+
+	function triggerClick(element: HTMLElement): void {
+		element.click();
+	}
+
+	/**
+	 * Angular Material dialogs listen to the Escape key on the keydown event
+	 */
+	function triggerKeydownEscape(element: HTMLElement): void {
+		// more verbose way to create and trigger an event (the only way it works in IE)
+		// https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events
+		const keydownEvent: Event = document.createEvent("Event");
+		keydownEvent.initEvent("keydown", true, true);
+		keydownEvent["key"] = "Escape";
+		keydownEvent["keyCode"] = ESCAPE;
+		element.dispatchEvent(keydownEvent);
+	}
+
+	beforeEach(async(() => {
+		return TestBed.configureTestingModule({
+			declarations: [TestHostComponent, StarkConfirmDialogComponent],
+			imports: [CommonModule, NoopAnimationsModule, MatDialogModule, TranslateModule.forRoot()],
+			providers: []
+		})
+			.overrideModule(BrowserDynamicTestingModule, {
+				// add entryComponent to TestingModule (suggested in https://github.com/angular/angular/issues/12079)
+				set: { entryComponents: [StarkConfirmDialogComponent] }
+			})
+			.compileComponents();
+	}));
+
+	beforeEach(inject(
+		[MatDialog, OverlayContainer, ComponentFactoryResolver],
+		(d: MatDialog, oc: OverlayContainer, cfr: ComponentFactoryResolver) => {
+			dialogService = d;
+			overlayContainer = oc;
+			overlayContainerElement = oc.getContainerElement();
+			dialogComponentSelector = cfr.resolveComponentFactory(StarkConfirmDialogComponent).selector;
+		}
+	));
+
+	afterEach(() => {
+		overlayContainer.ngOnDestroy();
+	});
+
+	beforeEach(() => {
+		hostFixture = TestBed.createComponent(TestHostComponent);
+		hostComponent = hostFixture.componentInstance;
+		hostFixture.detectChanges();
+
+		mockObserver = createSpyObj<Observer<StarkConfirmDialogResult>>("observerSpy", ["next", "error", "complete"]);
+	});
+
+	it("should be correctly opened via the MatDialog service", () => {
+		expect(hostComponent).toBeDefined();
+		expect(dialogService).toBeDefined();
+
+		const dialogRef: MatDialogRef<StarkConfirmDialogComponent, StarkConfirmDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		expect(dialogRef.componentInstance instanceof StarkConfirmDialogComponent).toBe(true);
+
+		const dialogElement: HTMLElement | null = overlayContainerElement.querySelector<HTMLElement>(
+			matDialogSelector + " " + dialogComponentSelector
+		);
+
+		const dialogTitleElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogTitleSelector);
+		expect(dialogTitleElement).toBeDefined();
+		expect((<HTMLElement>dialogTitleElement).innerHTML).toEqual(<string>dummyDialogContent.title);
+
+		const dialogContentElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogContentSelector);
+		expect(dialogContentElement).toBeDefined();
+		expect((<HTMLElement>dialogContentElement).innerHTML).toBe(<string>dummyDialogContent.textContent);
+
+		const dialogActionsElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogActionsSelector);
+		expect(dialogActionsElement).toBeDefined();
+		const dialogButtonElements: NodeListOf<HTMLElement> = (<HTMLElement>dialogActionsElement).querySelectorAll("button");
+		expect(dialogButtonElements.length).toBe(2);
+		expect(dialogButtonElements[0].innerHTML).toBe(<string>dummyDialogContent.cancel);
+		expect(dialogButtonElements[1].innerHTML).toBe(<string>dummyDialogContent.ok);
+	});
+
+	it("should return 'ok' as result when the 'Ok' button is clicked", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkConfirmDialogComponent, StarkConfirmDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		const dialogElement: HTMLElement | null = overlayContainerElement.querySelector<HTMLElement>(
+			matDialogSelector + " " + dialogComponentSelector
+		);
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		const dialogActionsElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogActionsSelector);
+		expect(dialogActionsElement).toBeDefined();
+		const dialogButtonElements: NodeListOf<HTMLElement> = (<HTMLElement>dialogActionsElement).querySelectorAll("button");
+		expect(dialogButtonElements.length).toBe(2);
+
+		triggerClick(dialogButtonElements[1]); // clicking the "ok" button
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith("ok");
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+
+	it("should return 'cancel' as result when the 'Cancel' button is clicked", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkConfirmDialogComponent, StarkConfirmDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		const dialogElement: HTMLElement | null = overlayContainerElement.querySelector<HTMLElement>(
+			matDialogSelector + " " + dialogComponentSelector
+		);
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		const dialogActionsElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogActionsSelector);
+		expect(dialogActionsElement).toBeDefined();
+		const dialogButtonElements: NodeListOf<HTMLElement> = (<HTMLElement>dialogActionsElement).querySelectorAll("button");
+		expect(dialogButtonElements.length).toBe(2);
+
+		triggerClick(dialogButtonElements[0]); // clicking the "cancel" button
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith("cancel");
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+
+	it("should return undefined as result when it is cancelled by clicking outside of the dialog", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkConfirmDialogComponent, StarkConfirmDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		triggerClick(<HTMLElement>overlayContainerElement.querySelector(".cdk-overlay-backdrop")); // clicking on the backdrop
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith(undefined);
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+
+	it("should return undefined as result when it is cancelled by pressing the ESC key", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkConfirmDialogComponent, StarkConfirmDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		triggerKeydownEscape(overlayContainerElement); // pressing Esc key in the overlay
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith(undefined);
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+});

--- a/packages/stark-ui/src/modules/dialogs/components/confirm-dialog.component.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/confirm-dialog.component.ts
@@ -1,0 +1,51 @@
+import { Component, Inject, ViewEncapsulation } from "@angular/core";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { StarkConfirmDialogContent } from "./confirm-dialog-content.intf";
+
+/**
+ * Possible results of the {@link StarkConfirmDialogComponent} after being closed.
+ *
+ * - "ok": The user clicked on the "Ok" button
+ * - "cancel": The dialog was cancelled by clicking on the "Cancel" button
+ * - `undefined`: The dialog was cancelled either by clicking outside of dialog or by pressing the ESC key
+ */
+export type StarkConfirmDialogResult = "ok" | "cancel" | undefined;
+
+/**
+ * Confirmation dialog component to be opened via the Angular Material's {@link MatDialog} service
+ */
+@Component({
+	selector: "stark-confirm-dialog",
+	templateUrl: "./confirm-dialog.component.html",
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: "stark-confirm-dialog"
+	}
+})
+export class StarkConfirmDialogComponent {
+	/**
+	 * Class constructor
+	 * @param dialogRef - Reference this dialog instance
+	 * @param content - Content to be shown in the confirmation dialog (dynamically translated via the [@link TranslateService} service if the
+	 * provided text is defined in the translation keys)
+	 */
+	public constructor(
+		public dialogRef: MatDialogRef<StarkConfirmDialogComponent, StarkConfirmDialogResult>,
+		@Inject(MAT_DIALOG_DATA) public content: StarkConfirmDialogContent
+	) {}
+
+	/**
+	 * Callback method to be triggered when the "Cancel" button is clicked
+	 */
+	public onCancel(): void {
+		this.dialogRef.close("cancel");
+	}
+
+	/**
+	 * Callback method to be triggered when the "Ok" button is clicked
+	 */
+	public onOk(): void {
+		this.dialogRef.close("ok");
+	}
+}

--- a/packages/stark-ui/src/modules/dialogs/components/dialog-content.intf.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/dialog-content.intf.ts
@@ -1,0 +1,20 @@
+/**
+ * Describes the basic content that can be shown in a predefined Dialog component from Stark.
+ * See: {@link StarkAlertDialogComponent}, {@link StarkConfirmDialogComponent}, {@link StarkPromptDialogComponent}
+ */
+export interface StarkBaseDialogContent {
+	/**
+	 * Dialog's title.
+	 */
+	title?: string;
+
+	/**
+	 * Dialog's simple text content.
+	 */
+	textContent?: string;
+
+	/**
+	 * Label to be set in the "Ok" button.
+	 */
+	ok?: string;
+}

--- a/packages/stark-ui/src/modules/dialogs/components/prompt-dialog-content.intf.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/prompt-dialog-content.intf.ts
@@ -1,0 +1,26 @@
+import { StarkBaseDialogContent } from "./dialog-content.intf";
+
+/**
+ * Content that can be shown in the {@link StarkPromptDialogComponent}
+ */
+export interface StarkPromptDialogContent extends StarkBaseDialogContent {
+	/**
+	 * Text to be shown as label of the prompt input.
+	 */
+	label?: string;
+
+	/**
+	 * Placeholder text of the prompt input.
+	 */
+	placeholder?: string;
+
+	/**
+	 * Initial value to be set to the prompt input.
+	 */
+	initialValue?: string;
+
+	/**
+	 * Label to be set in the "Cancel" button.
+	 */
+	cancel?: string;
+}

--- a/packages/stark-ui/src/modules/dialogs/components/prompt-dialog-theme.scss
+++ b/packages/stark-ui/src/modules/dialogs/components/prompt-dialog-theme.scss
@@ -1,0 +1,6 @@
+.stark-prompt-dialog {
+  .button-ok {
+    background-color: mat-color($primary-palette, 500);
+    color: mat-contrast($primary-palette, 500);
+  }
+}

--- a/packages/stark-ui/src/modules/dialogs/components/prompt-dialog.component.html
+++ b/packages/stark-ui/src/modules/dialogs/components/prompt-dialog.component.html
@@ -1,0 +1,17 @@
+<h2 mat-dialog-title>{{ content.title || "" | translate }}</h2>
+
+<div mat-dialog-content>
+	<span class="mat-caption">{{ content.textContent || "" | translate }}</span>
+
+	<mat-form-field class="prompt-text">
+		<mat-label translate>{{ content.label || content.placeholder }}</mat-label>
+		<input matInput [placeholder]="content.placeholder || '' | translate" [formControl]="formControl" />
+	</mat-form-field>
+</div>
+
+<div mat-dialog-actions>
+	<button mat-button class="button-cancel" (click)="onCancel()">{{ content.cancel || "CANCEL" | translate }}</button>
+	<button mat-raised-button class="button-ok" (click)="onOk()" [disabled]="!formControl.value">
+		{{ content.ok || "OK" | translate }}
+	</button>
+</div>

--- a/packages/stark-ui/src/modules/dialogs/components/prompt-dialog.component.scss
+++ b/packages/stark-ui/src/modules/dialogs/components/prompt-dialog.component.scss
@@ -1,0 +1,6 @@
+.stark-prompt-dialog {
+  .mat-form-field.prompt-text {
+    display: block;
+    margin: 16px 0;
+  }
+}

--- a/packages/stark-ui/src/modules/dialogs/components/prompt-dialog.component.spec.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/prompt-dialog.component.spec.ts
@@ -1,0 +1,234 @@
+/* tslint:disable:completed-docs no-big-function */
+import { async, ComponentFixture, fakeAsync, inject, TestBed, tick } from "@angular/core/testing";
+import { CommonModule } from "@angular/common";
+import { Component, ComponentFactoryResolver } from "@angular/core";
+import { ReactiveFormsModule } from "@angular/forms";
+import { MatDialog, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
+import { MatInputModule } from "@angular/material/input";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { BrowserDynamicTestingModule } from "@angular/platform-browser-dynamic/testing";
+import { OverlayContainer } from "@angular/cdk/overlay";
+import { ESCAPE } from "@angular/cdk/keycodes";
+import { TranslateModule } from "@ngx-translate/core";
+import { Observer } from "rxjs";
+import { StarkPromptDialogContent } from "./prompt-dialog-content.intf";
+import { StarkPromptDialogComponent, StarkPromptDialogResult } from "./prompt-dialog.component";
+import createSpyObj = jasmine.createSpyObj;
+import SpyObj = jasmine.SpyObj;
+
+@Component({
+	selector: `host-component`,
+	template: `
+		no content
+	`
+})
+class TestHostComponent {}
+
+describe("PromptDialogComponent", () => {
+	let hostFixture: ComponentFixture<TestHostComponent>;
+	let hostComponent: TestHostComponent;
+	let dialogService: MatDialog;
+	let overlayContainer: OverlayContainer;
+	let overlayContainerElement: HTMLElement;
+	let dialogComponentSelector: string;
+	let mockObserver: SpyObj<Observer<StarkPromptDialogResult>>;
+
+	const dummyDialogContent: StarkPromptDialogContent = {
+		title: "This is the dialog title",
+		textContent: "Here goes the content",
+		label: "The input's label",
+		placeholder: "The input's placeholder",
+		initialValue: "The input's initial value",
+		ok: "Ok button label",
+		cancel: "Cancel button label"
+	};
+
+	const matDialogSelector: string = "mat-dialog-container";
+	const matDialogTitleSelector: string = "[mat-dialog-title]";
+	const matDialogContentSelector: string = "[mat-dialog-content]";
+	const matDialogActionsSelector: string = "[mat-dialog-actions]";
+
+	function openDialog(dialogData: StarkPromptDialogContent): MatDialogRef<StarkPromptDialogComponent, StarkPromptDialogResult> {
+		return dialogService.open<StarkPromptDialogComponent, StarkPromptDialogContent, StarkPromptDialogResult>(
+			StarkPromptDialogComponent,
+			{
+				data: dialogData
+			}
+		);
+	}
+
+	function triggerClick(element: HTMLElement): void {
+		element.click();
+	}
+
+	/**
+	 * Angular Material dialogs listen to the Escape key on the keydown event
+	 */
+	function triggerKeydownEscape(element: HTMLElement): void {
+		// more verbose way to create and trigger an event (the only way it works in IE)
+		// https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events
+		const keydownEvent: Event = document.createEvent("Event");
+		keydownEvent.initEvent("keydown", true, true);
+		keydownEvent["key"] = "Escape";
+		keydownEvent["keyCode"] = ESCAPE;
+		element.dispatchEvent(keydownEvent);
+	}
+
+	beforeEach(async(() => {
+		return TestBed.configureTestingModule({
+			declarations: [TestHostComponent, StarkPromptDialogComponent],
+			imports: [CommonModule, ReactiveFormsModule, NoopAnimationsModule, MatInputModule, MatDialogModule, TranslateModule.forRoot()],
+			providers: []
+		})
+			.overrideModule(BrowserDynamicTestingModule, {
+				// add entryComponent to TestingModule (suggested in https://github.com/angular/angular/issues/12079)
+				set: { entryComponents: [StarkPromptDialogComponent] }
+			})
+			.compileComponents();
+	}));
+
+	beforeEach(inject(
+		[MatDialog, OverlayContainer, ComponentFactoryResolver],
+		(d: MatDialog, oc: OverlayContainer, cfr: ComponentFactoryResolver) => {
+			dialogService = d;
+			overlayContainer = oc;
+			overlayContainerElement = oc.getContainerElement();
+			dialogComponentSelector = cfr.resolveComponentFactory(StarkPromptDialogComponent).selector;
+		}
+	));
+
+	afterEach(() => {
+		overlayContainer.ngOnDestroy();
+	});
+
+	beforeEach(() => {
+		hostFixture = TestBed.createComponent(TestHostComponent);
+		hostComponent = hostFixture.componentInstance;
+		hostFixture.detectChanges();
+
+		mockObserver = createSpyObj<Observer<StarkPromptDialogResult>>("observerSpy", ["next", "error", "complete"]);
+	});
+
+	it("should be correctly opened via the MatDialog service", () => {
+		expect(hostComponent).toBeDefined();
+		expect(dialogService).toBeDefined();
+
+		const dialogRef: MatDialogRef<StarkPromptDialogComponent, StarkPromptDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		expect(dialogRef.componentInstance instanceof StarkPromptDialogComponent).toBe(true);
+
+		const dialogElement: HTMLElement | null = overlayContainerElement.querySelector<HTMLElement>(
+			matDialogSelector + " " + dialogComponentSelector
+		);
+
+		const dialogTitleElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogTitleSelector);
+		expect(dialogTitleElement).toBeDefined();
+		expect((<HTMLElement>dialogTitleElement).innerHTML).toEqual(<string>dummyDialogContent.title);
+
+		const dialogContentElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogContentSelector);
+		expect(dialogContentElement).toBeDefined();
+		expect((<HTMLElement>dialogContentElement).innerHTML).toContain(<string>dummyDialogContent.textContent);
+
+		const dialogActionsElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogActionsSelector);
+		expect(dialogActionsElement).toBeDefined();
+		const dialogButtonElements: NodeListOf<HTMLElement> = (<HTMLElement>dialogActionsElement).querySelectorAll("button");
+		expect(dialogButtonElements.length).toBe(2);
+		expect(dialogButtonElements[0].innerHTML).toBe(<string>dummyDialogContent.cancel);
+		expect(dialogButtonElements[1].innerHTML).toContain(<string>dummyDialogContent.ok);
+	});
+
+	it("should return the value typed by the user as result when the 'Ok' button is clicked", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkPromptDialogComponent, StarkPromptDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		const dialogElement: HTMLElement | null = overlayContainerElement.querySelector<HTMLElement>(
+			matDialogSelector + " " + dialogComponentSelector
+		);
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		const dummyValue: string = "some dummy value";
+		expect(dialogRef.componentInstance.formControl.value).toBe(dummyDialogContent.initialValue);
+		dialogRef.componentInstance.formControl.setValue(dummyValue); // changing the input's value
+
+		const dialogActionsElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogActionsSelector);
+		expect(dialogActionsElement).toBeDefined();
+		const dialogButtonElements: NodeListOf<HTMLElement> = (<HTMLElement>dialogActionsElement).querySelectorAll("button");
+		expect(dialogButtonElements.length).toBe(2);
+
+		triggerClick(dialogButtonElements[1]); // clicking the "ok" button
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith(dummyValue);
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+
+	it("should return 'cancel' as result when the 'Cancel' button is clicked", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkPromptDialogComponent, StarkPromptDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		const dialogElement: HTMLElement | null = overlayContainerElement.querySelector<HTMLElement>(
+			matDialogSelector + " " + dialogComponentSelector
+		);
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		const dialogActionsElement: HTMLElement | null = (<HTMLElement>dialogElement).querySelector<HTMLElement>(matDialogActionsSelector);
+		expect(dialogActionsElement).toBeDefined();
+		const dialogButtonElements: NodeListOf<HTMLElement> = (<HTMLElement>dialogActionsElement).querySelectorAll("button");
+		expect(dialogButtonElements.length).toBe(2);
+
+		triggerClick(dialogButtonElements[0]); // clicking the "cancel" button
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith("cancel");
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+
+	it("should return undefined as result when it is cancelled by clicking outside of the dialog", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkPromptDialogComponent, StarkPromptDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		triggerClick(<HTMLElement>overlayContainerElement.querySelector(".cdk-overlay-backdrop")); // clicking on the backdrop
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith(undefined);
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+
+	it("should return undefined as result when it is cancelled by pressing the ESC key", fakeAsync(() => {
+		const dialogRef: MatDialogRef<StarkPromptDialogComponent, StarkPromptDialogResult> = openDialog(dummyDialogContent);
+		hostFixture.detectChanges();
+
+		dialogRef.afterClosed().subscribe(mockObserver);
+
+		triggerKeydownEscape(overlayContainerElement); // pressing Esc key in the overlay
+		hostFixture.detectChanges();
+
+		// to avoid NgZone error: "Error: 3 timer(s) still in the queue"
+		tick(500); // the amount of mills can be known by calling flush(): const remainingMills: number = flush();
+
+		expect(mockObserver.next).toHaveBeenCalledTimes(1);
+		expect(mockObserver.next).toHaveBeenCalledWith(undefined);
+		expect(mockObserver.error).not.toHaveBeenCalled();
+		expect(mockObserver.complete).toHaveBeenCalled();
+	}));
+});

--- a/packages/stark-ui/src/modules/dialogs/components/prompt-dialog.component.ts
+++ b/packages/stark-ui/src/modules/dialogs/components/prompt-dialog.component.ts
@@ -1,0 +1,59 @@
+import { Component, Inject, ViewEncapsulation } from "@angular/core";
+import { FormControl } from "@angular/forms";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { StarkPromptDialogContent } from "./prompt-dialog-content.intf";
+
+/**
+ * Possible results of the {@link StarkPromptDialogComponent} after being closed.
+ *
+ * - `string`: The value provided by the user in the dialog's input after clikcing the "Ok" button.
+ * - "cancel": The dialog was cancelled by clicking on the "Cancel" button
+ * - `undefined`: The dialog was cancelled either by clicking outside of dialog or by pressing the ESC key
+ */
+export type StarkPromptDialogResult = string | "cancel" | undefined;
+
+/**
+ * Prompt dialog component to be opened via the Angular Material's {@link MatDialog} service
+ */
+@Component({
+	selector: "stark-prompt-dialog",
+	templateUrl: "./prompt-dialog.component.html",
+	encapsulation: ViewEncapsulation.None,
+	// We need to use host instead of @HostBinding: https://github.com/NationalBankBelgium/stark/issues/664
+	host: {
+		class: "stark-prompt-dialog"
+	}
+})
+export class StarkPromptDialogComponent {
+	/**
+	 * @ignore
+	 */
+	public formControl: FormControl;
+
+	/**
+	 * Class constructor
+	 * @param dialogRef - Reference this dialog instance
+	 * @param content - Content to be shown in the prompt dialog (dynamically translated via the [@link TranslateService} service if the
+	 * provided text is defined in the translation keys)
+	 */
+	public constructor(
+		public dialogRef: MatDialogRef<StarkPromptDialogComponent, StarkPromptDialogResult>,
+		@Inject(MAT_DIALOG_DATA) public content: StarkPromptDialogContent
+	) {
+		this.formControl = new FormControl(this.content.initialValue);
+	}
+
+	/**
+	 * Callback method to be triggered when the "Cancel" button is clicked
+	 */
+	public onCancel(): void {
+		this.dialogRef.close("cancel");
+	}
+
+	/**
+	 * Callback method to be triggered when the "Ok" button is clicked
+	 */
+	public onOk(): void {
+		this.dialogRef.close(this.formControl.value);
+	}
+}

--- a/packages/stark-ui/src/modules/dialogs/dialogs.module.ts
+++ b/packages/stark-ui/src/modules/dialogs/dialogs.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from "@angular/core";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { MatButtonModule } from "@angular/material/button";
+import { MatDialogModule } from "@angular/material/dialog";
+import { MatIconModule } from "@angular/material/icon";
+import { MatInputModule } from "@angular/material/input";
+import { TranslateModule } from "@ngx-translate/core";
+import { StarkAlertDialogComponent, StarkConfirmDialogComponent, StarkPromptDialogComponent } from "./components";
+
+@NgModule({
+	declarations: [StarkAlertDialogComponent, StarkConfirmDialogComponent, StarkPromptDialogComponent],
+	imports: [FormsModule, ReactiveFormsModule, MatButtonModule, MatDialogModule, MatInputModule, TranslateModule, MatIconModule],
+	exports: [StarkAlertDialogComponent, StarkConfirmDialogComponent, StarkPromptDialogComponent],
+	entryComponents: [StarkAlertDialogComponent, StarkConfirmDialogComponent, StarkPromptDialogComponent]
+})
+export class StarkDialogsModule {}

--- a/showcase/src/app/app-menu.config.ts
+++ b/showcase/src/app/app-menu.config.ts
@@ -109,6 +109,13 @@ export const APP_MENU_CONFIG: StarkMenuConfig = {
 							targetState: "demo-ui.date-range-picker"
 						},
 						{
+							id: "menu-stark-ui-components-dialogs",
+							label: "SHOWCASE.DEMO.DIALOGS.TITLE",
+							isVisible: true,
+							isEnabled: true,
+							targetState: "demo-ui.dialogs"
+						},
+						{
 							id: "menu-stark-ui-components-dropdown",
 							label: "SHOWCASE.DEMO.DROPDOWN.TITLE",
 							isVisible: true,

--- a/showcase/src/app/demo-ui/demo-ui.module.ts
+++ b/showcase/src/app/demo-ui/demo-ui.module.ts
@@ -29,6 +29,7 @@ import {
 	StarkCollapsibleModule,
 	StarkDatePickerModule,
 	StarkDateRangePickerModule,
+	StarkDialogsModule,
 	StarkDropdownModule,
 	StarkGenericSearchModule,
 	StarkInputMaskDirectivesModule,
@@ -51,6 +52,7 @@ import {
 	DemoCollapsiblePageComponent,
 	DemoDatePickerPageComponent,
 	DemoDateRangePickerPageComponent,
+	DemoDialogsPageComponent,
 	DemoDropdownPageComponent,
 	DemoFooterPageComponent,
 	DemoGenericSearchFormComponent,
@@ -80,10 +82,10 @@ import {
 	TableRegularComponent,
 	TableWithCustomActionsComponent,
 	TableWithCustomStylingComponent,
+	TableWithFixedActionsComponent,
 	TableWithFixedHeaderComponent,
 	TableWithSelectionComponent,
-	TableWithTranscludedActionBarComponent,
-	TableWithFixedActionsComponent
+	TableWithTranscludedActionBarComponent
 } from "./components";
 
 @NgModule({
@@ -119,6 +121,7 @@ import {
 		StarkCollapsibleModule,
 		StarkDatePickerModule,
 		StarkDateRangePickerModule,
+		StarkDialogsModule,
 		StarkDropdownModule,
 		StarkGenericSearchModule,
 		StarkInputMaskDirectivesModule,
@@ -142,6 +145,7 @@ import {
 		DemoCollapsiblePageComponent,
 		DemoDatePickerPageComponent,
 		DemoDateRangePickerPageComponent,
+		DemoDialogsPageComponent,
 		DemoDropdownPageComponent,
 		DemoFooterPageComponent,
 		DemoGenericSearchPageComponent,
@@ -177,6 +181,7 @@ import {
 		DemoCollapsiblePageComponent,
 		DemoDatePickerPageComponent,
 		DemoDateRangePickerPageComponent,
+		DemoDialogsPageComponent,
 		DemoDropdownPageComponent,
 		DemoFooterPageComponent,
 		DemoGenericSearchPageComponent,

--- a/showcase/src/app/demo-ui/pages/dialogs/dialogs-page.component.html
+++ b/showcase/src/app/demo-ui/pages/dialogs/dialogs-page.component.html
@@ -1,0 +1,24 @@
+<h1 class="mat-display-3" translate>SHOWCASE.DEMO.DIALOGS.TITLE</h1>
+<section class="stark-section">
+	<h1 translate>SHOWCASE.DEMO.SHARED.EXAMPLE_VIEWER_LIST</h1>
+	<example-viewer
+		[extensions]="['HTML', 'TS']"
+		filesPath="dialogs/predefined-dialogs"
+		exampleTitle="SHOWCASE.DEMO.DIALOGS.PREDEFINED_DIALOGS"
+	>
+		<div class="dialog-demo-content">
+			<button mat-raised-button color="alert" (click)="showAlert()">{{ "SHOWCASE.DEMO.DIALOGS.ALERT_DIALOG" | translate }}</button>
+			<button mat-raised-button color="primary" (click)="showConfirm()">
+				{{ "SHOWCASE.DEMO.DIALOGS.CONFIRM_DIALOG" | translate }}
+			</button>
+			<button mat-stroked-button color="primary" (click)="showPrompt()">
+				{{ "SHOWCASE.DEMO.DIALOGS.PROMPT_DIALOG" | translate }}
+			</button>
+		</div>
+
+		<div *ngIf="dialogStatus" class="demo-prompt-dialog-status">
+			<b>{{ dialogStatus | translate: { result: dialogResult } }}</b>
+		</div>
+	</example-viewer>
+</section>
+<stark-reference-block [links]="referenceList"></stark-reference-block>

--- a/showcase/src/app/demo-ui/pages/dialogs/dialogs-page.component.scss
+++ b/showcase/src/app/demo-ui/pages/dialogs/dialogs-page.component.scss
@@ -1,0 +1,16 @@
+.dialog-demo-content {
+  //display: flex;
+  //flex-direction: row;
+  //justify-content: space-between;
+  display: block;
+  text-align: center;
+
+  button {
+    margin: 10px;
+  }
+}
+
+.demo-prompt-dialog-status {
+  text-align: center;
+  padding: 16px 0;
+}

--- a/showcase/src/app/demo-ui/pages/dialogs/dialogs-page.component.ts
+++ b/showcase/src/app/demo-ui/pages/dialogs/dialogs-page.component.ts
@@ -1,0 +1,111 @@
+import { Component, Inject } from "@angular/core";
+import { MatDialog } from "@angular/material/dialog";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import {
+	StarkAlertDialogComponent,
+	StarkAlertDialogContent,
+	StarkAlertDialogResult,
+	StarkConfirmDialogComponent,
+	StarkConfirmDialogContent,
+	StarkConfirmDialogResult,
+	StarkPromptDialogComponent,
+	StarkPromptDialogContent,
+	StarkPromptDialogResult
+} from "@nationalbankbelgium/stark-ui";
+import { ReferenceLink } from "../../../shared/components/reference-block";
+
+/* tslint:disable:no-identical-functions */
+@Component({
+	selector: "demo-dialogs",
+	templateUrl: "./dialogs-page.component.html",
+	styleUrls: ["./dialogs-page.component.scss"]
+})
+export class DemoDialogsPageComponent {
+	public referenceList: ReferenceLink[];
+	public dialogStatus: string;
+	public dialogResult: any = "";
+
+	public constructor(@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService, public dialogService: MatDialog) {
+		this.referenceList = [
+			{
+				label: "Stark Alert Dialog component",
+				url: "blabla"
+			},
+			{
+				label: "Stark Confirm Dialog component",
+				url: "blabla"
+			},
+			{
+				label: "Stark Prompt Dialog component",
+				url: "blabla"
+			}
+		];
+	}
+
+	public showAlert(): void {
+		this.dialogService
+			.open<StarkAlertDialogComponent, StarkAlertDialogContent, StarkAlertDialogResult>(StarkAlertDialogComponent, {
+				data: {
+					title: "SHOWCASE.DEMO.DIALOGS.ALERT.TITLE",
+					textContent: "SHOWCASE.DEMO.DIALOGS.ALERT.TEXT",
+					ok: "SHOWCASE.DEMO.DIALOGS.ALERT.OK"
+				},
+				ariaLabel: "Alert Dialog Demo"
+			})
+			.afterClosed()
+			.subscribe((result: StarkAlertDialogResult) => {
+				this.dialogResult = result || "undefined";
+				if (result === "ok") {
+					this.dialogStatus = "SHOWCASE.DEMO.DIALOGS.ALERT.RESULT_OK";
+				} else {
+					this.dialogStatus = "SHOWCASE.DEMO.DIALOGS.ALERT.RESULT_CANCEL";
+				}
+			});
+	}
+
+	public showConfirm(): void {
+		this.dialogService
+			.open<StarkConfirmDialogComponent, StarkConfirmDialogContent, StarkConfirmDialogResult>(StarkConfirmDialogComponent, {
+				data: {
+					title: "SHOWCASE.DEMO.DIALOGS.CONFIRM.TITLE",
+					textContent: "SHOWCASE.DEMO.DIALOGS.CONFIRM.TEXT",
+					ok: "SHOWCASE.DEMO.DIALOGS.CONFIRM.OK",
+					cancel: "SHOWCASE.DEMO.DIALOGS.CONFIRM.CANCEL"
+				},
+				ariaLabel: "Lucky day"
+			})
+			.afterClosed()
+			.subscribe((result: StarkConfirmDialogResult) => {
+				this.dialogResult = result || "undefined";
+				if (result === "ok") {
+					this.dialogStatus = "SHOWCASE.DEMO.DIALOGS.CONFIRM.RESULT_OK";
+				} else {
+					this.dialogStatus = "SHOWCASE.DEMO.DIALOGS.CONFIRM.RESULT_CANCEL";
+				}
+			});
+	}
+
+	public showPrompt(): void {
+		this.dialogService
+			.open<StarkPromptDialogComponent, StarkPromptDialogContent, StarkPromptDialogResult>(StarkPromptDialogComponent, {
+				data: {
+					title: "SHOWCASE.DEMO.DIALOGS.PROMPT.TITLE",
+					textContent: "SHOWCASE.DEMO.DIALOGS.PROMPT.TEXT",
+					placeholder: "SHOWCASE.DEMO.DIALOGS.PROMPT.PLACEHOLDER",
+					initialValue: "",
+					ok: "SHOWCASE.DEMO.DIALOGS.PROMPT.OK",
+					cancel: "SHOWCASE.DEMO.DIALOGS.PROMPT.CANCEL"
+				},
+				ariaLabel: "Dog name"
+			})
+			.afterClosed()
+			.subscribe((result: StarkPromptDialogResult) => {
+				this.dialogResult = result || "undefined";
+				if (result === "cancel") {
+					this.dialogStatus = "SHOWCASE.DEMO.DIALOGS.PROMPT.RESULT_CANCEL";
+				} else {
+					this.dialogStatus = "SHOWCASE.DEMO.DIALOGS.PROMPT.RESULT_OK";
+				}
+			});
+	}
+}

--- a/showcase/src/app/demo-ui/pages/dialogs/index.ts
+++ b/showcase/src/app/demo-ui/pages/dialogs/index.ts
@@ -1,0 +1,1 @@
+export * from "./dialogs-page.component";

--- a/showcase/src/app/demo-ui/pages/index.ts
+++ b/showcase/src/app/demo-ui/pages/index.ts
@@ -4,6 +4,7 @@ export * from "./breadcrumb";
 export * from "./collapsible";
 export * from "./date-picker";
 export * from "./date-range-picker";
+export * from "./dialogs";
 export * from "./dropdown";
 export * from "./footer";
 export * from "./generic-search";

--- a/showcase/src/app/demo-ui/routes.ts
+++ b/showcase/src/app/demo-ui/routes.ts
@@ -6,6 +6,7 @@ import {
 	DemoCollapsiblePageComponent,
 	DemoDatePickerPageComponent,
 	DemoDateRangePickerPageComponent,
+	DemoDialogsPageComponent,
 	DemoDropdownPageComponent,
 	DemoFooterPageComponent,
 	DemoGenericSearchPageComponent,
@@ -76,6 +77,14 @@ export const DEMO_STATES: Ng2StateDeclaration[] = [
 			translationKey: "SHOWCASE.DEMO.DATE_RANGE_PICKER.TITLE"
 		},
 		views: { "@": { component: DemoDateRangePickerPageComponent } }
+	},
+	{
+		name: "demo-ui.dialogs",
+		url: "/dialogs",
+		data: {
+			translationKey: "SHOWCASE.DEMO.DIALOGS.TITLE"
+		},
+		views: { "@": { component: DemoDialogsPageComponent } }
 	},
 	{
 		name: "demo-ui.dropdown",

--- a/showcase/src/assets/examples/dialogs/predefined-dialogs.html
+++ b/showcase/src/assets/examples/dialogs/predefined-dialogs.html
@@ -1,0 +1,9 @@
+<div>
+	<button mat-raised-button color="alert" (click)="showAlert()">Alert dialog</button>
+	<button mat-raised-button color="primary" (click)="showConfirm()">Confirm dialog</button>
+	<button mat-stroked-button color="primary" (click)="showPrompt()">Prompt dialog</button>
+</div>
+
+<div *ngIf="dialogStatus">
+	<b>{{ dialogStatus }}</b>
+</div>

--- a/showcase/src/assets/examples/dialogs/predefined-dialogs.ts
+++ b/showcase/src/assets/examples/dialogs/predefined-dialogs.ts
@@ -1,0 +1,88 @@
+import { Component, Inject } from "@angular/core";
+import { MatDialog } from "@angular/material/dialog";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import {
+	StarkAlertDialogComponent,
+	StarkAlertDialogContent,
+	StarkAlertDialogResult,
+	StarkConfirmDialogComponent,
+	StarkConfirmDialogContent,
+	StarkConfirmDialogResult,
+	StarkPromptDialogComponent,
+	StarkPromptDialogContent,
+	StarkPromptDialogResult
+} from "@nationalbankbelgium/stark-ui";
+
+@Component({
+	selector: "demo-dialogs",
+	templateUrl: "./demo-dialogs.component.html"
+})
+export class DemoDialogsComponent {
+	public dialogStatus: string;
+
+	public constructor(@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService, public dialogService: MatDialog) {}
+
+	public showAlert(): void {
+		this.dialogService
+			.open<StarkAlertDialogComponent, StarkAlertDialogContent, StarkAlertDialogResult>(StarkAlertDialogComponent, {
+				data: {
+					title: "This is an alert title",
+					textContent: "You can specify some description text in here.",
+					ok: "Got it!"
+				},
+				ariaLabel: "Alert Dialog Demo"
+			})
+			.afterClosed()
+			.subscribe((result: StarkAlertDialogResult) => {
+				if (result === "ok") {
+					this.dialogStatus = `Alert dialog closed with value '${result}'`;
+				} else {
+					this.dialogStatus = `Alert dialog cancelled with value '${result}'`;
+				}
+			});
+	}
+
+	public showConfirm(): void {
+		this.dialogService
+			.open<StarkConfirmDialogComponent, StarkConfirmDialogContent, StarkConfirmDialogResult>(StarkConfirmDialogComponent, {
+				data: {
+					title: "Would you like to delete your debt?",
+					textContent: "All of the banks have agreed to forgive you your debts.",
+					ok: "Please do it!",
+					cancel: "Sounds like a scam"
+				},
+				ariaLabel: "Lucky day"
+			})
+			.afterClosed()
+			.subscribe((result: StarkConfirmDialogResult) => {
+				if (result === "ok") {
+					this.dialogStatus = "You decided to get rid of your debt.";
+				} else {
+					this.dialogStatus = "You decided to keep your debt.";
+				}
+			});
+	}
+
+	public showPrompt(): void {
+		this.dialogService
+			.open<StarkPromptDialogComponent, StarkPromptDialogContent, StarkPromptDialogResult>(StarkPromptDialogComponent, {
+				data: {
+					title: "What would you name your dog?",
+					textContent: "Bowser is a common name.",
+					placeholder: "Dog name",
+					initialValue: "",
+					ok: "Okay!",
+					cancel: "I'm a cat person"
+				},
+				ariaLabel: "Dog name"
+			})
+			.afterClosed()
+			.subscribe((result: StarkPromptDialogResult) => {
+				if (result === "cancel") {
+					this.dialogStatus = "You didn't name your dog.";
+				} else {
+					this.dialogStatus = `You decided to name your dog '${result}'`;
+				}
+			});
+	}
+}

--- a/showcase/src/assets/translations/en.json
+++ b/showcase/src/assets/translations/en.json
@@ -51,6 +51,37 @@
       "DATE_RANGE_PICKER": {
         "TITLE": "Date range picker"
       },
+      "DIALOGS": {
+        "ALERT": {
+          "TITLE": "This is an alert title",
+          "TEXT": "You can specify some description text in here.",
+          "OK": "Got it!",
+          "RESULT_OK": "Alert dialog closed with value '{{ result }}'",
+          "RESULT_CANCEL": "Alert dialog cancelled with value '{{ result }}'"
+        },
+        "CONFIRM": {
+          "TITLE": "Would you like to delete your debt?",
+          "TEXT": "All of the banks have agreed to forgive you your debts.",
+          "OK": "Please do it!",
+          "CANCEL": "Sounds like a scam",
+          "RESULT_OK": "You decided to get rid of your debt.",
+          "RESULT_CANCEL": "You decided to keep your debt."
+        },
+        "PROMPT": {
+          "TITLE": "What would you name your dog?",
+          "TEXT": "Bowser is a common name.",
+          "PLACEHOLDER": "Dog name",
+          "OK": "Okay!",
+          "CANCEL": "I'm a cat person",
+          "RESULT_OK": "You decided to name your dog '{{ result }}'",
+          "RESULT_CANCEL": "You didn't name your dog."
+        },
+        "TITLE": "Dialogs",
+        "PREDEFINED_DIALOGS": "Predefined dialogs",
+        "ALERT_DIALOG": "Alert dialog",
+        "CONFIRM_DIALOG": "Confirm dialog",
+        "PROMPT_DIALOG": "Prompt dialog"
+      },
       "DROPDOWN": {
         "PR": "IT applications",
         "BLANK": "Single selection with default blank",

--- a/showcase/src/assets/translations/fr.json
+++ b/showcase/src/assets/translations/fr.json
@@ -51,6 +51,37 @@
       "DATE_RANGE_PICKER": {
         "TITLE": "Date range picker"
       },
+      "DIALOGS": {
+        "ALERT": {
+          "TITLE": "Ceci est un titre d'alerte",
+          "TEXT": "Vous pouvez spécifier un texte de description ici.",
+          "OK": "Compris!",
+          "RESULT_OK": "Dialogue d'alerte fermé avec la valeur '{{ result }}'",
+          "RESULT_CANCEL": "Dialogue d'alerte annulé avec la valeur '{{ result }}'"
+        },
+        "CONFIRM": {
+          "TITLE": "Voulez-vous supprimer votre dette?",
+          "TEXT": "Toutes les banques ont accepté d'oublier vos dettes.",
+          "OK": "Faites-le!",
+          "CANCEL": "On dirait une arnaque",
+          "RESULT_OK": "Vous avez décidé de vous débarrasser de votre dette.",
+          "RESULT_CANCEL": "Vous avez décidé de garder votre dette."
+        },
+        "PROMPT": {
+          "TITLE": "Comment nommeriez-vous votre chien?",
+          "TEXT": "Bowser est un nom commun.",
+          "PLACEHOLDER": "Nom du chien",
+          "OK": "D'accord!",
+          "CANCEL": "Je suis une personne à chat",
+          "RESULT_OK": "Vous avez décidé de nommer votre chien '{{ result }}'",
+          "RESULT_CANCEL": "Vous n'avez pas nommé votre chien."
+        },
+        "TITLE": "Dialogues",
+        "PREDEFINED_DIALOGS": "Dialogues prédéfinis",
+        "ALERT_DIALOG": "Dialogue d'alerte",
+        "CONFIRM_DIALOG": "Dialogue de confirmation",
+        "PROMPT_DIALOG": "Dialogue d'invite"
+      },
       "DROPDOWN": {
         "PR": "Applications informatiques",
         "BLANK": "Option par défaut (blank)",

--- a/showcase/src/assets/translations/nl.json
+++ b/showcase/src/assets/translations/nl.json
@@ -51,6 +51,37 @@
       "DATE_RANGE_PICKER": {
         "TITLE": "Date range picker"
       },
+      "DIALOGS": {
+        "ALERT": {
+          "TITLE": "Dit is een waarschuwings titel",
+          "TEXT": "Je kan hierin een beschrijvende tekst opgeven.",
+          "OK": "Begrepen!",
+          "RESULT_OK": "Waarschuwings dialoog gesloten met waarde '{{ result }}'",
+          "RESULT_CANCEL": "Waarschuwings dialoog gesloten met waarde '{{ result }}'"
+        },
+        "CONFIRM": {
+          "TITLE": "Wil je jouw schuld laten schrappen?",
+          "TEXT": "Alle banken hebben afgesproken om jouw schulden te vergeven.",
+          "OK": "Doe het alsjeblieft!",
+          "CANCEL": "Klinkt als een scam",
+          "RESULT_OK": "Je hebt besloten om jouw schuld te laten kwijtschelden.",
+          "RESULT_CANCEL": "Je hebt besloten jouw schuld te behouden."
+        },
+        "PROMPT": {
+          "TITLE": "Hoe zou je jouw hond noemen?",
+          "TEXT": "Bowser is een veel voorkomende naam.",
+          "PLACEHOLDER": "Hondennaam",
+          "OK": "Oké!",
+          "CANCEL": "Ik ben een kat persoon",
+          "RESULT_OK": "Je hebt besloten om je hond '{{ result }}' te noemen.",
+          "RESULT_CANCEL": "Je hebt je hond geen naam gegeven."
+        },
+        "TITLE": "Dialogen",
+        "PREDEFINED_DIALOGS": "Voorgedefinieerde dialogen",
+        "ALERT_DIALOG": "Waarschuwings dialoog",
+        "CONFIRM_DIALOG": "Bevestigings dialoog",
+        "PROMPT_DIALOG": "Prompt dialoog"
+      },
       "DROPDOWN": {
         "PR": "Informaticatoepassingen",
         "BLANK": "Bij verstek keus (blank)",


### PR DESCRIPTION
ISSUES CLOSED: #793

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #793 


## What is the new behavior?
Implemented a predefined set of simple dialog components to be used with Angular Material's MatDialog component: Alert, Confirm and Prompt.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->