### PR TITLE
test(stark-ui): adapt failing unit test with latest version of PrismJS (1.16.0)

### DIFF
--- a/packages/stark-ui/src/modules/pretty-print/components/pretty-print.component.spec.ts
+++ b/packages/stark-ui/src/modules/pretty-print/components/pretty-print.component.spec.ts
@@ -599,7 +599,8 @@ describe("PrettyPrintComponent", () => {
 				const preElement: HTMLPreElement | null = <HTMLPreElement>hostFixture.nativeElement.querySelector("pre");
 				expect(preElement).not.toBeNull();
 				expect(preElement.innerHTML).toContain('<code class="language-css">');
-				expect(preElement.innerHTML).toContain('<span class="token selector">body </span>');
+				// in PrismJS 1.15.0 there is an extra whitespace (most likely a bug) but in version 1.16.0 it is not there anymore
+				expect(preElement.innerHTML).toMatch('<span class="token selector">body.+</span>');
 				expect(preElement.innerHTML).toContain('<span class="token punctuation">:</span>');
 			});
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
After the automatic upgrade to the latest version of `PrismJS` (1.16.0) one unit test in stark-ui is failing.
The cause is a small change in the new version compared to the previous one (most likely a bug in the previous version).

## What is the new behavior?
The failing unit test is fixed in a way that is compatible with the previous and latest versions of `PrismJS`

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->