### PR TITLE
fix(stark-ui): table - when data changes, selection is now reset

### DIFF
--- a/packages/stark-ui/src/modules/table/components/table.component.spec.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.spec.ts
@@ -209,6 +209,16 @@ describe("TableComponent", () => {
 			expect(component.dataSource.data).toEqual([{ name: "test-data-2" }]);
 		});
 
+		it("should reset 'selection' when 'data' changes", () => {
+			component.selection.toggle({ name: "selected-data-1" });
+			expect(component.selection.selected).toEqual([{ name: "selected-data-1" }]);
+
+			hostComponent.dummyData = [{ name: "data-1" }];
+			hostFixture.detectChanges();
+
+			expect(component.selection.selected).toEqual([]);
+		});
+
 		it("should assign right value to isFixedHeaderEnabled when fixedHeader changes", () => {
 			hostComponent.fixedHeader = "true";
 			hostFixture.detectChanges();

--- a/packages/stark-ui/src/modules/table/components/table.component.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.ts
@@ -484,6 +484,8 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 			this.data = this.data || [];
 
 			if (!changes["data"].isFirstChange()) {
+				this._resetSelection();
+
 				if (this.resetFilterValueOnDataChange()) {
 					this.filterChanged.emit(this.filter);
 					this.applyFilter();


### PR DESCRIPTION
ISSUES CLOSED: #1366

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Selection is not reset when data changes in table component

Issue Number: #1366 

## What is the new behavior?
Selection is reset when data changes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information