### PR TITLE
feat(stark-ui): put the column filter of the table above the title

### DIFF
--- a/packages/stark-ui/src/modules/table/components/column.component.html
+++ b/packages/stark-ui/src/modules/table/components/column.component.html
@@ -16,7 +16,7 @@
 				<mat-icon class="stark-small-icon" svgIcon="filter" [matTooltip]="'STARK.TABLE.COLUMN_FILTER' | translate"></mat-icon>
 			</button>
 		</div>
-		<mat-menu class="mat-table-filter" #filterMenu="matMenu" xPosition="before" [overlapTrigger]="false">
+		<mat-menu class="mat-table-filter" #filterMenu="matMenu" [yPosition]="filterPosition" xPosition="before" [overlapTrigger]="false">
 			<div>
 				<mat-form-field
 					class=""

--- a/packages/stark-ui/src/modules/table/components/column.component.ts
+++ b/packages/stark-ui/src/modules/table/components/column.component.ts
@@ -20,7 +20,12 @@ import { FormControl } from "@angular/forms";
 import { distinctUntilChanged } from "rxjs/operators";
 import isEqual from "lodash-es/isEqual";
 import get from "lodash-es/get";
-import { StarkColumnFilterChangedOutput, StarkColumnSortChangedOutput, StarkTableColumnSortingDirection } from "../entities";
+import {
+	StarkColumnFilterChangedOutput,
+	StarkColumnSortChangedOutput,
+	StarkTableColumnFilter,
+	StarkTableColumnSortingDirection
+} from "../entities";
 
 /**
  * Component to display a column inside the StarkTableComponent
@@ -129,6 +134,24 @@ export class StarkTableColumnComponent extends AbstractStarkUiComponent implemen
 	 */
 	@Input()
 	public sortable = true;
+
+	/**
+	 * Position where the column filter box should be displayed. Default: "below"
+	 */
+	@Input()
+	public get filterPosition(): StarkTableColumnFilter["filterPosition"] {
+		return this._filterPosition;
+	}
+
+	public set filterPosition(value: StarkTableColumnFilter["filterPosition"]) {
+		this._filterPosition = value || "below";
+	}
+
+	/**
+	 * @ignore
+	 * @internal
+	 */
+	private _filterPosition?: StarkTableColumnFilter["filterPosition"] = "below";
 
 	/**
 	 * Priority of the column.

--- a/packages/stark-ui/src/modules/table/components/table.component.html
+++ b/packages/stark-ui/src/modules/table/components/table.component.html
@@ -22,7 +22,13 @@
 		>
 			<mat-icon [matTooltip]="'STARK.TABLE.FILTER' | translate" class="stark-small-icon" svgIcon="filter"></mat-icon>
 		</button>
-		<mat-menu class="mat-table-filter" #globalFilter="matMenu" xPosition="before" [overlapTrigger]="false">
+		<mat-menu
+			class="mat-table-filter"
+			#globalFilter="matMenu"
+			[yPosition]="filter.filterPosition"
+			xPosition="before"
+			[overlapTrigger]="false"
+		>
 			<div>
 				<mat-form-field (click)="$event.stopPropagation()" (keyup)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
 					<input
@@ -109,6 +115,7 @@
 			[filterable]="col.isFilterable"
 			[filterValue]="getColumnFilterValue(col.name)"
 			[visible]="col.isVisible"
+			[filterPosition]="getColumnFilterPosition(col.name)"
 			[compareFn]="col.compareFn"
 			[cellFormatter]="col.cellFormatter"
 			[cellClassName]="col.cellClassName"

--- a/packages/stark-ui/src/modules/table/components/table.component.spec.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.spec.ts
@@ -366,7 +366,8 @@ describe("TableComponent", () => {
 			hostFixture.detectChanges();
 			expect(component.filter).toEqual({
 				globalFilterValue: "test",
-				globalFilterPresent: true
+				globalFilterPresent: true,
+				filterPosition: "below"
 			});
 		});
 

--- a/packages/stark-ui/src/modules/table/components/table.component.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.ts
@@ -34,6 +34,7 @@ import { StarkAction, StarkActionBarConfig } from "../../action-bar/components";
 import {
 	StarkColumnFilterChangedOutput,
 	StarkColumnSortChangedOutput,
+	StarkTableColumnFilter,
 	StarkTableColumnProperties,
 	StarkTableColumnSortingDirection,
 	StarkTableFilter,
@@ -53,7 +54,8 @@ const componentName = "stark-table";
  * Default filter configuration
  */
 const defaultFilter: StarkTableFilter = {
-	globalFilterPresent: true
+	globalFilterPresent: true,
+	filterPosition: "below"
 };
 
 /**
@@ -951,6 +953,20 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 			}
 		}
 		return columnFilterValue;
+	}
+
+	/**
+	 * Get the position of the filter box of the specified column.
+	 * @param columnName - Name of the column whose filter box position should be retrieved.
+	 * @returns The position of the filter box of the specified column.
+	 */
+	public getColumnFilterPosition(columnName: string): StarkTableColumnFilter["filterPosition"] {
+		if (!(this.filter.columns instanceof Array)) {
+			return undefined;
+		}
+
+		const column = this.filter.columns.find((columnFilter: StarkTableColumnFilter) => columnFilter.columnName === columnName);
+		return column ? column.filterPosition : undefined;
 	}
 
 	/**

--- a/packages/stark-ui/src/modules/table/entities/table-column-filter.intf.ts
+++ b/packages/stark-ui/src/modules/table/entities/table-column-filter.intf.ts
@@ -18,4 +18,9 @@ export interface StarkTableColumnFilter {
 	 * Whether the filter in the Table component must be reset when the data changes. Default: false.
 	 */
 	resetFilterOnDataChange?: boolean;
