### PR TITLE
test(stark-all): fix last TSLint error in Showcase unit tests after upgrade of @types/jasmine to v3.3.12

### DIFF
--- a/packages/stark-core/package-lock.json
+++ b/packages/stark-core/package-lock.json
@@ -13,7 +13,7 @@
       "version": "file:../stark-testing",
       "dev": true,
       "requires": {
-        "@types/jasmine": "^3.3.9",
+        "@types/jasmine": "^3.3.12",
         "@types/node": "^8.10.44",
         "coveralls": "^3.0.3",
         "istanbul-lib-instrument": "^3.1.0",
@@ -132,7 +132,7 @@
           }
         },
         "@types/jasmine": {
-          "version": "3.3.9",
+          "version": "3.3.12",
           "bundled": true,
           "dev": true
         },

--- a/packages/stark-ui/package-lock.json
+++ b/packages/stark-ui/package-lock.json
@@ -21,7 +21,7 @@
       "version": "file:../stark-testing",
       "dev": true,
       "requires": {
-        "@types/jasmine": "^3.3.9",
+        "@types/jasmine": "^3.3.12",
         "@types/node": "^8.10.44",
         "coveralls": "^3.0.3",
         "istanbul-lib-instrument": "^3.1.0",
@@ -140,7 +140,7 @@
           }
         },
         "@types/jasmine": {
-          "version": "3.3.9",
+          "version": "3.3.12",
           "bundled": true,
           "dev": true
         },

--- a/showcase/package-lock.json
+++ b/showcase/package-lock.json
@@ -1399,7 +1399,7 @@
       "integrity": "sha512-uJzwvVGbYffs7zqvkfgFZJoaQYkDs0SFFVT/kEuyKgYHAjTTSQPNeD18hxb4gzty3qL+2GBsM/12NghWRfN6UA==",
       "dev": true,
       "requires": {
-        "@types/jasmine": "^3.3.9",
+        "@types/jasmine": "^3.3.12",
         "@types/node": "^8.10.44",
         "coveralls": "^3.0.3",
         "istanbul-lib-instrument": "^3.1.0",
@@ -1611,9 +1611,9 @@
       "dev": true
     },
     "@types/jasmine": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.3.9.tgz",
-      "integrity": "sha512-vw3VyFPa9mlba6NZPBZC3q2Zrnkgy5xuCVI43/tTLX6umdYrYvcFtQUKi2zH3PjFZQ9XCxNM/NMrM9uk8TPOzg==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.3.12.tgz",
+      "integrity": "sha512-lXvr2xFQEVQLkIhuGaR3GC1L9lMU1IxeWnAF/wNY5ZWpC4p9dgxkKkzMp7pntpAdv9pZSnYqgsBkCg32MXSZMg==",
       "dev": true
     },
     "@types/minimatch": {

--- a/showcase/src/app/shared/components/table-of-contents/table-of-contents.component.spec.ts
+++ b/showcase/src/app/shared/components/table-of-contents/table-of-contents.component.spec.ts
@@ -73,7 +73,7 @@ describe("TableOfContents", () => {
 			{ innerText: "second link", offsetTop: 50, tagName: "SECOND", id: "2" }
 		];
 
-		spyOn(document, "querySelectorAll").and.returnValue(headerSelector);
+		spyOn(document, "querySelectorAll").and.returnValue(<NodeListOf<HTMLElement>><unknown>headerSelector);
 
 		const expectedFirstLink: TableOfContentLink = { name: "first link", type: "first", top: 5, id: "1", active: false };
 		const expectedSecondLink: TableOfContentLink = { name: "second link", type: "second", top: 30, id: "2", active: false };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
After the automatic upgrade of `@types/jasmine` to v3.3.12, some new violations were reported on the `.spec.ts` files of the Showcase which break the Travis build.


## What is the new behavior?
- The new violations are fixed.
- Adapted the `package-lock.json` file in stark-core, stark-ui and showcase to specify the latest version of `@types/jasmine` being used.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->