### PR TITLE
fix(stark-demo): fix wrong reference links in Dialogs demo page

### DIFF
--- a/showcase/src/app/demo-ui/pages/dialogs/dialogs-page.component.ts
+++ b/showcase/src/app/demo-ui/pages/dialogs/dialogs-page.component.ts
@@ -29,15 +29,15 @@ export class DemoDialogsPageComponent {
 		this.referenceList = [
 			{
 				label: "Stark Alert Dialog component",
-				url: "blabla"
+				url: "https://stark.nbb.be/api-docs/stark-ui/latest/components/StarkAlertDialogComponent.html"
 			},
 			{
 				label: "Stark Confirm Dialog component",
-				url: "blabla"
+				url: "https://stark.nbb.be/api-docs/stark-ui/latest/components/StarkConfirmDialogComponent.html"
 			},
 			{
 				label: "Stark Prompt Dialog component",
-				url: "blabla"
+				url: "https://stark.nbb.be/api-docs/stark-ui/latest/components/StarkPromptDialogComponent.html"
 			}
 		];
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Wrong reference links in the Dialogs demo page created in #1183 


## What is the new behavior?
Correct reference links pointing to the corresponding API docs.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->