### PR TITLE
fix(stark-ui): change the Multisort component to display the label in…

### DIFF
--- a/packages/stark-ui/src/modules/table/components/dialogs/multisort.component.html
+++ b/packages/stark-ui/src/modules/table/components/dialogs/multisort.component.html
@@ -13,8 +13,8 @@
 				<mat-form-field class="form-field-name">
 					<mat-select [value]="rule" (selectionChange)="onColumnChange(rule, $event.value)">
 						<ng-container *ngFor="let ruleOption of rules; trackBy: trackRuleFn">
-							<mat-option *ngIf="ruleOption == rule || !ruleOption.sortDirection" [value]="ruleOption"
-								>{{ ruleOption.column.name }}
+							<mat-option *ngIf="ruleOption == rule || !ruleOption.sortDirection" [value]="ruleOption">
+								{{ (ruleOption.column.label ? ruleOption.column.label : ruleOption.column.name) | translate }}
 							</mat-option>
 						</ng-container>
 					</mat-select>


### PR DESCRIPTION
…stead of the name of the column

ISSUES CLOSED: #1397

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The Multisort dialog displays the name of the column and not the label.

Issue Number: #1397


## What is the new behavior?
The displayed columns in the Multisort dialog should the label instead of the name (corresponding to the column header in the table...)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information