### PR TITLE
feat(stark-ui): change color of global filter icon to indicate when the global filter is enabled

### DIFF
--- a/packages/stark-ui/src/modules/table/components/_table-theme.scss
+++ b/packages/stark-ui/src/modules/table/components/_table-theme.scss
@@ -1,7 +1,7 @@
 /* ============================================================================== */
-/*  S t a r k   A p p   T a b l e                                                  */
+/*  S t a r k   T a b l e                                                         */
 /* ============================================================================== */
-/* stark-ui: src/modules/app-menu/components/_table-theme.scss */
+/* stark-ui: src/modules/table/components/_table-theme.scss */
 
 .stark-table {
   tr {

--- a/packages/stark-ui/src/modules/table/components/_table.component.scss
+++ b/packages/stark-ui/src/modules/table/components/_table.component.scss
@@ -1,7 +1,7 @@
 /* ============================================================================== */
 /*  S t a r k   T a b l e                                                         */
 /* ============================================================================== */
-/* stark-ui: src/modules/table/components/table/_table.component.scss */
+/* stark-ui: src/modules/table/components/_table.component.scss */
 
 .stark-table {
   .header {
@@ -18,6 +18,13 @@
       align-items: center;
       display: flex;
       justify-content: flex-end;
+
+      .button-global-filter {
+        opacity: 0.2;
+        &.filter-enabled {
+          opacity: 1;
+        }
+      }
 
       stark-minimap {
         mat-icon {

--- a/packages/stark-ui/src/modules/table/components/table.component.html
+++ b/packages/stark-ui/src/modules/table/components/table.component.html
@@ -14,7 +14,12 @@
 	</button>
 
 	<ng-container *ngIf="filter.globalFilterPresent">
-		<button [matMenuTriggerFor]="globalFilter" mat-icon-button>
+		<button
+			[matMenuTriggerFor]="globalFilter"
+			mat-icon-button
+			class="button-global-filter"
+			[ngClass]="{ 'filter-enabled': !!filter.globalFilterValue }"
+		>
 			<mat-icon [matTooltip]="'STARK.TABLE.FILTER' | translate" class="stark-small-icon" svgIcon="filter"></mat-icon>
 		</button>
 		<mat-menu class="mat-table-filter" #globalFilter="matMenu" xPosition="before" [overlapTrigger]="false">

--- a/packages/stark-ui/src/modules/table/components/table.component.spec.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.spec.ts
@@ -12,7 +12,7 @@ import { MatPaginatorModule } from "@angular/material/paginator";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatSelectModule } from "@angular/material/select";
 import { MatInputModule } from "@angular/material/input";
-import { HAMMER_LOADER } from "@angular/platform-browser";
+import { By, HAMMER_LOADER } from "@angular/platform-browser";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { STARK_LOGGING_SERVICE } from "@nationalbankbelgium/stark-core";
 import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
@@ -303,7 +303,12 @@ describe("TableComponent", () => {
 
 		it("should display/hide the counter element when 'showRowsCounter' changes", () => {
 			const rowsCounterSelector = ".stark-table-rows-counter";
-			hostComponent.dummyData = [{ name: "dummy-data-1" }, { name: "dummy-data-2" }, { name: "dummy-data-3" }, { name: "dummy-data-4" }];
+			hostComponent.dummyData = [
+				{ name: "dummy-data-1" },
+				{ name: "dummy-data-2" },
+				{ name: "dummy-data-3" },
+				{ name: "dummy-data-4" }
+			];
 			hostFixture.detectChanges();
 
 			let rowsCounterElement = hostFixture.debugElement.nativeElement.querySelector(rowsCounterSelector);
@@ -827,6 +832,20 @@ describe("TableComponent", () => {
 				hostComponent.tableFilter = { globalFilterPresent: true, globalFilterValue: "ThisShouldBeAUniqueValue" };
 				hostFixture.detectChanges();
 				expect(component.paginationConfig.totalItems).toBe(1);
+			});
+
+			it("should add the 'filter-enabled' CSS class to the global filter button only when filterValue is not empty", () => {
+				hostComponent.tableFilter = { globalFilterValue: "some value" };
+				hostFixture.detectChanges();
+
+				const globalFilterButton = hostFixture.debugElement.query(By.css(".header .actions .button-global-filter"));
+
+				expect(globalFilterButton.classes["filter-enabled"]).toBe(true);
+
+				hostComponent.tableFilter = { globalFilterValue: "" };
+				hostFixture.detectChanges();
+
+				expect(globalFilterButton.classes["filter-enabled"]).toBe(false);
 			});
 		});
 


### PR DESCRIPTION
ISSUES CLOSED: #1303

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1303 


## What is the new behavior?
The icon of the global filter now changes color whenever the filter is enabled so the user knows that the filtered is being applied.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->