### PR TITLE
feat(stark-build): enable all strict type checking options in tsconfig.json file. Remove obsolete options

### DIFF
--- a/packages/stark-build/tsconfig.json
+++ b/packages/stark-build/tsconfig.json
@@ -24,7 +24,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": false,
+    "noImplicitThis": true,
     "noImplicitUseStrict": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -50,11 +50,6 @@
     "paths": {}
   },
   "exclude": ["node_modules", "dist", "packages/stark-build/config-stark"],
-  "awesomeTypescriptLoaderOptions": {
-    "forkChecker": true,
-    "useWebpackText": true,
-    "useCache": false
-  },
   "formatCodeOptions": {
     "indentSize": 2,
     "tabSize": 4,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Since the TypeScript configuration used in Stark will be moved to a separate package: https://github.com/NationalBankBelgium/code-style. It is important to update/enhance our TypeScript compilation rules to make sure we keep those that are really relevant for our packages.


## What is the new behavior?
All the [strict type checking options](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#new---strict-master-option) are now enabled:

- noImplicitAny
- [noImplicitThis](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#--noimplicitthis)
- [alwaysStrict](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#new---alwaysstrict)
- [strictBindCallApply](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#strictbindcallapply)
- [strictNullChecks](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#strictbindcallapply)
- [strictFunctionTypes](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#strict-function-types)
- [strictPropertyInitialization](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#strict-class-initialization)

No actual changes in our code since we already enabled most of those rules 👍 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```