### PR TITLE
fix(stark-ui): select only available rows with select all on table

### DIFF
--- a/packages/stark-ui/src/modules/table/components/table.component.spec.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.spec.ts
@@ -1429,6 +1429,44 @@ describe("TableComponent", () => {
 			expect(rowsElements[1].classList).toContain("selected");
 			expect(rowsElements[2].classList).not.toContain("selected");
 		});
+
+		describe("select all", () => {
+			let selectAllButton: HTMLButtonElement;
+			const handleChange = jasmine.createSpy();
+
+			beforeEach(() => {
+				hostComponent.columnProperties = [{ name: "id" }, { name: "description" }];
+				hostComponent.dummyData = dummyData;
+
+				hostComponent.selection = new SelectionModel<object>(true);
+				hostComponent.selection.changed.subscribe(handleChange);
+				handleChange.calls.reset();
+
+				hostFixture.detectChanges(); // trigger data binding
+				component.ngAfterViewInit();
+
+				selectAllButton = hostFixture.nativeElement.querySelector(
+					"table thead tr th.mat-column-select mat-checkbox .mat-checkbox-inner-container"
+				);
+			});
+
+			it("should select all rows when clicking the select all", () => {
+				selectAllButton.click();
+				hostFixture.detectChanges();
+
+				expect(handleChange).toHaveBeenCalledTimes(dummyData.length);
+			});
+
+			it("should select all rows available after filter when clicking the select all", () => {
+				component.filter.columns = [{ columnName: "id", filterValue: "1" }];
+				hostFixture.detectChanges();
+
+				selectAllButton.click();
+				hostFixture.detectChanges();
+
+				expect(handleChange).toHaveBeenCalledTimes(1);
+			});
+		});
 	});
 
 	describe("async", () => {

--- a/packages/stark-ui/src/modules/table/components/table.component.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.ts
@@ -635,7 +635,7 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 		if (this.isAllSelected()) {
 			this.selection.clear();
 		} else {
-			for (const row of this.data) {
+			for (const row of this.dataSource.filteredData) {
 				this.selection.select(row);
 			}
 		}


### PR DESCRIPTION
ISSUES CLOSED: #1392

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1392 


## What is the new behavior?
only the available rows are selected / emitted

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information