### PR TITLE
Bugfix/date picker mask weird behavior + inconsistent date picker locale in Showcase and Starter

### DIFF
--- a/packages/stark-ui/src/modules/input-mask-directives/directives/timestamp-mask.directive.ts
+++ b/packages/stark-ui/src/modules/input-mask-directives/directives/timestamp-mask.directive.ts
@@ -122,7 +122,8 @@ export class StarkTimestampMaskDirective extends MaskedInputDirective implements
 			return {
 				pipe: <any>createTimestampPipe(timestampMaskConfig.format),
 				mask: this.convertFormatIntoMask(timestampMaskConfig.format),
-				placeholderChar: "_"
+				placeholderChar: "_",
+				keepCharPositions: true // to avoid weird date values when deleting characters (see https://github.com/NationalBankBelgium/stark/issues/1260)
 			};
 		}
 	}

--- a/packages/stark-ui/src/modules/input-mask-directives/directives/timestamp-pipe.fn.spec.ts
+++ b/packages/stark-ui/src/modules/input-mask-directives/directives/timestamp-pipe.fn.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:completed-docs */
+/* tslint:disable:completed-docs no-big-function */
 import { createTimestampPipe } from "./timestamp-pipe.fn";
 
 describe("createTimestampPipe", () => {
@@ -26,12 +26,13 @@ describe("createTimestampPipe", () => {
 	});
 
 	describe("with the default format: 'DD-MM-YYYY HH:mm:ss'", () => {
-		it("should return the same date time string if a part of date time string is correct", () => {
-			const validDateTimeStrings: string[] = [
+		it("should return the date time string if the partial date time string is correct", () => {
+			const validDateTimeStrings = [
 				"31",
-				"29-02",
+				"29-02", // valid date until no year is entered
 				"29-02-20",
 				"29-02-200",
+				"30-12-2017",
 				"0", // when typing a day starting with 0
 				"29-0" // when typing a month starting with 0
 			];
@@ -39,34 +40,103 @@ describe("createTimestampPipe", () => {
 			assertTimestampsValidity(validDateTimeStrings, true);
 		});
 
-		it("should return FALSE if a part of date time string is incorrect", () => {
-			const invalidDateTimeStrings: string[] = ["02-13", "30-02", "31-04"];
+		it("should return the date time string if the partial date time string is correct including placeholder characters", () => {
+			// FIXME: uncomment the date strings below that should be valid once we enhance the logic of the createTimestampPipe function (https://github.com/NationalBankBelgium/stark/issues/1277)
+			const validDateTimeStrings = [
+				"3_",
+				"__-02", // valid date until no year is entered
+				"29-__-20",
+				"29-0_-200",
+				"30-1_-2017",
+				"30-12-____",
+				"30-12-2___",
+				"30-12-20__",
+				"30-12-201_",
+				// "30-12-2017 __:15:20",
+				// "30-12-2017 1_:15:20",
+				// "30-12-2017 10:__:20",
+				// "30-12-2017 10:1_:20",
+				"30-12-2017 10:15:__",
+				"30-12-2017 10:15:2_",
+				"0_", // when typing a day starting with 0
+				"29-0_" // when typing a month starting with 0
+			];
+
+			assertTimestampsValidity(validDateTimeStrings, true);
+		});
+
+		it("should return FALSE if the day-month combination in the date time string is incorrect", () => {
+			const invalidDateTimeStrings = [
+				"32-01",
+				"30-02", // although 29-02 might be valid in case of a leap year
+				"32-03",
+				"31-04",
+				"32-05",
+				"31-06",
+				"32-07",
+				"32-08",
+				"31-09",
+				"32-10",
+				"31-11",
+				"32-12"
+			];
 
 			assertTimestampsValidity(invalidDateTimeStrings, false);
 		});
 
 		it("should return FALSE if the date time string doesn't match the format", () => {
-			const invalidDateTimeStrings: string[] = [
-				"32-12-2000 12:12:12",
-				"40-12-2000 12:12:12",
-				"22-13-2000 12:12:12",
-				"22-20-2000 12:12:12",
-				"22-11-3000 12:12:12",
-				"22-11-2000 62:12:12",
-				"22-11-2000 70:12:12",
-				"22-11-2000 44:13:12",
-				"22-11-2000 44:70:12",
-				"22-11-2000 44:44:62",
-				"22-11-2000 44:44:70"
+			const invalidDateTimeStrings = ["30/12/2000", "12/30/2000 12:12:12", "12-30-2000 12:12:12"];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false);
+		});
+
+		it("should return the date time string if it is 29 February and is a leap year or FALSE otherwise", () => {
+			const invalidDateTimeStrings = [
+				"02-29-2017 10:15:20", // non leap year
+				"02-29-2018" // non leap year
 			];
 
 			assertTimestampsValidity(invalidDateTimeStrings, false);
+
+			const validDateTimeStrings = [
+				"29-02-2016 10:15:20", // leap year
+				"29-02-2012" // leap year
+			];
+
+			assertTimestampsValidity(validDateTimeStrings, true);
+		});
+
+		it("should return FALSE if any of the parts of the date time string is not within the valid range of values", () => {
+			const invalidDateTimeStrings = [
+				"32-12-2000 12:12:12", // day
+				"00-12-2000 12:12:12",
+				"20-13-2000 12:12:12", // month
+				"20-00-2000 12:12:12",
+				"20-12-2000 24:12:12", // hours
+				"20-12-2000 13:60:12", // minutes
+				"20-12-2000 13:12:60" // seconds
+			];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false);
+
+			const validDateTimeStrings = [
+				"20-12-9999 12:12:12", // year
+				"20-12-0000 12:12:12", // year
+				"20-12-2000 23:12:12", // hours
+				"20-12-2000 00:12:12", // hours
+				"20-12-2000 13:00:12", // minutes
+				"20-12-2000 13:59:12", // minutes
+				"20-12-2000 13:12:59", // seconds
+				"20-12-2000 13:12:00" // seconds
+			];
+
+			assertTimestampsValidity(validDateTimeStrings, true);
 		});
 	});
 
 	describe("with a custom format", () => {
-		it("should return the same date time string if a part of date time string is correct", () => {
-			let validDateTimeStrings: string[] = [
+		it("should return the date time string if the partial date time string is correct", () => {
+			let validDateTimeStrings = [
 				"2017-30-12",
 				"2016-29-02 10:15:20" // leap year
 			];
@@ -82,41 +152,186 @@ describe("createTimestampPipe", () => {
 			assertTimestampsValidity(validDateTimeStrings, true, fullDateTimeShortYearFormat);
 		});
 
-		it("should return FALSE if 29 February is given and the format given has no year", () => {
-			// it is invalid because when there is no year specified, it is assumed to be something recurrent
-			// and you shouldn't put something recurrent on a Feb 29!
-
-			let validDateTimeStrings: string[] = [
-				"29-02" // valid date until no year is entered
+		it("should return the date time string if the partial date time string is correct including placeholder characters", () => {
+			// FIXME: uncomment the date strings below that should be valid once we enhance the logic of the createTimestampPipe function (https://github.com/NationalBankBelgium/stark/issues/1277)
+			let validDateTimeStrings = [
+				// "____-30-12",
+				// "2___-30-12",
+				// "20__-30-12",
+				// "201_-30-12",
+				"2017-__-12",
+				"2017-3_-12",
+				"2017-3_-__",
+				"2017-3_-1_",
+				// "2016-29-02 __:15:20", // leap year
+				// "2016-29-02 1_:15:20", // leap year
+				// "2016-29-02 10:__:20", // leap year
+				// "2016-29-02 10:1_:20", // leap year
+				"2016-29-02 10:15:__", // leap year
+				"2016-29-02 10:15:2_" // leap year
 			];
 
-			assertTimestampsValidity(validDateTimeStrings, false, "DD-MM");
+			assertTimestampsValidity(validDateTimeStrings, true, fullDateTimeLongYearFormat);
 
 			validDateTimeStrings = [
-				"02-29" // valid date until no year is entered
+				"__-11-15 12:12:12",
+				"2_-11-15 12:12:12",
+				"22-__-15 12:12:12",
+				"22-1_-15 12:12:12",
+				"__-02",
+				"2_-02",
+				"29-__",
+				"29-0_",
+				// "29-02-16 __:15:20", // leap year
+				// "29-02-16 1_:15:20", // leap year
+				// "29-02-16 10:__:20", // leap year
+				// "29-02-16 10:1_:20", // leap year
+				"29-02-16 10:15:__", // leap year
+				"29-02-16 10:15:2_" // leap year
 			];
 
-			assertTimestampsValidity(validDateTimeStrings, false, "MM-DD");
+			assertTimestampsValidity(validDateTimeStrings, true, fullDateTimeShortYearFormat);
 		});
 
-		it("should return FALSE if the date time string doesn't match the format", () => {
-			let invalidDateTimeStrings: string[] = [
-				"2017/30/12",
-				"2017/30/12 12:12:12",
-				"2017-29-02 10:15:20", // non leap year
-				"31-12-2000"
+		it("should return FALSE if the day-month combination in the date time string is incorrect", () => {
+			let invalidDateTimeStrings = [
+				"2019-32-01",
+				"2019-30-02",
+				"2019-32-03",
+				"2019-31-04",
+				"2019-32-05",
+				"2019-31-06",
+				"2019-32-07",
+				"2019-32-08",
+				"2019-31-09",
+				"2019-32-10",
+				"2019-31-11",
+				"2019-32-12"
 			];
 
 			assertTimestampsValidity(invalidDateTimeStrings, false, fullDateTimeLongYearFormat);
 
 			invalidDateTimeStrings = [
-				"30/12/17",
-				"30/12/2017 12:12:12",
-				"29-02-17 10:15:20", // non leap year
-				"31-12-2000"
+				"32-01",
+				"30-02", // although 29-02 might be valid in case of a leap year
+				"32-03",
+				"31-04",
+				"32-05",
+				"31-06",
+				"32-07",
+				"32-08",
+				"31-09",
+				"32-10",
+				"31-11",
+				"32-12"
 			];
 
 			assertTimestampsValidity(invalidDateTimeStrings, false, fullDateTimeShortYearFormat);
+		});
+
+		it("should return FALSE if 29 February is given and the format given has no year", () => {
+			// it is invalid because when there is no year specified, it is assumed to be something recurrent
+			// and you shouldn't put something recurrent on a Feb 29!
+
+			let invalidDateTimeStrings = ["29-02"];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false, "DD-MM");
+
+			invalidDateTimeStrings = ["02-29"];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false, "MM-DD");
+		});
+
+		it("should return FALSE if the date time string doesn't match the format", () => {
+			let invalidDateTimeStrings = ["2017/30/12", "2017/30/12 12:12:12", "31-12-2000"];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false, fullDateTimeLongYearFormat);
+
+			invalidDateTimeStrings = ["30/12/17", "30/12/2017 12:12:12", "31-12-2000"];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false, fullDateTimeShortYearFormat);
+		});
+
+		it("should return the date time string if it is 29 February and is a leap year or FALSE otherwise", () => {
+			let invalidDateTimeStrings = [
+				"2017-29-02 10:15:20", // non leap year
+				"2018-29-02" // non leap year
+			];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false, fullDateTimeLongYearFormat);
+
+			let validDateTimeStrings = [
+				"2016-29-02 10:15:20", // leap year
+				"2012-29-02" // leap year
+			];
+
+			assertTimestampsValidity(validDateTimeStrings, true, fullDateTimeLongYearFormat);
+
+			invalidDateTimeStrings = [
+				"29-02-17 10:15:20", // non leap year
+				"29-02-18" // non leap year
+			];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false, fullDateTimeShortYearFormat);
+
+			validDateTimeStrings = [
+				"29-02-16 10:15:20", // leap year
+				"29-02-12" // leap year
+			];
+
+			assertTimestampsValidity(validDateTimeStrings, true, fullDateTimeShortYearFormat);
+		});
+
+		it("should return FALSE if any of the parts of the date time string is not within the valid range of values", () => {
+			let invalidDateTimeStrings = [
+				"2000-32-12 12:12:12", // day
+				"2000-00-12 12:12:12",
+				"2000-20-13 12:12:12", // month
+				"2000-20-00 12:12:12",
+				"2000-20-12 24:12:12", // hours
+				"2000-20-12 13:60:12", // minutes
+				"2000-20-12 13:12:60" // seconds
+			];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false, fullDateTimeLongYearFormat);
+
+			let validDateTimeStrings = [
+				"9999-20-12 12:12:12", // year
+				"0000-20-12 12:12:12", // year
+				"2000-20-12 23:12:12", // hours
+				"2000-20-12 00:12:12", // hours
+				"2000-20-12 13:00:12", // minutes
+				"2000-20-12 13:59:12", // minutes
+				"2000-20-12 13:12:59", // seconds
+				"2000-20-12 13:12:00" // seconds
+			];
+
+			assertTimestampsValidity(validDateTimeStrings, true, fullDateTimeLongYearFormat);
+
+			invalidDateTimeStrings = [
+				"32-12-00 12:12:12", // day
+				"00-12-00 12:12:12",
+				"20-13-00 12:12:12", // month
+				"20-00-00 12:12:12",
+				"20-12-00 24:12:12", // hours
+				"20-12-00 13:60:12", // minutes
+				"20-12-00 13:12:60" // seconds
+			];
+
+			assertTimestampsValidity(invalidDateTimeStrings, false, fullDateTimeShortYearFormat);
+
+			validDateTimeStrings = [
+				"20-12-99 12:12:12", // year
+				"20-12-00 12:12:12", // year
+				"20-12-00 23:12:12", // hours
+				"20-12-00 00:12:12", // hours
+				"20-12-00 13:00:12", // minutes
+				"20-12-00 13:59:12", // minutes
+				"20-12-00 13:12:59", // seconds
+				"20-12-00 13:12:00" // seconds
+			];
+
+			assertTimestampsValidity(validDateTimeStrings, true, fullDateTimeShortYearFormat);
 		});
 	});
 });

--- a/showcase/src/app/app.module.ts
+++ b/showcase/src/app/app.module.ts
@@ -263,7 +263,7 @@ export class AppModule {
 
 		this.settingsService.initializeSettings();
 
-		sessionService
+		this.sessionService
 			.getCurrentUser()
 			.pipe(filter((user?: StarkUser): user is StarkUser => typeof user !== "undefined"))
 			.subscribe((user: StarkUser) => {

--- a/showcase/src/app/shared/shared.module.ts
+++ b/showcase/src/app/shared/shared.module.ts
@@ -1,3 +1,4 @@
+import { DateAdapter } from "@angular/material/core";
 import { MatButtonModule } from "@angular/material/button";
 import { MatCardModule } from "@angular/material/card";
 import { MatIconModule } from "@angular/material/icon";
@@ -5,10 +6,19 @@ import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatTabsModule } from "@angular/material/tabs";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { CommonModule } from "@angular/common";
-import { NgModule } from "@angular/core";
+import { Inject, NgModule } from "@angular/core";
 import { StarkPrettyPrintModule, StarkSvgViewBoxModule } from "@nationalbankbelgium/stark-ui";
 import { TranslateModule } from "@ngx-translate/core";
 import { FlexLayoutModule } from "@angular/flex-layout";
+import {
+	STARK_APP_METADATA,
+	STARK_SESSION_SERVICE,
+	StarkApplicationMetadata,
+	StarkLanguage,
+	StarkSessionService
+} from "@nationalbankbelgium/stark-core";
+import moment from "moment";
+import { filter } from "rxjs/operators";
 import { ExampleViewerComponent, ReferenceBlockComponent, TableOfContentsComponent } from "./components";
 import { FileService } from "./services";
 
@@ -31,4 +41,32 @@ import { FileService } from "./services";
 	entryComponents: [],
 	exports: [ExampleViewerComponent, ReferenceBlockComponent, TableOfContentsComponent, FlexLayoutModule, StarkSvgViewBoxModule]
 })
-export class SharedModule {}
+export class SharedModule {
+	public constructor(
+		@Inject(STARK_APP_METADATA) private appMetadata: StarkApplicationMetadata,
+		@Inject(STARK_SESSION_SERVICE) private sessionService: StarkSessionService,
+		private dateAdapter: DateAdapter<any>
+	) {
+		/**
+		 * When the application language changes, the Moment locale and the Material Moment Adapter (internally used by Stark Date Pickers) should be changed as well
+		 * FIXME: currently this logic cannot be implemented in the AppModule and should be implemented in a different module instead (see https://github.com/angular/components/issues/15419)
+		 */
+		this.sessionService
+			.getCurrentLanguage()
+			.pipe(filter((currentLang?: string): currentLang is string => typeof currentLang !== "undefined"))
+			.subscribe((currentLang: string) => {
+				const matchingAppLanguage: StarkLanguage | undefined = this.appMetadata.supportedLanguages.filter(
+					(language: StarkLanguage) => language.code === currentLang
+				)[0];
+
+				// change the Moment locale to the matching locale from AppMetadata or use the 'currentLang' instead if no locale matched
+				// IMPORTANT: Moment won't change the locale (it will keep the current one) if it doesn't know the locale specified
+				const momentLocale = matchingAppLanguage
+					? moment.locale(matchingAppLanguage.isoCode.toLowerCase())
+					: moment.locale(currentLang);
+
+				// finally, the locale of the Material Moment Adapter should be set
+				this.dateAdapter.setLocale(momentLocale);
+			});
+	}
+}

--- a/showcase/src/app/translation.config.ts
+++ b/showcase/src/app/translation.config.ts
@@ -1,6 +1,7 @@
+import moment from "moment";
 import "moment/locale/fr";
 import "moment/locale/nl-be";
-import "moment/locale/en-gb";
+// no need to load the English locale since we use US English and Moment default language is just that one (see https://momentjs.com/docs/#/i18n/changing-locale/)
 
 import { TranslateService } from "@ngx-translate/core";
 import { DateAdapter } from "@angular/material/core";
@@ -15,7 +16,9 @@ export function initializeTranslation(translateService: TranslateService, dateAd
 	translateService.setDefaultLang("en");
 	translateService.use("en");
 
-	dateAdapter.setLocale("en-us");
+	// set the Moment language, otherwise it is set by the last imported locale!
+	moment.locale("en"); // in fact Moment default language is US English
+	dateAdapter.setLocale("en"); // US English locale in Moment is just "en"
 
 	const english: StarkLocale = { languageCode: "en", translations: translationsEn };
 	const french: StarkLocale = { languageCode: "fr", translations: translationsFr };

--- a/starter/src/app/app.module.ts
+++ b/starter/src/app/app.module.ts
@@ -218,7 +218,7 @@ export class AppModule {
 
 		this.settingsService.initializeSettings();
 
-		sessionService
+		this.sessionService
 			.getCurrentUser()
 			.pipe(filter((user?: StarkUser): user is StarkUser => typeof user !== "undefined"))
 			.subscribe((user: StarkUser) => {

--- a/starter/src/app/home/home.module.ts
+++ b/starter/src/app/home/home.module.ts
@@ -1,6 +1,16 @@
-import { NgModule } from "@angular/core";
+import { Inject, NgModule } from "@angular/core";
 import { UIRouterModule } from "@uirouter/angular";
+import { DateAdapter } from "@angular/material/core";
 import { TranslateModule } from "@ngx-translate/core";
+import {
+	STARK_APP_METADATA,
+	STARK_SESSION_SERVICE,
+	StarkApplicationMetadata,
+	StarkLanguage,
+	StarkSessionService
+} from "@nationalbankbelgium/stark-core";
+import moment from "moment";
+import { filter } from "rxjs/operators";
 import { AboutPageComponent, HomePageComponent, NoContentPageComponent } from "./pages";
 import { HOME_STATES } from "./routes";
 
@@ -14,4 +24,32 @@ import { HOME_STATES } from "./routes";
 	declarations: [AboutPageComponent, HomePageComponent, NoContentPageComponent],
 	exports: []
 })
-export class HomeModule {}
+export class HomeModule {
+	public constructor(
+		@Inject(STARK_APP_METADATA) private appMetadata: StarkApplicationMetadata,
+		@Inject(STARK_SESSION_SERVICE) private sessionService: StarkSessionService,
+		private dateAdapter: DateAdapter<any>
+	) {
+		/**
+		 * When the application language changes, the Moment locale and the Material Moment Adapter (internally used by Stark Date Pickers) should be changed as well
+		 * FIXME: currently this logic cannot be implemented in the AppModule and should be implemented in a different module instead (see https://github.com/angular/components/issues/15419)
+		 */
+		this.sessionService
+			.getCurrentLanguage()
+			.pipe(filter((currentLang?: string): currentLang is string => typeof currentLang !== "undefined"))
+			.subscribe((currentLang: string) => {
+				const matchingAppLanguage: StarkLanguage | undefined = this.appMetadata.supportedLanguages.filter(
+					(language: StarkLanguage) => language.code === currentLang
+				)[0];
+
+				// change the Moment locale to the matching locale from AppMetadata or use the 'currentLang' instead if no locale matched
+				// IMPORTANT: Moment won't change the locale (it will keep the current one) if it doesn't know the locale specified
+				const momentLocale = matchingAppLanguage
+					? moment.locale(matchingAppLanguage.isoCode.toLowerCase())
+					: moment.locale(currentLang);
+
+				// finally, the locale of the Material Moment Adapter should be set
+				this.dateAdapter.setLocale(momentLocale);
+			});
+	}
+}

--- a/starter/src/app/translation.config.ts
+++ b/starter/src/app/translation.config.ts
@@ -1,6 +1,7 @@
+import moment from "moment";
 import "moment/locale/fr";
 import "moment/locale/nl-be";
-import "moment/locale/en-gb";
+// no need to load the English locale since we use US English and Moment default language is just that one (see https://momentjs.com/docs/#/i18n/changing-locale/)
 
 import { TranslateService } from "@ngx-translate/core";
 import { DateAdapter } from "@angular/material/core";
@@ -15,7 +16,9 @@ export function initializeTranslation(translateService: TranslateService, dateAd
 	translateService.setDefaultLang("en");
 	translateService.use("en");
 
-	dateAdapter.setLocale("en-us");
+	// set the Moment language, otherwise it is set by the last imported locale!
+	moment.locale("en"); // in fact Moment default language is US English
+	dateAdapter.setLocale("en"); // US English locale in Moment is just "en"
 
 	const english: StarkLocale = { languageCode: "en", translations: translationsEn };
 	const french: StarkLocale = { languageCode: "fr", translations: translationsFr };


### PR DESCRIPTION
ISSUES CLOSED: #1260 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1260


## What is the new behavior?
- now when deleting a character, the mask keeps the position as empty instead of moving the characters backwards so the user can safely type in the new character. This prevents the date picker from getting weird date values. The `keepCharPositions` option is now enabled in the timestamp directive (see https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#keepcharpositions)
- the max and min range values for the different date parts of a timestamp are now correct.
- expanded the unit tests of the `createTimestampPipe` to cover all possible use cases with date time strings.
- enhanced the translation initialization to also initialize the Moment locale to keep it in sync with the application language.
- implemented some logic to change the Moment locale and the Material Date Adapter when the app language changes.

**IMPORTANT: Although the locale of the Material Date Adapter is now changed when the app language changes, the date pickers don't reflect the new locale. This is a known bug in Angular Material (see https://github.com/angular/components/issues/15419) and should be fixed soon.**

**So for the moment, the logic has been put in the `SharedModule` instead to make it work**

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->