### PR TITLE
refactor(stark-all): remove usages of starkSvgViewBox directive where it is no longer needed

### DIFF
--- a/packages/stark-ui/package.json
+++ b/packages/stark-ui/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@angular/material-moment-adapter": "^7.0.0",
-    "@mdi/angular-material": "^3.3.92",
+    "@mdi/angular-material": "^3.6.95",
     "@types/lodash-es": "^4.17.1",
     "@types/nouislider": "^9.0.4",
     "@types/prismjs": "^1.16.0",

--- a/packages/stark-ui/src/modules/action-bar/action-bar.module.ts
+++ b/packages/stark-ui/src/modules/action-bar/action-bar.module.ts
@@ -4,13 +4,12 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatIconModule } from "@angular/material/icon";
 import { MatMenuModule } from "@angular/material/menu";
 import { MatTooltipModule } from "@angular/material/tooltip";
-import { StarkSvgViewBoxModule } from "../svg-view-box/svg-view-box.module";
 import { StarkActionBarComponent } from "./components";
 import { TranslateModule } from "@ngx-translate/core";
 
 @NgModule({
 	declarations: [StarkActionBarComponent],
-	imports: [CommonModule, StarkSvgViewBoxModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule, TranslateModule],
+	imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule, TranslateModule],
 	exports: [StarkActionBarComponent]
 })
 export class StarkActionBarModule {}

--- a/packages/stark-ui/src/modules/action-bar/components/action-bar.component.html
+++ b/packages/stark-ui/src/modules/action-bar/components/action-bar.component.html
@@ -21,7 +21,6 @@
 					type="button"
 				>
 					<mat-icon
-						starkSvgViewBox
 						[svgIcon]="action.iconSwitchFunction ? action.iconActivated : action.icon"
 						class="stark-small-icon"
 					></mat-icon>
@@ -46,7 +45,7 @@
 			(click)="toggleExtendedActionBar()"
 			type="button"
 		>
-			<mat-icon starkSvgViewBox svgIcon="dots-horizontal" class="stark-small-icon"></mat-icon>
+			<mat-icon svgIcon="dots-horizontal" class="stark-small-icon"></mat-icon>
 		</button>
 		<button
 			class="open-alt-actions"
@@ -56,7 +55,7 @@
 			[matMenuTriggerFor]="menu"
 			type="button"
 		>
-			<mat-icon starkSvgViewBox svgIcon="dots-vertical" class="stark-small-icon"></mat-icon>
+			<mat-icon svgIcon="dots-vertical" class="stark-small-icon"></mat-icon>
 		</button>
 		<mat-menu #menu="matMenu" xPosition="before">
 			<div
@@ -68,7 +67,7 @@
 			>
 				<ng-container *ngIf="action.isVisible !== false">
 					<div [ngClass]="action.className">
-						<mat-icon starkSvgViewBox [svgIcon]="action.icon" class="stark-small-icon"></mat-icon>
+						<mat-icon [svgIcon]="action.icon" class="stark-small-icon"></mat-icon>
 						<span translate>{{ action.label }}</span>
 					</div>
 				</ng-container>

--- a/packages/stark-ui/src/modules/app-data/app-data.module.ts
+++ b/packages/stark-ui/src/modules/app-data/app-data.module.ts
@@ -10,11 +10,10 @@ import { mergeUiTranslations } from "../../common/translations";
 import { translationsEn } from "./assets/translations/en";
 import { translationsNl } from "./assets/translations/nl";
 import { StarkLocale } from "@nationalbankbelgium/stark-core";
