### PR TITLE
feat(stark-all): upgrade to TypeScript 3.2 (latest version supported in Angular 7.2)

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -14,5 +14,5 @@
       "packages": ["showcase/package.json", "starter/package.json"]
     }
   },
-  "ignore": ["@angular/flex-layout", "@compodoc/compodoc", "@types/node", "typescript"]
+  "ignore": ["@compodoc/compodoc", "@types/node", "typescript"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10620,9 +10620,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
       "dev": true
     },
     "uglify-es": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.17.0",
     "tslint-sonarts": "^1.8.0",
-    "typescript": "~3.1.6",
+    "typescript": "~3.2.4",
     "uglify-es": "^3.3.9",
     "zone.js": "~0.8.26"
   },
@@ -154,7 +154,7 @@
     "test:showcase:e2e:browserstack": "cd showcase && npm run e2e:browserstack && cd ../..",
     "test:starter": "cd starter && npm run test-fast && cd ../..",
     "test:starter:e2e": "cd starter && npm run e2e && cd ../..",
-    "test:ci:all": "npm run test:ci:stark-core && npm run test:ci:stark-ui && npm run test:ci:starter && npm run test:ci:showcase",
+    "test:ci:all": "npm run test:ci:stark-core && npm run test:ci:stark-ui && npm run test:ci:stark-rbac && npm run test:ci:starter && npm run test:ci:showcase",
     "test:ci:stark-core": "cd packages/stark-core && npm run test-fast:ci && cd ../..",
     "test:ci:stark-rbac": "cd packages/stark-rbac && npm run test-fast:ci && cd ../..",
     "test:ci:stark-ui": "cd packages/stark-ui && npm run test-fast:ci && cd ../..",

--- a/packages/stark-core/src/modules/http/builder/http-request-builder.spec.ts
+++ b/packages/stark-core/src/modules/http/builder/http-request-builder.spec.ts
@@ -30,7 +30,7 @@ const deepFreeze: Function = require("deep-freeze-strict");
 const resourcePath = "/something/:somethingId/else/:elseId/next";
 const resourceUuid = "dummyUUID";
 const resourceEtag = "123456789";
-const mockDate: Date = new Date();
+const mockDate = new Date();
 const mockFrozenPathParamsWithoutUUID: StarkHttpRequestParams = deepFreeze({
 	pathParameters: { someId: "1234" }
 });

