### PR TITLE
fix(stark-ui): properly size `.stark-main-container` on different screen sizes

### DIFF
--- a/packages/stark-ui/assets/styles/_base.scss
+++ b/packages/stark-ui/assets/styles/_base.scss
@@ -21,23 +21,11 @@ body {
     flex: 1 0 auto;
     align-self: center;
 
-    max-width: 100%;
+    width: 100%;
+    max-width: $stark-max-content-width;
+
     box-sizing: border-box;
     padding: 64px 15px;
-  }
-}
-@media #{$tablet-query} {
-  .stark-main-container {
-    padding-left: 70px;
-    padding-right: 70px;
-  }
-}
-
-// We want to keep at least 70px horizontal padding for the main content, therefore we add 140px to the media query
-@media screen and (min-width: 1100px) {
-  .stark-main-container {
-    align-self: center;
-    width: $stark-max-content-width;
   }
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When the view width gets below 1100px the `.stark-main-container` sizes on content width, creating a lot of white space and inconsistent design across different pages.

Issue Number: N/A


## What is the new behavior?
Scales better.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information