### PR TITLE
fix(stark-ui): ui: app-data - in 'dropdown' mode the 'detail' pane overlaps the 'summary'

### DIFF
--- a/packages/stark-ui/src/modules/app-data/components/_app-data.component.scss
+++ b/packages/stark-ui/src/modules/app-data/components/_app-data.component.scss
@@ -46,7 +46,7 @@
 
   & .stark-app-data-detail {
     position: absolute;
-    top: 55px;
+    top: 100%;
     width: 250px;
     right: 0;
     left: 0;


### PR DESCRIPTION
In the AppData in 'dropdown' mode, when the 'summary' pane is too big, it is overlapped by the
'detail' pane so the summary content is not fully visible

ISSUES CLOSED: #1341

## PR Checklist
The 'summary' pane isn't overlapped anymore.
- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1341 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information