+
+	/**
+	 * The position where the column filter box should be displayed. Default: "below".
+	 */
+	filterPosition?: "below" | "above";
 }

--- a/packages/stark-ui/src/modules/table/entities/table-filter.intf.ts
+++ b/packages/stark-ui/src/modules/table/entities/table-filter.intf.ts
@@ -26,4 +26,9 @@ export interface StarkTableFilter {
 	 * Whether the filter in the Table component must be reset when the data changes. Default: false.
 	 */
 	resetGlobalFilterOnDataChange?: boolean;
+
+	/**
+	 * The position in which the global filter box for the table should be displayed. Default: "below".
+	 */
+	filterPosition?: "above" | "below";
 }

--- a/showcase/src/app/demo-ui/components/table-regular/table-regular.component.ts
+++ b/showcase/src/app/demo-ui/components/table-regular/table-regular.component.ts
@@ -51,10 +51,20 @@ export class TableRegularComponent {
 			compareFn: (n1: { value: number }, n2: { value: number }): number => n1.value - n2.value
 		},
 		{ name: "description", label: "SHOWCASE.DEMO.TABLE.LABELS.DESCRIPTION" },
-		{ name: "extra", label: "SHOWCASE.DEMO.TABLE.LABELS.EXTRA_INFO", isFilterable: false, isSortable: false, isVisible: false }
+		{
+			name: "extra",
+			label: "SHOWCASE.DEMO.TABLE.LABELS.EXTRA_INFO",
+			isFilterable: false,
+			isSortable: false,
+			isVisible: false
+		}
 	];
 
-	public filter: StarkTableFilter = { globalFilterPresent: true, columns: [] };
+	public filter: StarkTableFilter = {
+		globalFilterPresent: true,
+		columns: [{ columnName: "id", filterPosition: "below" }, { columnName: "title", filterPosition: "above" }],
+		filterPosition: "below"
+	};
 
 	public order: string[] = ["title", "-description", "id"];
 


### PR DESCRIPTION
ISSUES CLOSED: #1352

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
In column filtering, there is a little popup screen to type the filter-characters. Now it opens under the column header, which makes it difficult to see the results of the filter.

Issue Number: #1352


## What is the new behavior?
Open it above the column header instead.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information