### PR TITLE
fix(stark-ui): date-picker - disabled stark-date-picker not focusable anymore

### DIFF
--- a/packages/stark-ui/src/modules/date-picker/components/date-picker.component.ts
+++ b/packages/stark-ui/src/modules/date-picker/components/date-picker.component.ts
@@ -123,7 +123,7 @@ export class StarkDatePickerComponent extends AbstractStarkUiComponent
 	 * Timestamp Mask Configuration to apply on the date-picker.
 	 * If `true` is passed, the default mask config is applied: {DEFAULT_DATE_MASK_CONFIG|DEFAULT_DATE_MASK_CONFIG}
 	 * If `false` is passed or if `dateMask` is not present, the directive is disabled.
-	 * If a `StarkTimestampMaskConfig` is passed, it is set as the date mask config. 
+	 * If a `StarkTimestampMaskConfig` is passed, it is set as the date mask config.
 	 */
 	@Input()
 	public dateMask: StarkDatePickerMaskConfig;
@@ -291,7 +291,7 @@ export class StarkDatePickerComponent extends AbstractStarkUiComponent
 		super(renderer, elementRef);
 
 		fm.monitor(elementRef, true).subscribe((origin: FocusOrigin) => {
-			this.focused = !!origin;
+			this.focused = !!origin && !this.disabled;
 			this.stateChanges.next();
 		});
 	}
@@ -419,7 +419,6 @@ export class StarkDatePickerComponent extends AbstractStarkUiComponent
 	public setDisabledState(isDisabled: boolean): void {
 		this.disabled = isDisabled;
 		this.stateChanges.next();
-		this.cdRef.detectChanges();
 		this._onValidatorChange();
 	}
 
@@ -519,7 +518,7 @@ export class StarkDatePickerComponent extends AbstractStarkUiComponent
 
 		// tslint:disable-next-line:no-null-keyword
 		this.value = event.value ? event.value.toDate() : null;
-		
+
 		const value: Date | undefined = this.value ? this.value : undefined;
 		this.dateChange.emit(value);
 		this._onChange(value);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There was a small bug with the date-picker due to our implementation of MatFormField in #1178. 
When the date-picker was disabled, it was still focusable.


## What is the new behavior?
When the date-picker is disabled, it is not focusable anymore.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->