-import { StarkSvgViewBoxModule } from "../svg-view-box";
 
 @NgModule({
 	declarations: [StarkAppDataComponent],
-	imports: [CommonModule, StarkSvgViewBoxModule, MatButtonModule, MatIconModule, MatTooltipModule, TranslateModule],
+	imports: [CommonModule, MatButtonModule, MatIconModule, MatTooltipModule, TranslateModule],
 	exports: [StarkAppDataComponent]
 })
 export class StarkAppDataModule {

--- a/packages/stark-ui/src/modules/app-data/components/app-data.component.html
+++ b/packages/stark-ui/src/modules/app-data/components/app-data.component.html
@@ -10,7 +10,7 @@
 	</div>
 
 	<button mat-icon-button aria-label="Application Data" (click)="toggleDetail()" [ngClass]="{ 'is-open': !isDetailHidden }" mat-button>
-		<mat-icon svgIcon="menu-down" starkSvgViewBox></mat-icon>
+		<mat-icon svgIcon="menu-down"></mat-icon>
 	</button>
 	<div class="stark-app-data-detail stark-fade-animation" *ngIf="!isDetailHidden">
 		<ng-container *ngTemplateOutlet="appDataDetail"></ng-container>
@@ -25,7 +25,7 @@
 		mat-button
 		[matTooltip]="'STARK.ICONS.APP_DATA' | translate"
 	>
-		<mat-icon svgIcon="dots-vertical" starkSvgViewBox></mat-icon>
+		<mat-icon svgIcon="dots-vertical"></mat-icon>
 	</button>
 	<div class="stark-app-data-detail animate-show-hide" *ngIf="!isDetailHidden">
 		<ng-container *ngTemplateOutlet="appDataDetail"></ng-container>

--- a/packages/stark-ui/src/modules/app-logout/app-logout.module.ts
+++ b/packages/stark-ui/src/modules/app-logout/app-logout.module.ts
@@ -5,7 +5,6 @@ import { MatButtonModule } from "@angular/material/button";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { StarkLocale } from "@nationalbankbelgium/stark-core";
 import { StarkAppLogoutComponent } from "./components";
-import { StarkSvgViewBoxModule } from "../svg-view-box/svg-view-box.module";
 import { translationsEn } from "./assets/translations/en";
 import { translationsFr } from "./assets/translations/fr";
 import { translationsNl } from "./assets/translations/nl";
@@ -14,7 +13,7 @@ import { mergeUiTranslations } from "../../common/translations";
 @NgModule({
 	declarations: [StarkAppLogoutComponent],
 	exports: [StarkAppLogoutComponent],
-	imports: [MatIconModule, StarkSvgViewBoxModule, TranslateModule, MatTooltipModule, MatButtonModule]
+	imports: [MatIconModule, TranslateModule, MatTooltipModule, MatButtonModule]
 })
 export class StarkAppLogoutModule {
 	/**

--- a/packages/stark-ui/src/modules/app-logout/components/app-logout.component.html
+++ b/packages/stark-ui/src/modules/app-logout/components/app-logout.component.html
@@ -1,3 +1,3 @@
 <button mat-mini-fab color="alert" (click)="logout()" [matTooltip]="'STARK.APP_LOGOUT.TITLE' | translate">
-	<mat-icon starkSvgViewBox [svgIcon]="icon"></mat-icon>
+	<mat-icon [svgIcon]="icon"></mat-icon>
 </button>

--- a/packages/stark-ui/src/modules/app-menu/app-menu.module.ts
+++ b/packages/stark-ui/src/modules/app-menu/app-menu.module.ts
@@ -7,20 +7,10 @@ import { MatListModule } from "@angular/material/list";
 import { TranslateModule } from "@ngx-translate/core";
 import { UIRouterModule } from "@uirouter/angular";
 import { StarkAppMenuComponent, StarkAppMenuItemComponent } from "./components";
-import { StarkSvgViewBoxModule } from "../svg-view-box/svg-view-box.module";
 
 @NgModule({
 	declarations: [StarkAppMenuComponent, StarkAppMenuItemComponent],
-	imports: [
-		CommonModule,
-		MatListModule,
-		MatDividerModule,
-		MatExpansionModule,
-		MatIconModule,
-		StarkSvgViewBoxModule,
-		TranslateModule,
-		UIRouterModule
-	],
+	imports: [CommonModule, MatListModule, MatDividerModule, MatExpansionModule, MatIconModule, TranslateModule, UIRouterModule],
 	exports: [StarkAppMenuComponent, StarkAppMenuItemComponent]
 })
 export class StarkAppMenuModule {}

--- a/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.html
+++ b/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.html
@@ -7,13 +7,7 @@
 	[disableRipple]="!menuGroup.isEnabled"
 	(click)="onClick()"
 >
-	<mat-icon
-		*ngIf="menuGroup.icon"
-		[color]="isActive ? 'primary' : ''"
-		starkSvgViewBox
-		[svgIcon]="menuGroup.icon"
-		class="stark-small-icon"
-	></mat-icon>
+	<mat-icon *ngIf="menuGroup.icon" [color]="isActive ? 'primary' : ''" [svgIcon]="menuGroup.icon" class="stark-small-icon"></mat-icon>
 	<span matLine translate>{{ menuGroup.label }}</span>
 </mat-list-item>
 <mat-expansion-panel *ngIf="menuGroup.entries" #menuGroupsPanel>

--- a/packages/stark-ui/src/modules/collapsible/components/collapsible.component.html
+++ b/packages/stark-ui/src/modules/collapsible/components/collapsible.component.html
@@ -1,7 +1,7 @@
 <mat-expansion-panel class="stark-collapsible" id="{{ htmlId }}" [expanded]="isExpanded" hideToggle>
 	<mat-expansion-panel-header (click)="toggleCollapsible()">
 		<mat-panel-title>
-			<mat-icon [ngClass]="{ spin: _isDefaultIcon }" class="stark-collapsible-icon" starkSvgViewBox [svgIcon]="icon"></mat-icon>
+			<mat-icon [ngClass]="{ spin: _isDefaultIcon }" class="stark-collapsible-icon" [svgIcon]="icon"></mat-icon>
 			<span class="stark-collapsible-title" translate>{{ titleLabel }}</span>
 		</mat-panel-title>
 	</mat-expansion-panel-header>

--- a/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.html
+++ b/packages/stark-ui/src/modules/dialogs/components/alert-dialog.component.html
@@ -1,5 +1,5 @@
 <h2 mat-dialog-title>
-	<mat-icon svgIcon="alert" starkSvgViewBox></mat-icon>&nbsp;
+	<mat-icon svgIcon="alert"></mat-icon>&nbsp;
 	<span>{{ content.title || "" | translate }}</span>
 </h2>
 

--- a/packages/stark-ui/src/modules/generic-search/components/generic-search/generic-search.component.html
+++ b/packages/stark-ui/src/modules/generic-search/components/generic-search/generic-search.component.html
@@ -25,7 +25,6 @@
 			<mat-icon
 				*ngIf="normalizedFormButtonsConfig.new.icon"
 				[matTooltip]="normalizedFormButtonsConfig.new.label | translate"
-				starkSvgViewBox
 				[svgIcon]="normalizedFormButtonsConfig.new.icon"
 			></mat-icon>
 			<span translate>{{ normalizedFormButtonsConfig.new.label }}</span>
@@ -42,7 +41,6 @@
 			<mat-icon
 				*ngIf="normalizedFormButtonsConfig.reset.icon"
 				[matTooltip]="normalizedFormButtonsConfig.reset.label | translate"
-				starkSvgViewBox
 				[svgIcon]="normalizedFormButtonsConfig.reset.icon"
 			></mat-icon>
 			<span translate>{{ normalizedFormButtonsConfig.reset.label }}</span>
@@ -57,7 +55,6 @@
 			<mat-icon
 				*ngIf="normalizedFormButtonsConfig.search.icon"
 				[matTooltip]="normalizedFormButtonsConfig.search.label | translate"
-				starkSvgViewBox
 				[svgIcon]="normalizedFormButtonsConfig.search.icon"
 			></mat-icon>
 			<span translate>{{ normalizedFormButtonsConfig.search.label }}</span>
@@ -72,12 +69,7 @@
 				(click)="formButton.onClick()"
 				type="button"
 			>
-				<mat-icon
-					*ngIf="formButton.icon"
-					[matTooltip]="formButton.label | translate"
-					starkSvgViewBox
-					[svgIcon]="formButton.icon"
-				></mat-icon>
+				<mat-icon *ngIf="formButton.icon" [matTooltip]="formButton.label | translate" [svgIcon]="formButton.icon"></mat-icon>
 				<span>{{ formButton.label | translate }}</span>
 			</button>
 		</ng-container>

--- a/packages/stark-ui/src/modules/message-pane/components/message-pane.component.html
+++ b/packages/stark-ui/src/modules/message-pane/components/message-pane.component.html
@@ -80,9 +80,9 @@
 		<ng-container *ngIf="currentNavItem === 'errors'">
 			<div
 				class="stark-message-pane-item stark-message-pane-item-error errors"
-				*ngFor="let message of (errorMessages$ | async); trackBy: trackItemFn"
+				*ngFor="let message of errorMessages$ | async; trackBy: trackItemFn"
 			>
-				<mat-icon starkSvgViewBox svgIcon="alert-circle"></mat-icon>
+				<mat-icon svgIcon="alert-circle"></mat-icon>
 				<div translate="{{ message.key }}" translate-values="message.interpolateValues"></div>
 				<button
 					mat-icon-button
@@ -98,9 +98,9 @@
 		<ng-container *ngIf="currentNavItem === 'warnings'">
 			<div
 				class="stark-message-pane-item stark-message-pane-item-warning warnings"
-				*ngFor="let message of (warningMessages$ | async); trackBy: trackItemFn"
+				*ngFor="let message of warningMessages$ | async; trackBy: trackItemFn"
 			>
-				<mat-icon starkSvgViewBox svgIcon="alert"></mat-icon>
+				<mat-icon svgIcon="alert"></mat-icon>
 				<div translate="{{ message.key }}" translate-values="message.interpolateValues"></div>
 				<button
 					mat-icon-button
@@ -116,9 +116,9 @@
 		<ng-container *ngIf="currentNavItem === 'infos'">
 			<div
 				class="stark-message-pane-item stark-message-pane-item-info infos"
-				*ngFor="let message of (infoMessages$ | async); trackBy: trackItemFn"
+				*ngFor="let message of infoMessages$ | async; trackBy: trackItemFn"
 			>
-				<mat-icon starkSvgViewBox svgIcon="information"></mat-icon>
+				<mat-icon svgIcon="information"></mat-icon>
 				<div translate="{{ message.key }}" translate-values="message.interpolateValues"></div>
 				<button
 					mat-icon-button

--- a/packages/stark-ui/src/modules/minimap/components/minimap.component.html
+++ b/packages/stark-ui/src/modules/minimap/components/minimap.component.html
@@ -4,8 +4,8 @@
 	</div>
 </div>
 <button mat-icon-button #minimapMenuTrigger="matMenuTrigger" [matMenuTriggerFor]="minimapMenu" [color]="color">
-	<mat-icon *ngIf="mode === 'compact'" svgIcon="view-column" starkSvgViewBox></mat-icon>
-	<mat-icon *ngIf="mode !== 'compact'" [class.open]="minimapMenuTrigger.menuOpen" svgIcon="menu-down" starkSvgViewBox></mat-icon>
+	<mat-icon *ngIf="mode === 'compact'" svgIcon="view-column"></mat-icon>
+	<mat-icon *ngIf="mode !== 'compact'" [class.open]="minimapMenuTrigger.menuOpen" svgIcon="menu-down"></mat-icon>
 </button>
 <mat-menu #minimapMenu="matMenu">
 	<div class="stark-minimap-menu-item" mat-menu-item *ngFor="let item of items; trackBy: trackItemFn">

--- a/packages/stark-ui/src/modules/minimap/minimap.module.ts
+++ b/packages/stark-ui/src/modules/minimap/minimap.module.ts
@@ -8,7 +8,6 @@ import { MatTooltipModule } from "@angular/material/tooltip";
 import { CommonModule } from "@angular/common";
 import { TranslateModule } from "@ngx-translate/core";
 import { MatMenuModule } from "@angular/material/menu";
-import { StarkSvgViewBoxModule } from "../svg-view-box";
 
 @NgModule({
 	declarations: [StarkMinimapComponent],
@@ -20,7 +19,6 @@ import { StarkSvgViewBoxModule } from "../svg-view-box";
 		MatIconModule,
 		MatTooltipModule,
 		MatMenuModule,
-		StarkSvgViewBoxModule,
 		TranslateModule
 	],
 	exports: [StarkMinimapComponent]

--- a/packages/stark-ui/src/modules/pagination/components/pagination.component.html
+++ b/packages/stark-ui/src/modules/pagination/components/pagination.component.html
@@ -2,13 +2,13 @@
 	<ul *ngIf="paginationConfig.pageNavIsPresent !== false">
 		<li class="first-page" aria-label="First page" *ngIf="!paginationConfig.isExtended">
 			<button mat-icon-button (click)="goToFirst()" [disabled]="!hasPrevious()" aria-label="First page">
-				<mat-icon starkSvgViewBox svgIcon="page-first"></mat-icon>
+				<mat-icon svgIcon="page-first"></mat-icon>
 			</button>
 		</li>
 
 		<li class="previous" aria-label="Previous">
 			<button mat-icon-button (click)="goToPrevious()" [disabled]="!hasPrevious()" aria-label="Previous">
-				<mat-icon starkSvgViewBox svgIcon="chevron-left"></mat-icon>
+				<mat-icon svgIcon="chevron-left"></mat-icon>
 			</button>
 		</li>
 
@@ -27,13 +27,13 @@
 
 		<li class="next" aria-label="Next">
 			<button mat-icon-button type="button" (click)="goToNext()" [disabled]="!hasNext()">
-				<mat-icon starkSvgViewBox svgIcon="chevron-right"></mat-icon>
+				<mat-icon svgIcon="chevron-right"></mat-icon>
 			</button>
 		</li>
 
 		<li class="last-page" aria-label="Last page" *ngIf="!paginationConfig.isExtended">
 			<button mat-icon-button type="button" (click)="goToLast()" [disabled]="!hasNext()" aria-label="Last page">
-				<mat-icon starkSvgViewBox svgIcon="page-last"></mat-icon>
+				<mat-icon svgIcon="page-last"></mat-icon>
 			</button>
 		</li>
 	</ul>
@@ -68,13 +68,13 @@
 	<ul *ngIf="paginationConfig.pageNavIsPresent !== false">
 		<li class="first-page" aria-label="First page">
 			<button mat-icon-button (click)="goToFirst()" [disabled]="!hasPrevious()" aria-label="First page">
-				<mat-icon starkSvgViewBox svgIcon="page-first"></mat-icon>
+				<mat-icon svgIcon="page-first"></mat-icon>
 			</button>
 		</li>
 
 		<li class="previous" aria-label="Previous">
 			<button mat-icon-button (click)="goToPrevious()" [disabled]="!hasPrevious()" aria-label="Previous">
-				<mat-icon starkSvgViewBox svgIcon="chevron-left"></mat-icon>
+				<mat-icon svgIcon="chevron-left"></mat-icon>
 			</button>
 		</li>
 
@@ -91,13 +91,13 @@
 
 		<li class="next" aria-label="Next">
 			<button mat-icon-button (click)="goToNext()" [disabled]="!hasNext()">
-				<mat-icon starkSvgViewBox svgIcon="chevron-right"></mat-icon>
+				<mat-icon svgIcon="chevron-right"></mat-icon>
 			</button>
 		</li>
 
 		<li class="last-page" aria-label="Last page">
 			<button mat-icon-button (click)="goToLast()" [disabled]="!hasNext()" aria-label="Last page">
-				<mat-icon starkSvgViewBox svgIcon="page-last"></mat-icon>
+				<mat-icon svgIcon="page-last"></mat-icon>
 			</button>
 		</li>
 	</ul>

--- a/packages/stark-ui/src/modules/pagination/pagination.module.ts
+++ b/packages/stark-ui/src/modules/pagination/pagination.module.ts
@@ -7,7 +7,6 @@ import { MatButtonModule } from "@angular/material/button";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { MatPaginatorModule } from "@angular/material/paginator";
 import { StarkPaginationComponent } from "./components";
-import { StarkSvgViewBoxModule } from "../svg-view-box/svg-view-box.module";
 import { StarkRestrictInputDirectiveModule } from "../restrict-input-directive/restrict-input-directive.module";
 import { StarkDropdownModule } from "../dropdown/dropdown.module";
 
@@ -23,7 +22,6 @@ import { StarkDropdownModule } from "../dropdown/dropdown.module";
 		MatPaginatorModule,
 		MatTooltipModule,
 		StarkRestrictInputDirectiveModule,
-		StarkSvgViewBoxModule,
 		StarkDropdownModule
 	]
 })

--- a/packages/stark-ui/src/modules/route-search/components/route-search.component.html
+++ b/packages/stark-ui/src/modules/route-search/components/route-search.component.html
@@ -7,7 +7,7 @@
 		(click)="show()"
 		[matTooltip]="'STARK.ROUTE_SEARCH.ABOUT' | translate"
 	>
-		<mat-icon [svgIcon]="icon" starkSvgViewBox></mat-icon>
+		<mat-icon [svgIcon]="icon"></mat-icon>
 	</button>
 	<div [ngClass]="{ hide: hide }" class="route-search-input-wrapper">
 		<mat-form-field floatLabel="never" class="search-field">
@@ -21,7 +21,7 @@
 			<mat-autocomplete #autocompleteComp="matAutocomplete" autoActiveFirstOption class="search-route-autocomplete">
 				<mat-option
 					(onSelectionChange)="redirect(option)"
-					*ngFor="let option of (filteredRouteEntries | async); trackBy: trackPath"
+					*ngFor="let option of filteredRouteEntries | async; trackBy: trackPath"
 					[value]="option.label"
 				>
 					<p>{{ option.label }}</p>

--- a/packages/stark-ui/src/modules/svg-view-box/directives/svg-view-box.directive.spec.ts
+++ b/packages/stark-ui/src/modules/svg-view-box/directives/svg-view-box.directive.spec.ts
@@ -16,13 +16,13 @@ describe("SvgViewBoxDirective", () => {
 	let fixture: ComponentFixture<TestComponent>;
 
 	function getTemplate(svgViewBoxDirective: string, viewBoxAttribute?: string): string {
-		return (`
+		return `
 <div ${svgViewBoxDirective}>
 	<svg xmlns="http://www.w3.org/2000/svg" ${viewBoxAttribute}>
 		<text font-size="8" font-family="serif" y="6"><![CDATA[dummy icon]]></text>
 	</svg>
 </div>
-`);
+`;
 	}
 
 	function initializeComponentFixture(): void {

--- a/packages/stark-ui/src/modules/table/components/column.component.html
+++ b/packages/stark-ui/src/modules/table/components/column.component.html
@@ -6,19 +6,14 @@
 			<div [ngSwitch]="sortDirection" class="sort-header" (click)="onSortChange()">
 				<span>{{ headerLabel | translate }}</span>
 				<ng-container *ngIf="sortable" [ngSwitch]="sortDirection">
-					<mat-icon *ngSwitchCase="'asc'" starkSvgViewBox svgIcon="arrow-up" class="stark-small-icon"></mat-icon>
-					<mat-icon *ngSwitchCase="'desc'" starkSvgViewBox svgIcon="arrow-down" class="stark-small-icon"></mat-icon>
-					<mat-icon class="order-tip stark-small-icon" *ngSwitchDefault starkSvgViewBox svgIcon="arrow-up"></mat-icon>
+					<mat-icon *ngSwitchCase="'asc'" svgIcon="arrow-up" class="stark-small-icon"></mat-icon>
+					<mat-icon *ngSwitchCase="'desc'" svgIcon="arrow-down" class="stark-small-icon"></mat-icon>
+					<mat-icon class="order-tip stark-small-icon" *ngSwitchDefault svgIcon="arrow-up"></mat-icon>
 				</ng-container>
 				<span *ngIf="sortPriority < 1000 && sortDirection" class="priority">{{ sortPriority }}</span>
 			</div>
 			<button *ngIf="filterable" class="button-filter" [matMenuTriggerFor]="filterMenu" mat-icon-button>
-				<mat-icon
-					class="stark-small-icon"
-					starkSvgViewBox
-					svgIcon="filter"
-					[matTooltip]="'STARK.TABLE.COLUMN_FILTER' | translate"
-				></mat-icon>
+				<mat-icon class="stark-small-icon" svgIcon="filter" [matTooltip]="'STARK.TABLE.COLUMN_FILTER' | translate"></mat-icon>
 			</button>
 		</div>
 		<mat-menu class="mat-table-filter" #filterMenu="matMenu" xPosition="before" [overlapTrigger]="false">

--- a/packages/stark-ui/src/modules/table/components/table.component.html
+++ b/packages/stark-ui/src/modules/table/components/table.component.html
@@ -10,17 +10,12 @@
 	<stark-pagination htmlSuffixId="{{ htmlId }}-pagination" [paginationConfig]="paginationConfig" mode="compact"></stark-pagination>
 
 	<button *ngIf="isMultiSortEnabled" (click)="openMultiSortDialog()" mat-icon-button>
-		<mat-icon
-			class="stark-small-icon"
-			[matTooltip]="'STARK.TABLE.MULTI_COLUMN_SORTING' | translate"
-			starkSvgViewBox
-			svgIcon="sort"
-		></mat-icon>
+		<mat-icon class="stark-small-icon" [matTooltip]="'STARK.TABLE.MULTI_COLUMN_SORTING' | translate" svgIcon="sort"></mat-icon>
 	</button>
 
 	<ng-container *ngIf="filter.globalFilterPresent">
 		<button [matMenuTriggerFor]="globalFilter" mat-icon-button>
-			<mat-icon [matTooltip]="'STARK.TABLE.FILTER' | translate" class="stark-small-icon" starkSvgViewBox svgIcon="filter"></mat-icon>
+			<mat-icon [matTooltip]="'STARK.TABLE.FILTER' | translate" class="stark-small-icon" svgIcon="filter"></mat-icon>
 		</button>
 		<mat-menu class="mat-table-filter" #globalFilter="matMenu" xPosition="before" [overlapTrigger]="false">
 			<div>
@@ -34,12 +29,7 @@
 					/>
 				</mat-form-field>
 				<button mat-icon-button (click)="onClearFilter()">
-					<mat-icon
-						class="stark-small-icon"
-						starkSvgViewBox
-						svgIcon="close"
-						[matTooltip]="'STARK.TABLE.CLEAR_FILTER' | translate"
-					></mat-icon>
+					<mat-icon class="stark-small-icon" svgIcon="close" [matTooltip]="'STARK.TABLE.CLEAR_FILTER' | translate"></mat-icon>
 				</button>
 			</div>
 		</mat-menu>

--- a/packages/stark-ui/src/modules/table/table.module.ts
+++ b/packages/stark-ui/src/modules/table/table.module.ts
@@ -17,7 +17,6 @@ import { StarkTableColumnComponent, StarkTableComponent } from "./components";
 import { StarkTableMultisortDialogComponent } from "./components/dialogs/multisort.component";
 import { StarkActionBarModule } from "../action-bar/action-bar.module";
 import { StarkPaginationModule } from "../pagination/pagination.module";
-import { StarkSvgViewBoxModule } from "../svg-view-box/svg-view-box.module";
 import { StarkMinimapModule } from "../minimap/minimap.module";
 import { translationsEn } from "./assets/translations/en";
 import { translationsFr } from "./assets/translations/fr";
@@ -45,7 +44,6 @@ import { mergeUiTranslations } from "../../common/translations";
 		TranslateModule,
 		StarkActionBarModule,
 		StarkPaginationModule,
-		StarkSvgViewBoxModule,
 		StarkMinimapModule
 	]
 })

--- a/packages/stark-ui/src/modules/toast-notification/components/toast-notification.component.html
+++ b/packages/stark-ui/src/modules/toast-notification/components/toast-notification.component.html
@@ -1,7 +1,7 @@
 <div class="stark-toast" [ngClass]="getMessageTypeClass()">
-	<mat-icon svgIcon="information" starkSvgViewBox *ngIf="message.type === 0"></mat-icon>
-	<mat-icon svgIcon="alert-circle" starkSvgViewBox *ngIf="message.type === 1"></mat-icon>
-	<mat-icon svgIcon="alert" starkSvgViewBox *ngIf="message.type === 2"></mat-icon>
+	<mat-icon svgIcon="information" *ngIf="message.type === 0"></mat-icon>
+	<mat-icon svgIcon="alert-circle" *ngIf="message.type === 1"></mat-icon>
+	<mat-icon svgIcon="alert" *ngIf="message.type === 2"></mat-icon>
 
 	<span class="stark-toast-text" role="alert" [innerHTML]="message.key | translate: message.interpolateValues"></span>
 

--- a/showcase/package-lock.json
+++ b/showcase/package-lock.json
@@ -1374,10 +1374,10 @@
       "requires": {
         "@angular-builders/custom-webpack": "^7.3.1",
         "@angular-builders/dev-server": "^7.3.1",
-        "@angular-devkit/build-angular": "0.13.9",
+        "@angular-devkit/build-angular": "^0.13.0",
         "@babel/core": "^7.2.2",
         "@babel/preset-env": "^7.2.3",
-        "@types/webpack": "4.4.32",
+        "@types/webpack": "^4.4.24",
         "babel-loader": "^8.0.5",
         "base-href-webpack-plugin": "^2.0.0",
         "codelyzer": "^4.5.0",
@@ -1408,7 +1408,7 @@
         "@ngrx/store": "^7.1.0",
         "@ngrx/store-devtools": "^7.1.0",
         "@ngx-translate/core": "^11.0.1",
-        "@types/lodash-es": "4.17.3",
+        "@types/lodash-es": "^4.17.1",
         "@types/uuid": "^3.4.4",
         "@uirouter/angular": "^3.0.0",
         "cerialize": "^0.1.18",
@@ -1424,7 +1424,7 @@
       "version": "file:../dist/packages-dist/stark-rbac/nationalbankbelgium-stark-rbac-10.0.0-beta.7-e0b3ee03.tgz",
       "integrity": "sha512-JfZ0Y69RPXZKwphKx3YSkhgC+PbFr0vkgo4eMExW6PxuIYqpOoIRNxzG/gwP6ldVfHDA34ZgGpf+BXMMxxYFgw==",
       "requires": {
-        "@types/lodash-es": "4.17.3"
+        "@types/lodash-es": "^4.17.1"
       }
     },
     "@nationalbankbelgium/stark-testing": {
@@ -1432,8 +1432,8 @@
       "integrity": "sha512-RRJ1XlICfL4jQ8qZbSQMoKkzxIqIHZTcFQx2wNymSlTciNGh8eWsajuLY4dMOXpae7heiNM53NymOlv5GHp7SQ==",
       "dev": true,
       "requires": {
-        "@types/jasmine": "3.3.13",
-        "@types/node": "8.10.48",
+        "@types/jasmine": "^3.3.12",
+        "@types/node": "^8.10.37",
         "coveralls": "^3.0.2",
         "istanbul-lib-instrument": "^3.0.0",
         "jasmine-core": "^3.3.0",
@@ -1451,7 +1451,7 @@
         "karma-typescript-angular2-transform": "^4.0.0",
         "karma-typescript-es6-transform": "^4.0.0",
         "protractor": "^5.4.2",
-        "puppeteer": "1.17.0"
+        "puppeteer": "^1.11.0"
       },
       "dependencies": {
         "istanbul-lib-coverage": {
@@ -1488,8 +1488,8 @@
       "integrity": "sha512-TqXA1YrtC9Eixtx9E1bKuRWhCcgNORP/64e2dSVhzTi5uHTv7pQpUwnFjmhIptmoskOYz7oHm7n89OdWGfF7Bg==",
       "requires": {
         "@angular/material-moment-adapter": "^7.0.0",
-        "@mdi/angular-material": "^3.3.92",
-        "@types/lodash-es": "4.17.3",
+        "@mdi/angular-material": "^3.6.95",
+        "@types/lodash-es": "^4.17.1",
         "@types/nouislider": "^9.0.4",
         "@types/prismjs": "^1.16.0",
         "angular2-text-mask": "^9.0.0",

--- a/showcase/src/app/app.component.html
+++ b/showcase/src/app/app.component.html
@@ -23,10 +23,10 @@
 						<div class="stark-app-bar-content-left">
 							<div class="stark-actions">
 								<button class="stark-home-button" (click)="goHome()" color="white" mat-icon-button>
-									<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+									<mat-icon svgIcon="home"></mat-icon>
 								</button>
 								<button color="white" mat-icon-button (click)="toggleMenu()">
-									<mat-icon starkSvgViewBox svgIcon="menu"></mat-icon>
+									<mat-icon svgIcon="menu"></mat-icon>
 								</button>
 							</div>
 						</div>
@@ -75,10 +75,10 @@
 								</div>
 								<stark-language-selector color="white" class="stark-full-width" mode="dropdown"></stark-language-selector>
 								<button color="white" (click)="openLeftSidebar()" mat-icon-button>
-									<mat-icon starkSvgViewBox svgIcon="skip-next"></mat-icon>
+									<mat-icon svgIcon="skip-next"></mat-icon>
 								</button>
 								<button color="white" (click)="openRightSidebar()" mat-icon-button>
-									<mat-icon starkSvgViewBox svgIcon="skip-previous"></mat-icon>
+									<mat-icon svgIcon="skip-previous"></mat-icon>
 								</button>
 							</div>
 							<div class="stark-app-bar-content-right-actions-alt">
@@ -90,7 +90,7 @@
 										color="success"
 										[matTooltip]="'SHOWCASE.ICONS.STARK_UI' | translate"
 									>
-										<mat-icon class="header-icon" svgIcon="television-guide" starkSvgViewBox></mat-icon>
+										<mat-icon class="header-icon" svgIcon="television-guide"></mat-icon>
 									</button>
 								</a>
 								<a href="https://stark.nbb.be/api-docs/stark-core/latest/" target="_blank" rel="noopener noreferrer">
@@ -99,7 +99,6 @@
 										mat-icon-button
 										color="primary"
 										[matTooltip]="'SHOWCASE.ICONS.STARK_CORE' | translate"
-										starkSvgViewBox
 									>
 										<mat-icon class="header-icon" svgIcon="atom"></mat-icon>
 									</button>
@@ -111,7 +110,7 @@
 										color="alert"
 										[matTooltip]="'SHOWCASE.ICONS.STARK_RBAC' | translate"
 									>
-										<mat-icon class="header-icon" svgIcon="shield-lock-outline" starkSvgViewBox></mat-icon>
+										<mat-icon class="header-icon" svgIcon="shield-lock-outline"></mat-icon>
 									</button>
 								</a>
 								<a href="https://github.com/NationalBankBelgium" target="_blank" rel="noopener noreferrer">
@@ -121,7 +120,7 @@
 										class="github-icon"
 										[matTooltip]="'SHOWCASE.ICONS.GITHUB' | translate"
 									>
-										<mat-icon class="custom-icon" svgIcon="github-circle" starkSvgViewBox></mat-icon>
+										<mat-icon class="custom-icon" svgIcon="github-circle"></mat-icon>
 									</button>
 								</a>
 							</div>

--- a/showcase/src/app/demo-ui/demo-ui.module.ts
+++ b/showcase/src/app/demo-ui/demo-ui.module.ts
@@ -40,7 +40,6 @@ import {
 	StarkProgressIndicatorModule,
 	StarkRouteSearchModule,
 	StarkSliderModule,
-	StarkSvgViewBoxModule,
 	StarkTableModule,
 	StarkTransformInputDirectiveModule
 } from "@nationalbankbelgium/stark-ui";
@@ -133,7 +132,6 @@ import {
 		StarkPrettyPrintModule,
 		StarkRouteSearchModule,
 		StarkSliderModule,
-		StarkSvgViewBoxModule,
 		StarkTableModule,
 		StoreModule.forFeature("DemoGenericSearch", demoGenericSearchReducers)
 	],

--- a/showcase/src/app/shared/shared.module.ts
+++ b/showcase/src/app/shared/shared.module.ts
@@ -7,7 +7,7 @@ import { MatTabsModule } from "@angular/material/tabs";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { CommonModule } from "@angular/common";
 import { Inject, NgModule } from "@angular/core";
-import { StarkPrettyPrintModule, StarkSvgViewBoxModule } from "@nationalbankbelgium/stark-ui";
+import { StarkPrettyPrintModule } from "@nationalbankbelgium/stark-ui";
 import { TranslateModule } from "@ngx-translate/core";
 import { FlexLayoutModule } from "@angular/flex-layout";
 import {
@@ -33,13 +33,12 @@ import { FileService } from "./services";
 		MatTabsModule,
 		CommonModule,
 		StarkPrettyPrintModule,
-		TranslateModule,
-		StarkSvgViewBoxModule // is needed here for directive to work in the different modules
+		TranslateModule
 	],
 	providers: [FileService],
 	declarations: [ExampleViewerComponent, ReferenceBlockComponent, TableOfContentsComponent],
 	entryComponents: [],
-	exports: [ExampleViewerComponent, ReferenceBlockComponent, TableOfContentsComponent, FlexLayoutModule, StarkSvgViewBoxModule]
+	exports: [ExampleViewerComponent, ReferenceBlockComponent, TableOfContentsComponent, FlexLayoutModule]
 })
 export class SharedModule {
 	public constructor(

--- a/showcase/src/app/styleguide/pages/button/styleguide-button-page.component.html
+++ b/showcase/src/app/styleguide/pages/button/styleguide-button-page.component.html
@@ -6,11 +6,11 @@
 			<button mat-button>Basic</button>
 			<button mat-raised-button>Basic</button>
 			<button mat-stroked-button>Basic</button>
-			<button mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 
@@ -19,11 +19,11 @@
 			<button color="primary" mat-button>Primary</button>
 			<button color="primary" mat-raised-button>Primary</button>
 			<button color="primary" mat-stroked-button>Primary</button>
-			<button color="primary" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="primary" mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="primary" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="primary" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button color="primary" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="primary" mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="primary" mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="primary" mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="primary" mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="primary" mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 
@@ -32,11 +32,11 @@
 			<button color="accent" mat-button>Accent</button>
 			<button color="accent" mat-raised-button>Accent</button>
 			<button color="accent" mat-stroked-button>Accent</button>
-			<button color="accent" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="accent" mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="accent" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="accent" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button color="accent" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="accent" mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="accent" mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="accent" mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="accent" mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="accent" mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 
@@ -45,11 +45,11 @@
 			<button color="warn" mat-button>Accent</button>
 			<button color="warn" mat-raised-button>Accent</button>
 			<button color="warn" mat-stroked-button>Accent</button>
-			<button color="warn" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="warn" mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="warn" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="warn" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button color="warn" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="warn" mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="warn" mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="warn" mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="warn" mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="warn" mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 
@@ -58,11 +58,11 @@
 			<button color="success" mat-button>Success</button>
 			<button color="success" mat-raised-button>Success</button>
 			<button color="success" mat-stroked-button>Success</button>
-			<button color="success" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="success" mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="success" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="success" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button color="success" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="success" mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="success" mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="success" mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="success" mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="success" mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 
@@ -71,11 +71,11 @@
 			<button color="alert" mat-button>Alert</button>
 			<button color="alert" mat-raised-button>Alert</button>
 			<button color="alert" mat-stroked-button>Alert</button>
-			<button color="alert" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="alert" mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="alert" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="alert" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button color="alert" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="alert" mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="alert" mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="alert" mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="alert" mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="alert" mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 
@@ -84,11 +84,11 @@
 			<button color="alt" mat-button>Alt</button>
 			<button color="alt" mat-raised-button>Alt</button>
 			<button color="alt" mat-stroked-button>Alt</button>
-			<button color="alt" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="alt" mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="alt" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="alt" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button color="alt" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="alt" mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="alt" mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="alt" mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="alt" mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="alt" mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 
@@ -97,11 +97,11 @@
 			<button color="neutral" mat-button>Neutral</button>
 			<button color="neutral" mat-raised-button>Neutral</button>
 			<button color="neutral" mat-stroked-button>Neutral</button>
-			<button color="neutral" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="neutral" mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="neutral" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="neutral" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button color="neutral" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="neutral" mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="neutral" mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="neutral" mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="neutral" mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="neutral" mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 
@@ -110,11 +110,11 @@
 			<button color="white" mat-button>White</button>
 			<button color="white" mat-raised-button>White</button>
 			<button color="white" mat-stroked-button>White</button>
-			<button color="white" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="white" mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="white" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button color="white" mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button color="white" mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="white" mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="white" mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="white" mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button color="white" mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button color="white" mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 
@@ -123,11 +123,11 @@
 			<button disabled mat-button>Disabled</button>
 			<button disabled mat-raised-button>Disabled</button>
 			<button disabled mat-stroked-button>Disabled</button>
-			<button disabled mat-icon-button><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button disabled mat-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button disabled mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home"></mat-icon></button>
-			<button disabled mat-icon-button><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
-			<button disabled mat-mini-fab><mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button disabled mat-icon-button><mat-icon svgIcon="home"></mat-icon></button>
+			<button disabled mat-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button disabled mat-mini-fab><mat-icon svgIcon="home"></mat-icon></button>
+			<button disabled mat-icon-button><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
+			<button disabled mat-mini-fab><mat-icon svgIcon="home" class="stark-small-icon"></mat-icon></button>
 		</div>
 	</example-viewer>
 </section>

--- a/showcase/src/app/styleguide/pages/header/styleguide-header-page.component.ts
+++ b/showcase/src/app/styleguide/pages/header/styleguide-header-page.component.ts
@@ -12,13 +12,13 @@ export class StyleguideHeaderPageComponent {
       <div class="stark-app-bar-content-left">
         <div class="stark-actions">
           <button class="stark-home-button" color="white" mat-icon-button>
-            <mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+            <mat-icon svgIcon="home"></mat-icon>
           </button>
           <button color="white" mat-icon-button (click)="sidenav.toggle()">
-            <mat-icon starkSvgViewBox svgIcon="menu"></mat-icon>
+            <mat-icon svgIcon="menu"></mat-icon>
           </button>
           <button color="white" mat-icon-button>
-            <mat-icon starkSvgViewBox svgIcon="arrow-left"></mat-icon>
+            <mat-icon svgIcon="arrow-left"></mat-icon>
           </button>
         </div>
       </div>
@@ -40,17 +40,17 @@ export class StyleguideHeaderPageComponent {
             mat-icon-button
             [matTooltip]="'STARK.ICONS.APP_DATA' | translate"
           >
-            <mat-icon starkSvgViewBox svgIcon="dots-vertical"></mat-icon>
+            <mat-icon svgIcon="dots-vertical"></mat-icon>
           </button>
           <stark-app-logout></stark-app-logout>
         </div>
         <div>
           <div class="dropdown-lang">App Lang</div>
           <button color="white" mat-icon-button>
-            <mat-icon starkSvgViewBox svgIcon="skip-next"></mat-icon>
+            <mat-icon svgIcon="skip-next"></mat-icon>
           </button>
           <button color="white" mat-icon-button>
-            <mat-icon starkSvgViewBox svgIcon="skip-previous"></mat-icon>
+            <mat-icon svgIcon="skip-previous"></mat-icon>
           </button>
         </div>
         <div class="stark-app-bar-content-right-actions-alt">
@@ -58,21 +58,21 @@ export class StyleguideHeaderPageComponent {
             mat-mini-fab
             [matTooltip]="'SHOWCASE.STYLEGUIDE.TITLE' | translate"
           >
-            <mat-icon starkSvgViewBox svgIcon="television-guide"></mat-icon>
+            <mat-icon svgIcon="television-guide"></mat-icon>
           </button>
           <button
             mat-mini-fab
             color="success"
             [matTooltip]="'STARK.ICONS.ADD_ITEM' | translate"
           >
-            <mat-icon starkSvgViewBox svgIcon="plus"></mat-icon>
+            <mat-icon svgIcon="plus"></mat-icon>
           </button>
           <button
             mat-mini-fab
             color="primary"
             [matTooltip]="'STARK.ICONS.SEARCH' | translate"
           >
-            <mat-icon starkSvgViewBox svgIcon="magnify"></mat-icon>
+            <mat-icon svgIcon="magnify"></mat-icon>
           </button>
         </div>
       </div>

--- a/showcase/src/app/styleguide/pages/layout/styleguide-layout-page.component.html
+++ b/showcase/src/app/styleguide/pages/layout/styleguide-layout-page.component.html
@@ -16,7 +16,7 @@
 <!--FIXME: add example back when chrome is updated to 57 or higher-->
 <!--<example-viewer filesPath="flex-layout/grid" [extensions]="['HTML', 'SCSS']" exampleTitle="SHOWCASE.STYLEGUIDE.LAYOUT.GRID">-->
 <!--<div class="warning">-->
-<!--<mat-icon svgIcon="alert-circle" starkSvgViewBox></mat-icon>-->
+<!--<mat-icon svgIcon="alert-circle"></mat-icon>-->
 <!--<span [innerHTML]="'SHOWCASE.STYLEGUIDE.LAYOUT.GRID_WARNING' | translate"></span>-->
 <!--</div>-->
 <!--<div class="layout-demo" gdAuto="row" gdAuto.gt-sm="column" gdGap="10px">-->

--- a/showcase/src/app/welcome/pages/home/home-page.component.html
+++ b/showcase/src/app/welcome/pages/home/home-page.component.html
@@ -14,7 +14,7 @@
 <div class="page-content">
 	<div class="section-division">
 		<div class="homepage-item">
-			<mat-icon class="about-image homepage-icons" starkSvgViewBox svgIcon="wall"></mat-icon>
+			<mat-icon class="about-image homepage-icons" svgIcon="wall"></mat-icon>
 			<div>
 				<h2 class="doc-subtitle" [innerHTML]="'SHOWCASE.HOMEPAGE.MAIN_TITLE' | translate"></h2>
 				<div class="doc-description" [innerHTML]="'SHOWCASE.HOMEPAGE.DESCRIPTION_DETAIL' | translate"></div>
@@ -28,7 +28,7 @@
 				<h2 class="doc-subtitle">{{ "SHOWCASE.HOMEPAGE.CORE" | translate }}</h2>
 				<div class="doc-description" [innerHTML]="'SHOWCASE.HOMEPAGE.DOCUMENTATION_CORE_DESC' | translate"></div>
 			</div>
-			<mat-icon class="core-image homepage-icons" starkSvgViewBox svgIcon="atom"></mat-icon>
+			<mat-icon class="core-image homepage-icons" svgIcon="atom"></mat-icon>
 		</div>
 		<div class="buttons-row">
 			<a
@@ -52,7 +52,7 @@
 
 	<div class="section-division">
 		<div class="homepage-item">
-			<mat-icon class="ui-image homepage-icons" starkSvgViewBox svgIcon="television-guide"></mat-icon>
+			<mat-icon class="ui-image homepage-icons" svgIcon="television-guide"></mat-icon>
 			<div class="text-block">
 				<h2 class="doc-subtitle">{{ "SHOWCASE.HOMEPAGE.UI" | translate }}</h2>
 				<div class="doc-description" [innerHTML]="'SHOWCASE.HOMEPAGE.DOCUMENTATION_UI_DESC' | translate"></div>
@@ -84,7 +84,7 @@
 				<h2 class="doc-subtitle">{{ "SHOWCASE.HOMEPAGE.RBAC" | translate }}</h2>
 				<div class="doc-description" [innerHTML]="'SHOWCASE.HOMEPAGE.DOCUMENTATION_RBAC_DESC' | translate"></div>
 			</div>
-			<mat-icon class="rbac-image homepage-icons" starkSvgViewBox svgIcon="shield-lock-outline"></mat-icon>
+			<mat-icon class="rbac-image homepage-icons" svgIcon="shield-lock-outline"></mat-icon>
 		</div>
 		<div class="buttons-row">
 			<a
@@ -108,7 +108,7 @@
 
 	<div class="last-section-division">
 		<div class="homepage-item">
-			<mat-icon class="showcase-image homepage-icons" starkSvgViewBox svgIcon="theater"></mat-icon>
+			<mat-icon class="showcase-image homepage-icons" svgIcon="theater"></mat-icon>
 			<div class="text-block">
 				<h2 class="doc-subtitle">{{ "SHOWCASE.HOMEPAGE.SHOWCASE" | translate }}</h2>
 				<div class="doc-description" [innerHTML]="'SHOWCASE.HOMEPAGE.DOCUMENTATION_SHOWCASE_DESC' | translate"></div>

--- a/showcase/src/assets/examples/button/accent.html
+++ b/showcase/src/assets/examples/button/accent.html
@@ -3,18 +3,18 @@
 	<button color="accent" mat-raised-button>Accent</button>
 	<button color="accent" mat-stroked-button>Accent</button>
 	<button color="accent" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="accent" mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="accent" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="accent" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button color="accent" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/showcase/src/assets/examples/button/alert.html
+++ b/showcase/src/assets/examples/button/alert.html
@@ -3,18 +3,18 @@
 	<button color="alert" mat-raised-button>Alert</button>
 	<button color="alert" mat-stroked-button>Alert</button>
 	<button color="alert" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="alert" mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="alert" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="alert" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button color="alert" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/showcase/src/assets/examples/button/alt.html
+++ b/showcase/src/assets/examples/button/alt.html
@@ -3,18 +3,18 @@
 	<button color="alt" mat-raised-button>Alt</button>
 	<button color="alt" mat-stroked-button>Alt</button>
 	<button color="alt" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="alt" mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="alt" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="alt" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button color="alt" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/showcase/src/assets/examples/button/basic.html
+++ b/showcase/src/assets/examples/button/basic.html
@@ -3,18 +3,18 @@
 	<button mat-raised-button>Basic</button>
 	<button mat-stroked-button>Basic</button>
 	<button mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/showcase/src/assets/examples/button/disabled.html
+++ b/showcase/src/assets/examples/button/disabled.html
@@ -3,18 +3,18 @@
 	<button disabled mat-raised-button>Disabled</button>
 	<button disabled mat-stroked-button>Disabled</button>
 	<button disabled mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button disabled mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button disabled mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button disabled mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button disabled mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/showcase/src/assets/examples/button/neutral.html
+++ b/showcase/src/assets/examples/button/neutral.html
@@ -3,18 +3,18 @@
 	<button color="neutral" mat-raised-button>Neutral</button>
 	<button color="neutral" mat-stroked-button>Neutral</button>
 	<button color="neutral" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="neutral" mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="neutral" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="neutral" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button color="neutral" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/showcase/src/assets/examples/button/primary.html
+++ b/showcase/src/assets/examples/button/primary.html
@@ -3,18 +3,18 @@
 	<button color="primary" mat-raised-button>Primary</button>
 	<button color="primary" mat-stroked-button>Primary</button>
 	<button color="primary" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="primary" mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="primary" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="primary" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button color="primary" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/showcase/src/assets/examples/button/success.html
+++ b/showcase/src/assets/examples/button/success.html
@@ -3,18 +3,18 @@
 	<button color="success" mat-raised-button>Success</button>
 	<button color="success" mat-stroked-button>Success</button>
 	<button color="success" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="success" mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="success" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="success" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button color="success" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/showcase/src/assets/examples/button/warn.html
+++ b/showcase/src/assets/examples/button/warn.html
@@ -3,18 +3,18 @@
 	<button color="warn" mat-raised-button>Warn</button>
 	<button color="warn" mat-stroked-button>Warn</button>
 	<button color="warn" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="warn" mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="warn" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="warn" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button color="warn" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/showcase/src/assets/examples/button/white.html
+++ b/showcase/src/assets/examples/button/white.html
@@ -3,18 +3,18 @@
 	<button color="white" mat-raised-button>White</button>
 	<button color="white" mat-stroked-button>White</button>
 	<button color="white" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="white" mat-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="white" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+		<mat-icon svgIcon="home"></mat-icon>
 	</button>
 	<button color="white" mat-icon-button>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 	<button color="white" mat-mini-fab>
-		<mat-icon starkSvgViewBox svgIcon="home" class="stark-small-icon"></mat-icon>
+		<mat-icon svgIcon="home" class="stark-small-icon"></mat-icon>
 	</button>
 </div>

--- a/starter/src/app/app.component.html
+++ b/starter/src/app/app.component.html
@@ -11,10 +11,10 @@
 						<div class="stark-app-bar-content-left">
 							<div class="stark-actions">
 								<button class="stark-home-button" (click)="goHome()" color="white" mat-icon-button>
-									<mat-icon starkSvgViewBox svgIcon="home"></mat-icon>
+									<mat-icon svgIcon="home"></mat-icon>
 								</button>
 								<button color="white" mat-icon-button (click)="toggleMenu()">
-									<mat-icon starkSvgViewBox svgIcon="menu"></mat-icon>
+									<mat-icon svgIcon="menu"></mat-icon>
 								</button>
 							</div>
 						</div>
@@ -32,7 +32,7 @@
 									mat-icon-button
 									[matTooltip]="'STARK.ICONS.APP_DATA' | translate"
 								>
-									<mat-icon starkSvgViewBox svgIcon="dots-vertical"></mat-icon>
+									<mat-icon svgIcon="dots-vertical"></mat-icon>
 								</button>
 								<stark-app-logout></stark-app-logout>
 							</div>
@@ -41,10 +41,10 @@
 							</div>
 							<div class="stark-app-bar-content-right-actions-alt">
 								<button mat-mini-fab color="success" [matTooltip]="'STARK.ICONS.ADD_ITEM' | translate">
-									<mat-icon starkSvgViewBox svgIcon="plus"></mat-icon>
+									<mat-icon svgIcon="plus"></mat-icon>
 								</button>
 								<button mat-mini-fab color="primary" [matTooltip]="'STARK.ICONS.SEARCH' | translate">
-									<mat-icon starkSvgViewBox svgIcon="magnify"></mat-icon>
+									<mat-icon svgIcon="magnify"></mat-icon>
 								</button>
 							</div>
 						</div>

--- a/starter/src/app/app.module.ts
+++ b/starter/src/app/app.module.ts
@@ -51,7 +51,6 @@ import {
 	StarkDatePickerModule,
 	StarkLanguageSelectorModule,
 	StarkSessionUiModule,
-	StarkSvgViewBoxModule,
 	StarkToastNotificationModule
 } from "@nationalbankbelgium/stark-ui";
 import { HomeModule } from "./home/home.module";
@@ -182,7 +181,6 @@ export const metaReducers: MetaReducer<State>[] = ENV !== "production" ? [logger
 		StarkAppSidebarModule.forRoot(),
 		StarkErrorHandlingModule.forRoot(),
 		StarkLanguageSelectorModule,
-		StarkSvgViewBoxModule,
 		StarkDatePickerModule,
 		StarkToastNotificationModule.forRoot({
 			delay: 5000,


### PR DESCRIPTION
ISSUES CLOSED: #1245

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1245 


## What is the new behavior?
The `starkSvgViewBox` is no longer used internally in the stark packages nor the starter and showcase since it is not needed anymore due to the `viewBox` attribute added by default in the MaterialDesignIcons package (as of version 3.6.95).

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->