--- a/packages/stark-core/src/util/date.util.spec.ts
+++ b/packages/stark-core/src/util/date.util.spec.ts
@@ -7,7 +7,7 @@ describe("Util: DateUtil", () => {
 
 	describe("parseDateWithFormat", () => {
 		it("should return a valid Date when different valid dateStrings are provided using the same format", () => {
-			const expectedDate: Date = new Date();
+			const expectedDate = new Date();
 
 			// full date-time
 			expectedDate.setFullYear(2016, 2, 18);
@@ -60,7 +60,7 @@ describe("Util: DateUtil", () => {
 		});
 
 		it("should return a valid Date when the same dateString is used and passing different formats", () => {
-			const expectedDate: Date = new Date();
+			const expectedDate = new Date();
 
 			// full date-time (UTC format and including milliseconds)
 			expectedDate.setUTCFullYear(2016, 2, 18);
@@ -124,7 +124,7 @@ describe("Util: DateUtil", () => {
 		});
 
 		it("should return a valid Date when the same date is represented in different formats", () => {
-			const expectedDate: Date = new Date();
+			const expectedDate = new Date();
 			expectedDate.setUTCFullYear(2016, 2, 18);
 			expectedDate.setUTCHours(17, 25, 43, 511);
 
@@ -185,10 +185,10 @@ describe("Util: DateUtil", () => {
 		it("should return the date in a formatted string based on the given format", () => {
 			// IMPORTANT: in case the date string has a timezone, it should have a ':' between the hours and the minutes
 			// otherwise IE will fail to parse it returning "Invalid Date"
-			const mockDate: Date = new Date("2016-03-18T10:25:43.511+01:00");
+			const mockDate = new Date("2016-03-18T10:25:43.511+01:00");
 
 			// another way to create a date
-			// const mockDate: Date = new Date();
+			// const mockDate = new Date();
 			// mockDate.setFullYear(2016, 2, 18);
 			// mockDate.setHours(10, 25, 43, 511);
 
@@ -222,7 +222,7 @@ describe("Util: DateUtil", () => {
 		});
 
 		it("should return the date in a formatted string based on the default format if no format is defined", () => {
-			const mockDate: Date = new Date();
+			const mockDate = new Date();
 			mockDate.setFullYear(2016, 2, 18);
 			mockDate.setHours(10, 25, 43, 511);
 
@@ -231,7 +231,7 @@ describe("Util: DateUtil", () => {
 		});
 
 		it("should return 'invalid format' when the given format is invalid", () => {
-			const mockDate: Date = new Date();
+			const mockDate = new Date();
 			mockDate.setFullYear(2016, 2, 18);
 			mockDate.setHours(10, 25, 43, 511);
 

--- a/packages/stark-rbac/base.spec.ts
+++ b/packages/stark-rbac/base.spec.ts
@@ -21,6 +21,9 @@ if (window.NodeList && !NodeList.prototype.forEach) {
 }
 
 /* tslint:disable:no-import-side-effect */
+// FIXME: change when https://github.com/monounity/karma-typescript/issues/320 is resolved
+// tslint:disable-next-line:import-blacklist
+import "lodash-es"; // see https://github.com/monounity/karma-typescript/issues/150#issuecomment-318620280
 import "zone.js/dist/zone";
 import "zone.js/dist/long-stack-trace-zone";
 import "zone.js/dist/proxy"; // since zone.js 0.6.15
@@ -28,8 +31,6 @@ import "zone.js/dist/sync-test";
 import "zone.js/dist/jasmine-patch"; // put here since zone.js 0.6.14
 import "zone.js/dist/async-test";
 import "zone.js/dist/fake-async-test";
-import "zone.js/dist/zone-patch-rxjs";
-import "zone.js/dist/zone-patch-rxjs-fake-async";
 /* tslint:enable:no-import-side-effect */
 
 import { TestBed } from "@angular/core/testing";

--- a/packages/stark-rbac/karma.conf.ci.js
+++ b/packages/stark-rbac/karma.conf.ci.js
@@ -10,12 +10,17 @@ const karmaTypescriptFiles = require("./karma.conf").karmaTypescriptFiles;
 // start customizing the KarmaCI configuration from stark-testing
 const starkRBACSpecificConfiguration = {
 	...defaultKarmaCIConfig,
-	// change the module resolution for the KarmaTypescript bundler
+	// change the path of the report so that Coveralls takes the right path to the source files
+	coverageIstanbulReporter: { ...defaultKarmaCIConfig.coverageIstanbulReporter, dir: helpers.root("reports/coverage/packages") },
+	// add missing files due to "@nationalbankbelgium/stark-rbac" imports used in mock files of the testing sub-package
+	files: [...defaultKarmaCIConfig.files, ...karmaTypescriptFiles],
 	karmaTypescriptConfig: {
 		...defaultKarmaCIConfig.karmaTypescriptConfig,
 		bundlerOptions: {
 			...defaultKarmaCIConfig.karmaTypescriptConfig.bundlerOptions,
+			// change the module resolution for the KarmaTypescript bundler
 			...karmaTypescriptBundlerAliasResolution,
+			// Overwrite the karmaTypescriptConfig to pass the correct preset to karma-typescript-es6-transform
 			transforms: [
 				require("../stark-testing/node_modules/karma-typescript-angular2-transform"),
 				require("../stark-testing/node_modules/karma-typescript-es6-transform")({
@@ -23,11 +28,7 @@ const starkRBACSpecificConfiguration = {
 				})
 			]
 		}
-	},
-	// change the path of the report so that Coveralls takes the right path to the source files
-	coverageIstanbulReporter: { ...defaultKarmaCIConfig.coverageIstanbulReporter, dir: helpers.root("reports/coverage/packages") },
-	// add missing files due to "@nationalbankbelgium/stark-rbac" imports used in mock files of the testing sub-package
-	files: [...defaultKarmaCIConfig.files, ...karmaTypescriptFiles]
+	}
 };
 
 // export the configuration function that karma expects and simply return the stark configuration

--- a/packages/stark-rbac/karma.conf.js
+++ b/packages/stark-rbac/karma.conf.js
@@ -27,8 +27,14 @@ const karmaTypescriptBundlerAliasResolution = {
 			cerialize: "../stark-core/node_modules/cerialize/index.js",
 			"class-validator": "../stark-core/node_modules/class-validator/index.js",
 			"deep-freeze-strict": "../stark-core/node_modules/deep-freeze-strict/index.js",
-			moment: "../stark-core/node_modules/moment/moment.js",
-			ibantools: "../stark-core/node_modules/ibantools/build/ibantools.js"
+			ibantools: "../stark-core/node_modules/ibantools/build/ibantools.js",
+			"lodash-es": "../stark-core/node_modules/lodash-es/lodash.js",
+			"lodash-es/cloneDeep": "../stark-core/node_modules/lodash-es/cloneDeep.js",
+			"lodash-es/floor": "../stark-core/node_modules/lodash-es/floor.js",
+			"lodash-es/isEmpty": "../stark-core/node_modules/lodash-es/isEmpty.js",
+			"lodash-es/noop": "../stark-core/node_modules/lodash-es/noop.js",
+			"lodash-es/reduce": "../stark-core/node_modules/lodash-es/reduce.js",
+			moment: "../stark-core/node_modules/moment/moment.js"
 		}
 	}
 };

--- a/packages/stark-rbac/karma.conf.js
+++ b/packages/stark-rbac/karma.conf.js
@@ -42,12 +42,15 @@ const karmaTypescriptBundlerAliasResolution = {
 // start customizing the KarmaCI configuration from stark-testing
 const starkRBACSpecificConfiguration = {
 	...defaultKarmaConfig,
-	// change the module resolution for the KarmaTypescript bundler
+	// add missing files due to "@nationalbankbelgium/stark-rbac" imports used in mock files of the testing sub-package
+	files: [...defaultKarmaConfig.files, ...karmaTypescriptFiles],
 	karmaTypescriptConfig: {
 		...defaultKarmaConfig.karmaTypescriptConfig,
 		bundlerOptions: {
 			...defaultKarmaConfig.karmaTypescriptConfig.bundlerOptions,
+			// change the module resolution for the KarmaTypescript bundler
 			...karmaTypescriptBundlerAliasResolution,
+			// Overwrite the karmaTypescriptConfig to pass the correct preset to karma-typescript-es6-transform
 			transforms: [
 				require("../stark-testing/node_modules/karma-typescript-angular2-transform"),
 				require("../stark-testing/node_modules/karma-typescript-es6-transform")({
@@ -55,9 +58,7 @@ const starkRBACSpecificConfiguration = {
 				})
 			]
 		}
-	},
-	// add missing files due to "@nationalbankbelgium/stark-rbac" imports used in mock files of the testing sub-package
-	files: [...defaultKarmaConfig.files, ...karmaTypescriptFiles]
+	}
 };
 
 // export the configuration function that karma expects and simply return the stark configuration

--- a/packages/stark-ui/karma.conf.ci.js
+++ b/packages/stark-ui/karma.conf.ci.js
@@ -8,15 +8,21 @@ const karmaTypescriptBundlerAlias = require("./karma.conf").karmaTypescriptBundl
 const karmaTypescriptFiles = require("./karma.conf").karmaTypescriptFiles;
 
 // start customizing the KarmaCI configuration from stark-testing
-const starkUiSpecificConfiguration = Object.assign({}, defaultKarmaCIConfig, {
-	// change the module resolution for the KarmaTypescript bundler
+const starkUiSpecificConfiguration = {
+	...defaultKarmaCIConfig,
+	// change the path of the report so that Coveralls takes the right path to the source files
+	coverageIstanbulReporter: { ...defaultKarmaCIConfig.coverageIstanbulReporter, dir: helpers.root("reports/coverage/packages") },
+	// add missing files due to "@nationalbankbelgium/stark-ui" imports used in mock files of the testing sub-package
+	files: [...defaultKarmaCIConfig.files, ...karmaTypescriptFiles],
 	karmaTypescriptConfig: {
 		...defaultKarmaCIConfig.karmaTypescriptConfig,
 		bundlerOptions: {
 			...defaultKarmaCIConfig.karmaTypescriptConfig.bundlerOptions,
+			// change the module resolution for the KarmaTypescript bundler
 			resolve: {
 				alias: karmaTypescriptBundlerAlias
 			},
+			// Overwrite the karmaTypescriptConfig to pass the correct preset to karma-typescript-es6-transform
 			transforms: [
 				require("../stark-testing/node_modules/karma-typescript-angular2-transform"),
 				require("../stark-testing/node_modules/karma-typescript-es6-transform")({
@@ -24,10 +30,8 @@ const starkUiSpecificConfiguration = Object.assign({}, defaultKarmaCIConfig, {
 				})
 			]
 		}
-	},
-	// add missing files due to "@nationalbankbelgium/stark-ui" imports used in mock files of the testing sub-package
-	files: [...defaultKarmaCIConfig.files, ...karmaTypescriptFiles]
-});
+	}
+};
 
 // export the configuration function that karma expects and simply return the stark configuration
 module.exports = config => {

--- a/packages/stark-ui/karma.conf.js
+++ b/packages/stark-ui/karma.conf.js
@@ -25,7 +25,7 @@ const karmaTypescriptBundlerAlias = {
 	cerialize: "../stark-core/node_modules/cerialize/index.js",
 	"class-validator": "../stark-core/node_modules/class-validator/index.js",
 	"deep-freeze-strict": "../stark-core/node_modules/deep-freeze-strict/index.js",
-	moment: "../stark-core/node_modules/moment/moment.js",
+	ibantools: "../stark-core/node_modules/ibantools/build/ibantools.js",
 	"lodash-es": "../stark-core/node_modules/lodash-es/lodash.js",
 	"lodash-es/cloneDeep": "../stark-core/node_modules/lodash-es/cloneDeep.js",
 	"lodash-es/findIndex": "../stark-core/node_modules/lodash-es/findIndex.js",
@@ -39,7 +39,7 @@ const karmaTypescriptBundlerAlias = {
 	"lodash-es/reduce": "../stark-core/node_modules/lodash-es/reduce.js",
 	"lodash-es/startCase": "../stark-core/node_modules/lodash-es/startCase.js",
 	"lodash-es/uniqueId": "../stark-core/node_modules/lodash-es/uniqueId.js",
-	ibantools: "../stark-core/node_modules/ibantools/build/ibantools.js"
+	moment: "../stark-core/node_modules/moment/moment.js"
 };
 
 // start customizing the KarmaCI configuration from stark-testing

--- a/packages/stark-ui/karma.conf.js
+++ b/packages/stark-ui/karma.conf.js
@@ -43,15 +43,19 @@ const karmaTypescriptBundlerAlias = {
 };
 
 // start customizing the KarmaCI configuration from stark-testing
-const starkUiSpecificConfiguration = Object.assign({}, defaultKarmaConfig, {
-	// change the module resolution for the KarmaTypescript bundler
+const starkUiSpecificConfiguration = {
+	...defaultKarmaConfig,
+	// add missing files due to "@nationalbankbelgium/stark-ui" imports used in mock files of the testing sub-package
+	files: [...defaultKarmaConfig.files, ...karmaTypescriptFiles],
 	karmaTypescriptConfig: {
 		...defaultKarmaConfig.karmaTypescriptConfig,
 		bundlerOptions: {
 			...defaultKarmaConfig.karmaTypescriptConfig.bundlerOptions,
+			// change the module resolution for the KarmaTypescript bundler
 			resolve: {
 				alias: karmaTypescriptBundlerAlias
 			},
+			// Overwrite the karmaTypescriptConfig to pass the correct preset to karma-typescript-es6-transform
 			transforms: [
 				require("../stark-testing/node_modules/karma-typescript-angular2-transform"),
 				require("../stark-testing/node_modules/karma-typescript-es6-transform")({
@@ -59,10 +63,8 @@ const starkUiSpecificConfiguration = Object.assign({}, defaultKarmaConfig, {
 				})
 			]
 		}
-	},
-	// add missing files due to "@nationalbankbelgium/stark-ui" imports used in mock files of the testing sub-package
-	files: [...defaultKarmaConfig.files, ...karmaTypescriptFiles]
-});
+	}
+};
 
 // export the configuration function that karma expects and simply return the stark configuration
 module.exports = {

--- a/packages/stark-ui/src/modules/date-picker/components/date-picker.component.spec.ts
+++ b/packages/stark-ui/src/modules/date-picker/components/date-picker.component.spec.ts
@@ -174,7 +174,7 @@ describe("DatePickerComponent", () => {
 			});
 
 			it("the MatDatepickerInput min date should be minDate", () => {
-				const minDate: Date = new Date(2018, 6, 1);
+				const minDate = new Date(2018, 6, 1);
 				component.min = minDate;
 				hostFixture.detectChanges();
 				expect(component.pickerInput.min).not.toBeNull();
@@ -182,7 +182,7 @@ describe("DatePickerComponent", () => {
 			});
 
 			it("the MatDatepickerInput max date should be maxDate", () => {
-				const maxDate: Date = new Date(2018, 6, 2);
+				const maxDate = new Date(2018, 6, 2);
 				component.max = maxDate;
 				hostFixture.detectChanges();
 				expect(component.pickerInput.max).not.toBeNull();
@@ -190,7 +190,7 @@ describe("DatePickerComponent", () => {
 			});
 
 			it("the MatDatepickerInput value should be date", () => {
-				const date: Date = new Date(2018, 6, 3);
+				const date = new Date(2018, 6, 3);
 				hostComponent.formControl.setValue(date);
 				hostFixture.detectChanges();
 				expect(component.pickerInput.value).not.toBeNull();
@@ -341,7 +341,7 @@ describe("DatePickerComponent", () => {
 			});
 
 			it("the MatDatepickerInput min date should be minDate", () => {
-				const minDate: Date = new Date(2018, 6, 1);
+				const minDate = new Date(2018, 6, 1);
 				component.min = minDate;
 				hostFixture.detectChanges();
 				expect(component.pickerInput.min).not.toBeNull();
@@ -349,7 +349,7 @@ describe("DatePickerComponent", () => {
 			});
 
 			it("the MatDatepickerInput max date should be maxDate", () => {
-				const maxDate: Date = new Date(2018, 6, 2);
+				const maxDate = new Date(2018, 6, 2);
 				component.max = maxDate;
 				hostFixture.detectChanges();
 				expect(component.pickerInput.max).not.toBeNull();
@@ -357,7 +357,7 @@ describe("DatePickerComponent", () => {
 			});
 
 			it("the MatDatepickerInput value should be date", () => {
-				const date: Date = new Date(2018, 6, 3);
+				const date = new Date(2018, 6, 3);
 				hostComponent.value = date;
 				hostFixture.detectChanges();
 				expect(component.pickerInput.value).not.toBeNull();

--- a/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker.component.spec.ts
+++ b/packages/stark-ui/src/modules/date-range-picker/components/date-range-picker.component.spec.ts
@@ -110,7 +110,7 @@ describe("DateRangePickerComponent", () => {
 		});
 
 		it("the datepickers min date should be set correctly", () => {
-			const minDate: Date = new Date(2018, 6, 1);
+			const minDate = new Date(2018, 6, 1);
 			component.startMinDate = minDate;
 			component.endMinDate = minDate;
 			fixture.detectChanges();
@@ -121,7 +121,7 @@ describe("DateRangePickerComponent", () => {
 		});
 
 		it("the datepickers max date should be set correctly", () => {
-			const maxDate: Date = new Date(2018, 6, 2);
+			const maxDate = new Date(2018, 6, 2);
 			component.startMaxDate = maxDate;
 			component.endMaxDate = maxDate;
 			fixture.detectChanges();
@@ -132,7 +132,7 @@ describe("DateRangePickerComponent", () => {
 		});
 
 		it("the datepickers value should be set correctly", () => {
-			const date: Date = new Date(2018, 6, 3);
+			const date = new Date(2018, 6, 3);
 			component.startDate = date;
 			component.endDate = date;
 			fixture.detectChanges();
@@ -153,7 +153,7 @@ describe("DateRangePickerComponent", () => {
 		});
 
 		it("the end date should be correctly set if after the start date", () => {
-			const endDate: Date = new Date(2018, 6, 7);
+			const endDate = new Date(2018, 6, 7);
 			component.startDate = new Date(2018, 6, 6);
 			component.endDate = endDate;
 			fixture.detectChanges();
@@ -162,7 +162,7 @@ describe("DateRangePickerComponent", () => {
 		});
 
 		it("the end date should be correctly set if after the start date is undefined", () => {
-			const endDate: Date = new Date(2018, 6, 8);
+			const endDate = new Date(2018, 6, 8);
 			component.startDate = undefined;
 			component.endDate = endDate;
 			fixture.detectChanges();

--- a/showcase/package-lock.json
+++ b/showcase/package-lock.json
@@ -313,9 +313,9 @@
       }
     },
     "@angular/flex-layout": {
-      "version": "7.0.0-beta.22",
-      "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-7.0.0-beta.22.tgz",
-      "integrity": "sha512-UVsnkfRVqlHeZuOJhhl0DtX7sma68g7iu0ELKk21xrLp4twrzLtf0VHh4i2jE9oYWcRJEi3zK2qYtyTRA5NIGw==",
+      "version": "7.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-7.0.0-beta.24.tgz",
+      "integrity": "sha512-ll6sK0nLGxqI/f5+z4jbd+pve1QITzgehv2AuGvfSDgIjPMeqUDB5YZqQmIGM/dQRk/vIio5KCW5LQPJWzMMYQ==",
       "requires": {
         "tslib": "^1.7.1"
       }
@@ -15789,9 +15789,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+      "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
       "dev": true
     },
     "uglify-js": {

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -117,7 +117,7 @@
     "@angular/compiler": "~7.2.2",
     "@angular/compiler-cli": "~7.2.2",
     "@angular/core": "~7.2.2",
-    "@angular/flex-layout": "7.0.0-beta.22",
+    "@angular/flex-layout": "7.0.0-beta.24",
     "@angular/forms": "~7.2.2",
     "@angular/material": "~7.3.0",
     "@angular/platform-browser": "~7.2.2",
@@ -157,6 +157,6 @@
     "parse5": "~5.1.0",
     "ts-node": "~8.0.2",
     "tslib": "~1.9.3",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.4"
   }
 }

--- a/showcase/src/app/demo-ui/pages/date-picker/demo-date-picker-page.component.ts
+++ b/showcase/src/app/demo-ui/pages/date-picker/demo-date-picker-page.component.ts
@@ -15,7 +15,7 @@ export class DemoDatePickerPageComponent implements OnDestroy {
 	public minDate = new Date();
 	public maxDate = new Date(Date.now() + 30 * DAY_IN_MILLISECONDS);
 
-	public ngModelDate: Date = new Date();
+	public ngModelDate = new Date();
 	public formControl = new FormControl(new Date(), Validators.required);
 
 	public disabled = false;

--- a/showcase/src/app/demo-ui/pages/input-mask-directives/demo-input-mask-directives-page.component.ts
+++ b/showcase/src/app/demo-ui/pages/input-mask-directives/demo-input-mask-directives-page.component.ts
@@ -115,7 +115,7 @@ export class DemoInputMaskDirectivesPageComponent {
 	}
 
 	public logChange(event: Event): void {
-		this.logger.debug("input value changed", (<HTMLInputElement>event.srcElement).value);
+		this.logger.debug("input value changed", (<HTMLInputElement>event.target).value);
 	}
 
 	public logModelChange(model: any): void {

--- a/showcase/src/app/in-memory-data/interceptors/in-memory-data.interceptor.ts
+++ b/showcase/src/app/in-memory-data/interceptors/in-memory-data.interceptor.ts
@@ -184,7 +184,7 @@ export class InMemoryDataHttpInterceptor implements HttpInterceptor {
 		// 	.add(40, "m")
 		// 	.toDate()
 		// 	.toUTCString(); // 40 minutes from now
-		const expirationDate: Date = new Date();
+		const expirationDate = new Date();
 		expirationDate.setTime(new Date().getTime() + 2400000); // 40 minutes from now
 		const cookieExpiration: string = expirationDate.toUTCString();
 		const cookieAttributes: string[] = [`${this.xsrfCookieName}=${xsrfToken}`, `path='/'`, `expires=${cookieExpiration}`];

--- a/showcase/src/app/shared/components/table-of-contents/table-of-contents.component.ts
+++ b/showcase/src/app/shared/components/table-of-contents/table-of-contents.component.ts
@@ -9,7 +9,7 @@ import { TableOfContentLink } from "./table-of-content-link.intf";
 	templateUrl: "./table-of-contents.component.html"
 })
 /**
- * The table of contents component, freely inspired from :
+ * The table of contents component, freely inspired from:
  * @link https://github.com/angular/material.angular.io/tree/master/src/app/shared/table-of-contents
  */
 export class TableOfContentsComponent implements OnInit, AfterViewInit, OnDestroy {
@@ -67,7 +67,7 @@ export class TableOfContentsComponent implements OnInit, AfterViewInit, OnDestro
 	}
 
 	/**
-	 * Gets the scrolloffset of the container.
+	 * Gets the scrollOffset of the container.
 	 * Basically, this will return the position on the screen where the user is located.
 	 */
 	private getScrollOffset(): number {
@@ -118,10 +118,8 @@ export class TableOfContentsComponent implements OnInit, AfterViewInit, OnDestro
 	 */
 	private onScroll(): void {
 		const linksCounter: number = this.links.length - 1;
-		const max: number = (<HTMLElement>document.documentElement).scrollHeight;
-		const pos: number =
-			((<HTMLElement>document.documentElement).scrollTop || document.body.scrollTop) +
-			(<HTMLElement>document.documentElement).offsetHeight;
+		const max: number = document.documentElement.scrollHeight;
+		const pos: number = (document.documentElement.scrollTop || document.body.scrollTop) + document.documentElement.offsetHeight;
 		if (pos === max) {
 			this.links[linksCounter].active = true;
 			for (let i = 0; i < linksCounter; i++) {
@@ -137,8 +135,8 @@ export class TableOfContentsComponent implements OnInit, AfterViewInit, OnDestro
 
 	/**
 	 * This method will check, thanks to the user's position on a screen, if a link is active or not.
-	 * If the value of scrolloffset is higher than the top of the currentlink (so, below the currentLink)
-	 * and lower than the top of tne nextlinkg (so, above the nextLink), it means that the link is active.
+	 * If the value of scrollOffset is higher than the top of the current link (so, below the current link)
+	 * and lower than the top of tne next link (so, above the next link), it means that the link is active.
 	 * @param currentLink - the Link we are analysing
 	 * @param nextLink - the Link that follows the currentLink
 	 * @returns - if the link is active (true) or not (false)

--- a/showcase/src/assets/examples/date-picker/ng-model.ts
+++ b/showcase/src/assets/examples/date-picker/ng-model.ts
@@ -12,7 +12,7 @@ export class DemoDatePickerComponent {
 	public minDate = new Date();
 	public maxDate = new Date(Date.now() + 30 * DAY_IN_MILLISECONDS);
 
-	public date: Date = new Date();
+	public date = new Date();
 	public disabled = false;
 
 	public maskConfig: StarkTimestampMaskConfig = { format: "DD-MM-YYYY" };

--- a/starter/package.json
+++ b/starter/package.json
@@ -123,7 +123,7 @@
     "@angular/compiler": "~7.2.2",
     "@angular/compiler-cli": "~7.2.2",
     "@angular/core": "~7.2.2",
-    "@angular/flex-layout": "7.0.0-beta.22",
+    "@angular/flex-layout": "7.0.0-beta.24",
     "@angular/forms": "~7.2.2",
     "@angular/material": "~7.3.0",
     "@angular/platform-browser": "~7.2.2",
@@ -160,6 +160,6 @@
     "parse5": "~5.1.0",
     "ts-node": "~8.0.2",
     "tslib": "~1.9.3",
-    "typescript": "~3.1.6"
+    "typescript": "~3.2.4"
   }
 }


### PR DESCRIPTION
ISSUES CLOSED: #1234

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1234 


## What is the new behavior?
- upgraded `typescript` to version 3.2.4
- upgraded `@angular/flex-layout` to latest version (7.0.0-beta.24) since it depends on TS 3.2
- removed `@angular/flex-layout` from `greenkeeper.json` exclusions
- fix minor issues due to new deprecations in TypeSscript 3.2 DOM API
- removed some unnecessary types that are inferrable
- added missing RBAC tests in npm `test:ci:all` script
- fixed wrong code coverage report generation path in karma CI config (bug introduced in #1147)

**IMPORTANT**
The new [`strictBindCallApply`](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#strictbindcallapply) option in TS 3.2 is not added to `packages/stark-build/tsconfig.json` to avoid having a breaking change in all the apps whose `tsconfig` extend from this one so they are not forced to use TS 3.2. This is not an issue because the `strict` option is enabled so the new `strictBindCallApply` will be enalbled automatically in case the TypeScript version is 3.2 or higher. See https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#strictbindcallapply

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```