### PR TITLE
chore(release): fix 'unbound variable' error in build.sh introduced in #1185

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -143,6 +143,11 @@ if [[ -z ${TRAVIS_TAG+x} ]]; then
   TRAVIS_TAG=""
 fi
 
+# Making sure the variable exists
+if [[ -z ${TRAVIS_EVENT_TYPE+x} ]]; then
+  TRAVIS_EVENT_TYPE=""
+fi
+
 if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
   logInfo "Nightly build initiated by Travis cron job. Using nightly version as version prefix!" 1
   VERSION_PREFIX=$(node -p "require('./package.json').config.nightlyVersion")


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The changes to the `build.sh` script done in #1185 introduced a bug in Windows:

```
./build.sh: line 146: TRAVIS_EVENT_TYPE: unbound variable
```

The issue is that the `TRAVIS_EVENT_TYPE` variable is not initialized to ensure it exists locally (on Travis it is an environment variable so there is no error there).

## What is the new behavior?
A check was added to initialize the variable if it doesn't exist.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
