### PR TITLE
fix(release): set npm tags 'latest' and 'next' correctly after every release. Fix nightly builds versioning

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -6,7 +6,7 @@
 	"pkgFiles": ["package.json", "package-lock.json"],
 	"increment": "conventional:angular",
 	"scripts": {
-		"afterBump": "npm run generate:changelog",
+		"afterBump": "npm run check:nightly:stark-versions -- ${version} && npm run generate:changelog",
 		"afterRelease": false,
 		"beforeStage": false,
 		"beforeStart": "npm run check:starter:stark-versions",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@
 ### Local
 
 On your local machine, you must configure the `GITHUB_TOKEN` environment variable.
-It will be used by release-it to push to and create the release page on GitHub (cfr release:prepare section below).
+It will be used by release-it to push to and create the release page on GitHub (cfr [What happens once a release is triggered](#release-process) section below).
 
 ### Travis
 
@@ -17,10 +17,10 @@ On Travis, the following should be configured:
 
 ## Changelog
 
-First of all: _Never_ edit CHANGELOG.md manually!
+First of all: _**Never**_ edit [CHANGELOG.md](./CHANGELOG.md) manually!
 
 The changelog will be updated automatically as part of the release process and based on the commit log using conventional-changelog (https://github.com/conventional-changelog)
-We use the Angular format for our changelog and for it to work properly, please make sure to respect our commit conventions (see CONTRIBUTING guide).
+We use the Angular format for our changelog and for it to work properly, please make sure to respect our commit conventions (see our [CONTRIBUTING](./CONTRIBUTING.md) guide).
 
 ## Creating a release
 
@@ -29,18 +29,21 @@ Make sure that:
 -   all changes have merged into master
 -   everything is up to date locally
 -   everything is clean locally
+-   the base version set for nightly builds (at `config.nightlyVersion` in the root `package.json`) is higher than the version to be released
 -   execute `npm run release`
 
-Enjoy the show.
+Enjoy the show!
+
+_NOTE:_ If any of the pre-conditions mentioned above are not met, no worries, the npm command will fail with the proper description about what needs to be fixed.
 
 ## Publishing the release on npm
 
 Once you have pushed the tag, Travis will handle things from there.
 
-Once done, you must make sure that the tags are adapted so that the "latest" tag still points to what we consider the latest (i.e., next major/minor)!
+Once done, you must make sure that the distribution tags are adapted so that the `latest` tag still points to what we consider the latest (i.e., next major/minor)!
 Refer to the "Adapting tags of published packages" section below.
 
-## What happens once a release is triggered
+## <a name="release-process"></a>What happens once a release is triggered
 
 ### release
 
@@ -48,7 +51,8 @@ Refer to the "Adapting tags of published packages" section below.
 -   then we execute release-it: https://github.com/webpro/release-it which
     -   bumps the version in the root package.json automatically (determines the bump type to use depending on the commit message logs)
         -   that version number will be used as basis in the build to adapt all other package.json files
-    -   generates/updates the CHANGELOG.md file using: conventional-changelog: https://github.com/conventional-changelog
+    -   checks that the base version for nightly builds (at `config.nightlyVersion` in the root `package.json`) is higher than the version to be released
+    -   generates/updates the [CHANGELOG.md](./CHANGELOG.md) file using: conventional-changelog: https://github.com/conventional-changelog
     -   commits both package.json and CHANGELOG.md
     -   creates a new git tag and pushes it
     -   creates a github release page and makes it final
@@ -94,7 +98,7 @@ To replace the keys used by the docs publish script:
 -   associate the public key with the Stark repository as a "Deploy Key": https://developer.github.com/v3/guides/managing-deploy-keys/
 -   encrypt the private key with the Travis CLI: `travis encrypt-file ./stark-ssh -r NationalBankBelgium/stark`
     -   that command will generate an encrypted version of the key
-    -   make sure you're logged in (see next section)
+    -   make sure you're logged in (see [Installing the Travis CLI](#intalling-travis-cli) section)
     -   **IMPORTANT: on Windows the generation of the encrypted key produces a corrupted file. So you should generate it on a Linux system. See https://github.com/travis-ci/travis-ci/issues/4746**
 -   save the encrypted file as `stark-ssh.enc` and get rid of the non-encrypted key directly
 
@@ -105,7 +109,7 @@ The command will also
 
 The name of those variables will change each time it is used, therefore the `gh-deploy.sh` MUST also be adapted afterwards.
 
-#### Installing the Travis CLI
+#### <a name="intalling-travis-cli"></a>Installing the Travis CLI
 
 Steps:
 
@@ -119,7 +123,8 @@ Steps:
 
 Finally, Travis executes `npm run release:publish`.
 
-That script makes some checks then, if all succeed it publishes the different packages on npm.
+That script makes some checks then, if all succeed, it publishes the different packages on npm and sets the `last` and `next` distribution tags to the published version.
+
 Checks that are performed:
 
 -   node version: should be "8"
@@ -131,5 +136,5 @@ Other details can be found here: https://github.com/NationalBankBelgium/stark/is
 
 ## Adapting tags of published packages
 
-If a published version doesn't have all necessary tags, or if we want to adapt those for some reason (e.g., latest pointing to a patch release rather than the latest major/minor), then we can use the `npm dist-tag` command.
+If a published version doesn't have all necessary distribution tags, or if we want to adapt those for some reason (e.g., `latest` pointing to a patch release rather than the latest major/minor), then we can use the `npm dist-tag` command.
 Reference: https://docs.npmjs.com/cli/dist-tag

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,6 @@ IFS=${OLD_IFS} # restore IFS
 
 BUILD_ALL=true
 BUNDLE=true
-VERSION_PREFIX=$(node -p "require('./package.json').version")
 COMPILE_SOURCE=true
 TYPECHECK_ALL=true
 
@@ -144,12 +143,20 @@ if [[ -z ${TRAVIS_TAG+x} ]]; then
   TRAVIS_TAG=""
 fi
 
+if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
+  logInfo "Nightly build initiated by Travis cron job. Using nightly version as version prefix!" 1
+  VERSION_PREFIX=$(node -p "require('./package.json').config.nightlyVersion")
+else
+  logInfo "Normal build. Using current version as version prefix" 1
+  VERSION_PREFIX=$(node -p "require('./package.json').version")
+fi
+
 if [[ ${TRAVIS_TAG} == "" ]]; then
   logTrace "Setting the version suffix to the latest commit hash" 1
   VERSION_SUFFIX="-$(git log --oneline -1 | awk '{print $1}')" # last commit id
 else
   logTrace "Build executed for a tag. Not using a version suffix!" 1
-  VERSION_SUFFIX="" # last commit id
+  VERSION_SUFFIX="" # no suffix
 fi
 
 VERSION="${VERSION_PREFIX}${VERSION_SUFFIX}"

--- a/check-nightly-version.js
+++ b/check-nightly-version.js
@@ -1,0 +1,27 @@
+const fs = require("fs");
+
+let packageJsonPath = process.argv[2];
+let latestVersion = process.argv[3];
+let isCorrect = true;
+
+fs.readFile(packageJsonPath, "utf8", function(err, packageJsonData) {
+	if (err) {
+		return console.error("Error while reading file => " + err);
+	}
+
+	const validVersionPattern = new RegExp('\\"nightlyVersion\\": \\"' + latestVersion + '\\"', "gi");
+	if (packageJsonData.match(validVersionPattern)) {
+		isCorrect = false;
+		console.error("Nightly version of Stark packages is not correct. It should be higher than the latest version: '" + latestVersion + "'");
+	}
+
+	if (!isCorrect) {
+		throw new Error(
+			"The version set for nightly builds ('config.nightlyVersion') is not correct in " +
+				packageJsonPath +
+				". Please adapt to a valid version (higher than '" +
+				latestVersion +
+				"')."
+		);
+	}
+});

--- a/check-stark-versions.js
+++ b/check-stark-versions.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 
 let packageJsonPath = process.argv[2];
-let starkVersion = process.argv[3];
+let validVersion = process.argv[3];
 let isCorrect = true;
 
 fs.readFile("./modules.txt", "utf8", function(err, modulesData) {
@@ -19,15 +19,21 @@ fs.readFile("./modules.txt", "utf8", function(err, modulesData) {
 		}
 
 		for (const starkPackage of starkPackagesArray) {
-			const validVersionPattern = new RegExp('\\"@nationalbankbelgium/' + starkPackage + '\\": \\"' + starkVersion + '\\"', "gi");
+			const validVersionPattern = new RegExp('\\"@nationalbankbelgium/' + starkPackage + '\\": \\"' + validVersion + '\\"', "gi");
 			if (!packageJsonData.match(validVersionPattern)) {
 				isCorrect = false;
-				console.error("Version of package " + starkPackage + " is not correct. It should be `" + starkVersion + "`");
+				console.error("Version of package " + starkPackage + " is not correct. It should be '" + validVersion + "'");
 			}
 		}
 
 		if (!isCorrect) {
-			throw new Error("The version of some of the Stark packages is not correct in the Starter. Please adapt to a valid version.");
+			throw new Error(
+				"The version of some of the Stark packages is not correct in " +
+					packageJsonPath +
+					". Please adapt to '" +
+					validVersion +
+					"'."
+			);
 		}
 	});
 });

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "build:showcase:ghpages": "cd showcase && npm run build:prod:ghpages && cd ..",
     "build:starter": "cd starter && npm run build && cd ..",
     "check:starter:stark-versions": "node ./check-stark-versions.js ./starter/package.json latest",
+    "check:nightly:stark-versions": "node ./check-nightly-version.js ./package.json",
     "clean": "npx rimraf ./dist",
     "clean:all": "npm run clean && npm run clean:stark-build && npm run clean:stark-core && npm run clean:stark-ui && npm run clean:stark-testing && npm run clean:starter && npm run clean:showcase",
     "clean:stark-build": "cd packages/stark-build && npm run clean && cd ../..",
@@ -170,7 +171,8 @@
   "config": {
     "commitizen": {
       "path": "node_modules/cz-customizable"
-    }
+    },
+    "nightlyVersion": "10.0.0-beta.6"
   },
   "greenkeeper": {
     "commitMessages": {

--- a/release-publish.sh
+++ b/release-publish.sh
@@ -164,6 +164,8 @@ do
         if [[ ${NIGHTLY_BUILD} == false ]]; then
           logTrace "Publishing the release (with tag latest)" 2
           npm publish ${file} --access public
+          logTrace "Adapting the tag next to point to the new release" 2
+          npm dist-tag add @nationalbankbelgium/${PACKAGE}@${TRAVIS_TAG} next
         else
           logTrace "Check if nightly build is not already published."
           LATEST_NPM_VERSION=`npm view @nationalbankbelgium/${PACKAGE} dist-tags.next`


### PR DESCRIPTION
ISSUES CLOSED: #420, #468

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[X] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #420, #468


## What is the new behavior?
- After every release not only the `latest` is set but also the `next` tag (using the [`npm dis-tag`](https://docs.npmjs.com/adding-dist-tags-to-packages#adding-a-dist-tag-to-a-specific-version-of-your-package) ). So they will point to the same version right after releasing (until a new nightly build is created).
- The nightly builds versioning is now based on a "future" version to clearly indicate that our nightly builds are what will ultimately become that future version. For example: a nightly build version `10.1.0-abcdfg` will become a final version `10.1.0` at some point.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->