### PR TITLE
Feature/showcase enhancements

### DIFF
--- a/showcase/src/app/app.module.ts
+++ b/showcase/src/app/app.module.ts
@@ -1,21 +1,13 @@
 import { APP_INITIALIZER, Inject, NgModule, NgModuleFactoryLoader, SystemJsNgModuleLoader } from "@angular/core";
 import { BrowserModule, DomSanitizer } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { FormsModule } from "@angular/forms";
 import { UIRouter, UIRouterModule } from "@uirouter/angular";
 import { ActionReducer, ActionReducerMap, MetaReducer, StoreModule } from "@ngrx/store";
 import { StoreDevtoolsModule } from "@ngrx/store-devtools";
 import { EffectsModule } from "@ngrx/effects";
 import { storeFreeze } from "ngrx-store-freeze";
 import { storeLogger } from "ngrx-store-logger";
-import { MatIconModule, MatIconRegistry } from "@angular/material/icon";
-import { MatButtonModule } from "@angular/material/button";
-import { MatButtonToggleModule } from "@angular/material/button-toggle";
-import { MatCardModule } from "@angular/material/card";
-import { MatCheckboxModule } from "@angular/material/checkbox";
-import { MatExpansionModule } from "@angular/material/expansion";
-import { MatListModule } from "@angular/material/list";
-import { MatTooltipModule } from "@angular/material/tooltip";
+import { MatIconRegistry } from "@angular/material/icon";
 import { DateAdapter } from "@angular/material/core";
 import { Observable, of } from "rxjs";
 import { filter, map } from "rxjs/operators";
@@ -173,15 +165,6 @@ export const metaReducers: MetaReducer<State>[] = ENV !== "production" ? [logger
 	imports: [
 		BrowserModule,
 		BrowserAnimationsModule,
-		FormsModule,
-		MatButtonModule,
-		MatButtonToggleModule,
-		MatCardModule,
-		MatCheckboxModule,
-		MatExpansionModule,
-		MatIconModule,
-		MatListModule,
-		MatTooltipModule,
 		StoreModule.forRoot(reducers, {
 			metaReducers
 		}),

--- a/showcase/src/app/demo-rbac/demo-rbac.module.ts
+++ b/showcase/src/app/demo-rbac/demo-rbac.module.ts
@@ -1,11 +1,5 @@
 import { NgModule } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { FormsModule } from "@angular/forms";
 import { UIRouterModule } from "@uirouter/angular";
-import { MatButtonModule } from "@angular/material/button";
-import { MatButtonToggleModule } from "@angular/material/button-toggle";
-import { TranslateModule } from "@ngx-translate/core";
-import { StarkPrettyPrintModule } from "@nationalbankbelgium/stark-ui";
 import { StarkRBACAuthorizationModule } from "@nationalbankbelgium/stark-rbac";
 import { DEMO_STATES } from "./routes";
 import { SharedModule } from "../shared";
@@ -16,13 +10,7 @@ import { DemoAuthorizationDirectivesPageComponent, DemoAuthorizationServicePageC
 		UIRouterModule.forChild({
 			states: DEMO_STATES
 		}),
-		CommonModule,
-		FormsModule,
-		MatButtonModule,
-		MatButtonToggleModule,
-		TranslateModule,
 		SharedModule,
-		StarkPrettyPrintModule,
 		StarkRBACAuthorizationModule
 	],
 	declarations: [DemoAuthorizationDirectivesPageComponent, DemoAuthorizationServicePageComponent, DemoProtectedPageComponent],

--- a/showcase/src/app/demo-ui/demo-ui.module.ts
+++ b/showcase/src/app/demo-ui/demo-ui.module.ts
@@ -1,23 +1,11 @@
 import { NgModule } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatOptionModule } from "@angular/material/core";
 import { MatAutocompleteModule } from "@angular/material/autocomplete";
-import { MatCheckboxModule } from "@angular/material/checkbox";
-import { MatButtonModule } from "@angular/material/button";
-import { MatButtonToggleModule } from "@angular/material/button-toggle";
-import { MatCardModule } from "@angular/material/card";
 import { MatDividerModule } from "@angular/material/divider";
-import { MatExpansionModule } from "@angular/material/expansion";
-import { MatIconModule } from "@angular/material/icon";
-import { MatTabsModule } from "@angular/material/tabs";
-import { MatTooltipModule } from "@angular/material/tooltip";
-import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatFormFieldModule } from "@angular/material/form-field";
 import { MatInputModule } from "@angular/material/input";
 import { MatSlideToggleModule } from "@angular/material/slide-toggle";
 import { StoreModule } from "@ngrx/store";
