### PR TITLE
fix(stark-ui): ui dropdown: not taking into account option - emitEvent

### DIFF
--- a/packages/stark-ui/src/modules/dropdown/components/dropdown.component.spec.ts
+++ b/packages/stark-ui/src/modules/dropdown/components/dropdown.component.spec.ts
@@ -559,6 +559,48 @@ describe("DropdownComponent", () => {
 					hostFixture.detectChanges();
 					expect(selectElement.outerHTML).toMatch(/ng-reflect-disabled="false"/);
 				});
+
+				it("shouldn't trigger a 'valueChange' event when the formControl is disabled or enabled with emitEvent set to false", () => {
+					const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+
+					hostComponent.formControl.valueChanges.subscribe(mockObserver);
+
+					hostComponent.formControl.disable({ emitEvent: false });
+					hostFixture.detectChanges();
+
+					expect(component.disabled).toBe(true);
+
+					hostComponent.formControl.enable({ emitEvent: false });
+					hostFixture.detectChanges();
+
+					expect(component.disabled).toBe(false);
+					expect(mockObserver.next).not.toHaveBeenCalled(); // because the 'emitEvent' is false
+					expect(mockObserver.error).not.toHaveBeenCalled();
+					expect(mockObserver.complete).not.toHaveBeenCalled();
+				});
+
+				it("should trigger a 'valueChange' event when the formControl is disabled or enabled with emitEvent set to true", () => {
+					const mockObserver: SpyObj<Observer<any>> = createSpyObj<Observer<any>>("observerSpy", ["next", "error", "complete"]);
+
+					hostComponent.formControl.valueChanges.subscribe(mockObserver);
+
+					hostComponent.formControl.disable(); // 'emitEvent' true by default
+					hostFixture.detectChanges();
+
+					expect(component.disabled).toBe(true);
+					expect(mockObserver.next).toHaveBeenCalledTimes(1);
+					expect(mockObserver.error).not.toHaveBeenCalled();
+					expect(mockObserver.complete).not.toHaveBeenCalled();
+					mockObserver.next.calls.reset();
+
+					hostComponent.formControl.enable(); // 'emitEvent' true by default
+					hostFixture.detectChanges();
+
+					expect(component.disabled).toBe(false);
+					expect(mockObserver.next).toHaveBeenCalledTimes(1);
+					expect(mockObserver.error).not.toHaveBeenCalled();
+					expect(mockObserver.complete).not.toHaveBeenCalled();
+				});
 			});
 
 			describe("formControl.value", () => {
@@ -628,7 +670,6 @@ describe("DropdownComponent", () => {
 			}));
 		});
 	});
-
 	// FIXME re-enable those tests as soon as a solution to replace the md-select-header as been found: https://github.com/angular/material2/pull/7835
 	//
 	// describe("header", () => {

--- a/packages/stark-ui/src/modules/dropdown/components/dropdown.component.ts
+++ b/packages/stark-ui/src/modules/dropdown/components/dropdown.component.ts
@@ -473,7 +473,6 @@ export class StarkDropdownComponent extends AbstractStarkUiComponent
 	public setDisabledState(isDisabled: boolean): void {
 		this.disabled = isDisabled;
 		this.stateChanges.next();
-		this._onValidatorChange();
 	}
 
 	/**


### PR DESCRIPTION
ISSUES CLOSED: #1364

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Change the dropdown setDisabledState function to take into account the emitEvent.

Issue Number: #1364 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information