### PR TITLE
fix(stark-ui): reset line-height of <input/> to avoid letters to be cut off at the bottom

### DIFF
--- a/packages/stark-ui/assets/styles/_material-fixes.scss
+++ b/packages/stark-ui/assets/styles/_material-fixes.scss
@@ -6,6 +6,11 @@
   line-height: initial;
 }
 
+// the line-height of the mat-form-field needs to be reset, because of the line-height set in _typography.scss
+.mat-form-field {
+  line-height: initial;
+}
+
 // Causes checkbox trigger to take up entire width/height of menu item
 .mat-menu-content div.mat-menu-item > mat-checkbox label {
   margin: 0 -16px;


### PR DESCRIPTION
The default layout of inputs causes some letters (gj...) to be cut off at the bottom.

ISSUES CLOSED: #1374

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Change the default layout of inputs.

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The default layout of inputs causes some letters (gj...) to be cut off at the bottom.

Issue Number: #1374


## What is the new behavior?
The default layout of inputs doesn't cut off some letters anymore.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information