-import { TranslateModule } from "@ngx-translate/core";
 import { UIRouterModule } from "@uirouter/angular";
 import {
 	StarkActionBarModule,
@@ -93,25 +81,12 @@ import {
 		UIRouterModule.forChild({
 			states: DEMO_STATES
 		}),
-		CommonModule,
-		FormsModule,
-		ReactiveFormsModule,
 		MatAutocompleteModule,
-		MatButtonModule,
-		MatButtonToggleModule,
-		MatCardModule,
-		MatCheckboxModule,
 		MatDividerModule,
-		MatExpansionModule,
 		MatFormFieldModule,
-		MatIconModule,
 		MatInputModule,
 		MatOptionModule,
-		MatTooltipModule,
-		MatSnackBarModule,
-		MatTabsModule,
 		MatSlideToggleModule,
-		TranslateModule,
 		SharedModule,
 		StarkActionBarModule,
 		StarkAppLogoutModule,

--- a/showcase/src/app/shared/components/example-viewer/example-viewer.component.html
+++ b/showcase/src/app/shared/components/example-viewer/example-viewer.component.html
@@ -3,7 +3,7 @@
 		<mat-card-title>
 			<h3 translate>{{ exampleTitle }}</h3>
 		</mat-card-title>
-		<button color="white" mat-icon-button (click)="toggleSourceView()" matTooltip="View source">
+		<button color="white" mat-icon-button (click)="toggleSourceView()" matTooltip="View source" [disabled]="extensions.length === 0">
 			<mat-icon svgIcon="code-tags"></mat-icon>
 		</button>
 	</mat-card-header>

--- a/showcase/src/app/shared/components/example-viewer/example-viewer.component.ts
+++ b/showcase/src/app/shared/components/example-viewer/example-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, Input, OnInit } from "@angular/core";
+import { ChangeDetectionStrategy, Component, Inject, Input, OnInit } from "@angular/core";
 import { HttpErrorResponse } from "@angular/common/http";
 import { STARK_LOGGING_SERVICE, StarkErrorImpl, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { FileService } from "../../services";
@@ -12,27 +12,24 @@ export interface ExampleFile {
 @Component({
 	selector: "example-viewer",
 	templateUrl: "./example-viewer.component.html",
-	styleUrls: ["./example-viewer.component.scss"]
+	styleUrls: ["./example-viewer.component.scss"],
+	changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ExampleViewerComponent implements OnInit {
 	@Input()
-	public extensions: string[];
+	public extensions = ["HTML", "TS", "CSS"];
 	@Input()
 	public filesPath = "undefined";
 	@Input()
 	public exampleTitle = "undefined";
 
 	public appBaseHref: string;
-	public examplesFolder: string;
-	public exampleFiles: ExampleFile[];
-	public showSource: boolean;
+	public examplesFolder = "assets/examples/";
+	public exampleFiles: ExampleFile[] = [];
+	public showSource = false;
 
 	public constructor(private fileService: FileService, @Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService) {
-		this.extensions = ["HTML", "TS", "CSS"];
-		this.exampleFiles = [];
-		this.showSource = false;
 		this.appBaseHref = this.getAppBaseHref();
-		this.examplesFolder = "assets/examples/";
 	}
 
 	public ngOnInit(): void {

--- a/showcase/src/app/shared/shared.module.ts
+++ b/showcase/src/app/shared/shared.module.ts
@@ -1,11 +1,16 @@
 import { DateAdapter } from "@angular/material/core";
 import { MatButtonModule } from "@angular/material/button";
+import { MatButtonToggleModule } from "@angular/material/button-toggle";
 import { MatCardModule } from "@angular/material/card";
+import { MatCheckboxModule } from "@angular/material/checkbox";
+import { MatExpansionModule } from "@angular/material/expansion";
 import { MatIconModule } from "@angular/material/icon";
+import { MatListModule } from "@angular/material/list";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatTabsModule } from "@angular/material/tabs";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { CommonModule } from "@angular/common";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { Inject, NgModule } from "@angular/core";
 import { StarkPrettyPrintModule } from "@nationalbankbelgium/stark-ui";
 import { TranslateModule } from "@ngx-translate/core";
@@ -24,21 +29,48 @@ import { FileService } from "./services";
 
 @NgModule({
 	imports: [
+		CommonModule,
+		FormsModule,
+		ReactiveFormsModule,
 		FlexLayoutModule,
 		MatButtonModule,
+		MatButtonToggleModule,
 		MatCardModule,
+		MatCheckboxModule,
+		MatExpansionModule,
 		MatIconModule,
+		MatListModule,
+		MatTabsModule,
 		MatTooltipModule,
 		MatSnackBarModule,
-		MatTabsModule,
-		CommonModule,
 		StarkPrettyPrintModule,
 		TranslateModule
 	],
 	providers: [FileService],
 	declarations: [ExampleViewerComponent, ReferenceBlockComponent, TableOfContentsComponent],
 	entryComponents: [],
-	exports: [ExampleViewerComponent, ReferenceBlockComponent, TableOfContentsComponent, FlexLayoutModule]
+	// export commonly used components/directives/components (see https://angular.io/guide/sharing-ngmodules)
+	exports: [
+		ExampleViewerComponent,
+		ReferenceBlockComponent,
+		TableOfContentsComponent,
+		CommonModule,
+		FormsModule,
+		ReactiveFormsModule,
+		FlexLayoutModule,
+		MatButtonModule,
+		MatButtonToggleModule,
+		MatCardModule,
+		MatCheckboxModule,
+		MatExpansionModule,
+		MatIconModule,
+		MatListModule,
+		MatTabsModule,
+		MatTooltipModule,
+		MatSnackBarModule,
+		StarkPrettyPrintModule,
+		TranslateModule
+	]
 })
 export class SharedModule {
 	public constructor(

--- a/showcase/src/app/styleguide/pages/layout/styleguide-layout-page.component.html
+++ b/showcase/src/app/styleguide/pages/layout/styleguide-layout-page.component.html
@@ -13,18 +13,17 @@
 	</div>
 </example-viewer>
 
-<!--FIXME: add example back when chrome is updated to 57 or higher-->
-<!--<example-viewer filesPath="flex-layout/grid" [extensions]="['HTML', 'SCSS']" exampleTitle="SHOWCASE.STYLEGUIDE.LAYOUT.GRID">-->
-<!--<div class="warning">-->
-<!--<mat-icon svgIcon="alert-circle"></mat-icon>-->
-<!--<span [innerHTML]="'SHOWCASE.STYLEGUIDE.LAYOUT.GRID_WARNING' | translate"></span>-->
-<!--</div>-->
-<!--<div class="layout-demo" gdAuto="row" gdAuto.gt-sm="column" gdGap="10px">-->
-<!--<div>1</div>-->
-<!--<div class="accent" gdRow.gt-md="1" gdColumn.gt-md="1">-->
-<!--2-->
-<!--</div>-->
-<!--<div>3</div>-->
-<!--<div>4</div>-->
-<!--</div>-->
-<!--</example-viewer>-->
+<example-viewer filesPath="flex-layout/grid" [extensions]="['HTML', 'SCSS']" exampleTitle="SHOWCASE.STYLEGUIDE.LAYOUT.GRID">
+	<div class="warning">
+		<mat-icon svgIcon="alert-circle"></mat-icon>
+		<span [innerHTML]="'SHOWCASE.STYLEGUIDE.LAYOUT.GRID_WARNING' | translate"></span>
+	</div>
+	<div class="layout-demo" gdAuto="row" gdAuto.gt-sm="column" gdGap="10px">
+		<div>1</div>
+		<div class="accent" gdRow.gt-md="1" gdColumn.gt-md="1">
+			2
+		</div>
+		<div>3</div>
+		<div>4</div>
+	</div>
+</example-viewer>

--- a/showcase/src/app/styleguide/pages/layout/styleguide-layout-page.component.scss
+++ b/showcase/src/app/styleguide/pages/layout/styleguide-layout-page.component.scss
@@ -1,8 +1,9 @@
 .styleguide-layout-page {
   .warning {
     margin-bottom: 24px;
+    font-weight: bold;
 
-    mat-icon > svg {
+    .mat-icon > svg {
       margin-bottom: -5px;
     }
   }

--- a/showcase/src/app/styleguide/pages/layout/styleguide-layout-page.theme.scss
+++ b/showcase/src/app/styleguide/pages/layout/styleguide-layout-page.theme.scss
@@ -1,6 +1,8 @@
 .styleguide-layout-page {
   .warning {
-    color: mat-color($warning-palette, 500);
+    .mat-icon {
+      color: mat-color($warning-palette, 500);
+    }
   }
 
   .layout-demo > * {

--- a/showcase/src/app/styleguide/styleguide.module.ts
+++ b/showcase/src/app/styleguide/styleguide.module.ts
@@ -1,10 +1,5 @@
 import { NgModule } from "@angular/core";
 import { UIRouterModule } from "@uirouter/angular";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCardModule } from "@angular/material/card";
-import { MatIconModule } from "@angular/material/icon";
-import { TranslateModule } from "@ngx-translate/core";
-import { StarkPrettyPrintModule } from "@nationalbankbelgium/stark-ui";
 import { SharedModule } from "../shared/shared.module";
 import { STYLEGUIDE_STATES } from "./routes";
 import {
@@ -21,11 +16,6 @@ import {
 		UIRouterModule.forChild({
 			states: STYLEGUIDE_STATES
 		}),
-		MatButtonModule,
-		MatCardModule,
-		MatIconModule,
-		TranslateModule,
-		StarkPrettyPrintModule,
 		SharedModule
 	],
 	providers: [],

--- a/showcase/src/app/welcome/welcome.module.ts
+++ b/showcase/src/app/welcome/welcome.module.ts
@@ -1,11 +1,5 @@
 import { NgModule } from "@angular/core";
-import { CommonModule } from "@angular/common";
 import { UIRouterModule } from "@uirouter/angular";
-import { MatIconModule } from "@angular/material/icon";
-import { MatCardModule } from "@angular/material/card";
-import { MatExpansionModule } from "@angular/material/expansion";
-import { TranslateModule } from "@ngx-translate/core";
-import { StarkPrettyPrintModule } from "@nationalbankbelgium/stark-ui";
 import { GettingStartedPageComponent, HomePageComponent, NewsPageComponent, NoContentPageComponent } from "./pages";
 import { NewsItemComponent } from "./components";
 import { SharedModule } from "../shared";
@@ -16,12 +10,6 @@ import { NEWS_STATES } from "./routes";
 		UIRouterModule.forChild({
 			states: NEWS_STATES
 		}),
-		CommonModule,
-		TranslateModule,
-		MatCardModule,
-		MatExpansionModule,
-		MatIconModule,
-		StarkPrettyPrintModule,
 		SharedModule
 	],
 	declarations: [GettingStartedPageComponent, HomePageComponent, NoContentPageComponent, NewsPageComponent, NewsItemComponent],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Some modules are duplicated and re-imported in other modules which makes the code too verbose and messy.

Also, the `ExampleViewerComponent` uses the default change detection strategy from Angular which runs too many unnecessary dirty checks. See #1331


## What is the new behavior?
- All the commonly used modules are put into the Shared module which exposes all those common modules in order to simplify the code. See https://angular.io/guide/sharing-ngmodules
- The `ChangeDetectionStrategy.OnPush` is now enabled in the `ExampleViewerComponent` in order to reduce the number of dirty checks performed by Angular and improve the performance of the apps.
- Minor enhancement in the `ExampleViewerComponent`: the "view source" button is disabled when there are no source files to view.
- Add back the Grid Layout example to the Layout demo page since the version of Chrome we use now supports it (Chrome 57+).

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->