### PR TITLE
test(stark-all): fix wrong types in unit tests after automatic upgrade of @types/jasmine to v3.4.X

### DIFF
--- a/packages/stark-core/src/modules/routing/services/routing.service.spec.ts
+++ b/packages/stark-core/src/modules/routing/services/routing.service.spec.ts
@@ -1840,7 +1840,7 @@ describe("Service: StarkRoutingService", () => {
 			const expectedCalls: number = 16 + 12 + 3 + 1;
 			expect(mockStore.dispatch).toHaveBeenCalledTimes(expectedCalls);
 
-			const actions: CallInfo<CallableRoutingAction>[] = mockStore.dispatch.calls.all();
+			const actions: ReadonlyArray<CallInfo<CallableRoutingAction>> = mockStore.dispatch.calls.all();
 			const actionIndex: number = 16 + 12;
 
 			for (let i = 0; i < actions.length; i++) {

--- a/packages/stark-core/src/modules/session/services/session.service.spec.ts
+++ b/packages/stark-core/src/modules/session/services/session.service.spec.ts
@@ -598,7 +598,7 @@ describe("Service: StarkSessionService", () => {
 				expect(mockStore.dispatch.calls.argsFor(0)[0]).toEqual(new StarkSessionTimeoutCountdownFinish());
 				expect(sessionService.logout).toHaveBeenCalledTimes(1);
 				expect(mockRoutingService.navigateTo).toHaveBeenCalledTimes(1);
-				expect(mockRoutingService.navigateTo).toHaveBeenCalledWith(mockSessionConfig.sessionExpiredStateName);
+				expect(mockRoutingService.navigateTo).toHaveBeenCalledWith(<string>mockSessionConfig.sessionExpiredStateName);
 
 				mockIdleService.onTimeout.complete();
 			});
@@ -691,7 +691,7 @@ describe("Service: StarkSessionService", () => {
 			expectedDevAuthHeaders.forEach((value: string, key: string) => (mockHeadersObj = mockHeadersObj.set(key, value)));
 			mockHeadersObj = mockHeadersObj.set(mockCorrelationIdHeaderName, mockCorrelationId);
 
-			expect(mockKeepaliveService.request).toHaveBeenCalledWith(
+			expect(<HttpRequest<void>>(<unknown>mockKeepaliveService.request)).toHaveBeenCalledWith(
 				new HttpRequest<void>("GET", <string>appConfig.keepAliveUrl, { headers: mockHeadersObj })
 			);
 		});
@@ -729,7 +729,7 @@ describe("Service: StarkSessionService", () => {
 			let mockHeadersObj: HttpHeaders = new HttpHeaders();
 			expectedDevAuthHeaders.forEach((value: string, key: string) => (mockHeadersObj = mockHeadersObj.set(key, value)));
 
-			expect(mockKeepaliveService.request).toHaveBeenCalledWith(
+			expect(<HttpRequest<void>>(<unknown>mockKeepaliveService.request)).toHaveBeenCalledWith(
 				new HttpRequest<void>("GET", <string>appConfig.keepAliveUrl, { headers: mockHeadersObj })
 			);
 		});

--- a/packages/stark-core/src/modules/xsrf/services/xsrf.service.spec.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf.service.spec.ts
@@ -255,7 +255,7 @@ describe("Service: StarkXSRFService", () => {
 			xsrfService.storeXSRFToken();
 
 			expect(xsrfService.setXSRFCookie).toHaveBeenCalledTimes(1);
-			expect(xsrfService.setXSRFCookie).toHaveBeenCalledWith(xsrfService.getCurrentToken());
+			expect(xsrfService.setXSRFCookie).toHaveBeenCalledWith(<string>xsrfService.getCurrentToken());
 			expect(mockDocument.cookie.length).toBeGreaterThan(0);
 			const cookieOptions: any[] = mockDocument.cookie.split(";");
 			expect(cookieOptions.length).toBe(3);
@@ -273,7 +273,7 @@ describe("Service: StarkXSRFService", () => {
 			tick();
 
 			expect(httpMock.get).toHaveBeenCalledTimes(appConfig.backends.size);
-			const httpCalls: CallInfo<HttpClientGet>[] = httpMock.get.calls.all();
+			const httpCalls: ReadonlyArray<CallInfo<HttpClientGet>> = httpMock.get.calls.all();
 			let callIndex = 0;
 
 			appConfig.backends.forEach((backendConfig: StarkBackend) => {
@@ -302,7 +302,7 @@ describe("Service: StarkXSRFService", () => {
 			tick();
 
 			expect(httpMock.get).toHaveBeenCalledTimes(appConfig.backends.size);
-			const httpCalls: CallInfo<HttpClientGet>[] = httpMock.get.calls.all();
+			const httpCalls: ReadonlyArray<CallInfo<HttpClientGet>> = httpMock.get.calls.all();
 			let httpCallIdx = 0;
 
 			appConfig.backends.forEach((backendConfig: StarkBackend) => {
@@ -312,7 +312,7 @@ describe("Service: StarkXSRFService", () => {
 			});
 
 			expect(mockLogger.error).toHaveBeenCalledTimes(failingBackends.length);
-			const logErrorCalls: CallInfo<HttpClientGet>[] = mockLogger.error.calls.all();
+			const logErrorCalls: ReadonlyArray<CallInfo<HttpClientGet>> = mockLogger.error.calls.all();
 			let logErrorCallIdx = 0;
 
 			for (const failingBackend of failingBackends) {

--- a/packages/stark-rbac/src/modules/authorization/services/authorization.service.spec.ts
+++ b/packages/stark-rbac/src/modules/authorization/services/authorization.service.spec.ts
@@ -165,7 +165,7 @@ describe("StarkRBACAuthorizationService", () => {
 			expect(authorizationService.isNavigationAuthorized).toHaveBeenCalledTimes(1);
 			expect(authorizationService.isNavigationAuthorized).toHaveBeenCalledWith(mockPermissions);
 			expect(authorizationService.handleUnauthorizedNavigation).toHaveBeenCalledTimes(1);
-			expect(authorizationService.handleUnauthorizedNavigation).toHaveBeenCalledWith(mockPermissions, mockTransition);
+			expect(authorizationService.handleUnauthorizedNavigation).toHaveBeenCalledWith(mockPermissions, <Transition>mockTransition);
 		});
 	});
 
@@ -293,14 +293,14 @@ describe("StarkRBACAuthorizationService", () => {
 
 			expect(result).toBe(true);
 			expect(authorizationService.hasAnyRole).toHaveBeenCalledTimes(1);
-			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(mockPermissions.only);
+			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(<string[]>mockPermissions.only);
 
 			(<Spy>authorizationService.hasAnyRole).calls.reset();
 			result = authorizationService.isNavigationAuthorized(mockPermissions);
 
 			expect(result).toBe(false);
 			expect(authorizationService.hasAnyRole).toHaveBeenCalledTimes(1);
-			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(mockPermissions.only);
+			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(<string[]>mockPermissions.only);
 		});
 
 		it("should call hasAnyRole() with the permissions 'except' if they are defined and return the INVERTED value that is returned", () => {
@@ -313,14 +313,14 @@ describe("StarkRBACAuthorizationService", () => {
 
 			expect(result).toBe(false); // inverted value of what hasAnyRole returns => 'except'
 			expect(authorizationService.hasAnyRole).toHaveBeenCalledTimes(1);
-			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(mockPermissions.except);
+			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(<string[]>mockPermissions.except);
 
 			(<Spy>authorizationService.hasAnyRole).calls.reset();
 			result = authorizationService.isNavigationAuthorized(mockPermissions);
 
 			expect(result).toBe(true); // inverted value of what hasAnyRole returns => 'except'
 			expect(authorizationService.hasAnyRole).toHaveBeenCalledTimes(1);
-			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(mockPermissions.except);
+			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(<string[]>mockPermissions.except);
 		});
 
 		it("should give preference to permissions 'only' over 'except' when both are defined and call hasAnyRole() with those", () => {
@@ -334,14 +334,14 @@ describe("StarkRBACAuthorizationService", () => {
 
 			expect(result).toBe(true);
 			expect(authorizationService.hasAnyRole).toHaveBeenCalledTimes(1);
-			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(mockPermissions.only);
+			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(<string[]>mockPermissions.only);
 
 			(<Spy>authorizationService.hasAnyRole).calls.reset();
 			result = authorizationService.isNavigationAuthorized(mockPermissions);
 
 			expect(result).toBe(false);
 			expect(authorizationService.hasAnyRole).toHaveBeenCalledTimes(1);
-			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(mockPermissions.only);
+			expect(authorizationService.hasAnyRole).toHaveBeenCalledWith(<string[]>mockPermissions.only);
 		});
 
 		it("should return true without calling hasAnyRole() when the permissions object has invalid 'only' nor 'except' or is undefined", () => {
@@ -391,7 +391,10 @@ describe("StarkRBACAuthorizationService", () => {
 
 			expect(result).toBe(<any>"dummy redirection return value");
 			expect(authorizationService.redirectNavigation).toHaveBeenCalledTimes(1);
-			expect(authorizationService.redirectNavigation).toHaveBeenCalledWith(mockPermissions.redirectTo, mockTransition);
+			expect(authorizationService.redirectNavigation).toHaveBeenCalledWith(
+				<StarkStateRedirection>mockPermissions.redirectTo,
+				<Transition>mockTransition
+			);
 			expect(mockLogger.warn).toHaveBeenCalledTimes(1);
 			expect(mockLogger.warn).toHaveBeenCalledWith(starkUnauthorizedUserError);
 			expect(mockStore.dispatch).not.toHaveBeenCalled();
@@ -497,7 +500,7 @@ describe("StarkRBACAuthorizationService", () => {
 			expect(result["redirectionStateParams"]).toBe(mockRedirectToObj.params);
 			expect(result["redirectionStateParamsReplaced"]).toBe(true);
 			expect(mockRedirectToFn).toHaveBeenCalledTimes(1);
-			expect(mockRedirectToFn).toHaveBeenCalledWith(mockTransition);
+			expect(mockRedirectToFn).toHaveBeenCalledWith(<Transition>mockTransition);
 			expect(mockTransition.targetState).toHaveBeenCalledTimes(1);
 			expect(targetStateObj.withState).toHaveBeenCalledTimes(1);
 			expect(targetStateObj.withState).toHaveBeenCalledWith(mockRedirectToObj.stateName);

--- a/packages/stark-testing/package-lock.json
+++ b/packages/stark-testing/package-lock.json
@@ -102,9 +102,9 @@
       }
     },
     "@types/jasmine": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.4.0.tgz",
-      "integrity": "sha512-6pUnBg6DuSB55xnxJ5+gW9JOkFrPsXkYAuqqEE8oyrpgDiPQ+TZ+1Zt4S+CHcRJcxyNYXeIXG4vHSzdF6y9Uvw=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.4.1.tgz",
+      "integrity": "sha512-kA2/srq6lb/kiczw+l/yW7lKdAN9Ae5A/pp1bhu8RBzhYY/ybc1hwav3sWrPyAwSRcAS95NVB0uZdM62qT75EA=="
     },
     "@types/node": {
       "version": "8.10.51",

--- a/packages/stark-testing/package.json
+++ b/packages/stark-testing/package.json
@@ -20,7 +20,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "@types/jasmine": "^3.3.12",
+    "@types/jasmine": "~3.4.1",
     "@types/node": "^8.10.37",
     "coveralls": "^3.0.2",
     "istanbul-lib-instrument": "^3.0.0",

--- a/packages/stark-ui/src/modules/app-logout/components/app-logout.component.spec.ts
+++ b/packages/stark-ui/src/modules/app-logout/components/app-logout.component.spec.ts
@@ -92,7 +92,7 @@ describe("AppLogoutComponent", () => {
 			component.logout();
 			expect(component.sessionService.logout).toHaveBeenCalledTimes(1);
 			expect(component.routingService.navigateTo).toHaveBeenCalledTimes(1);
-			expect(component.routingService.navigateTo).toHaveBeenCalledWith(mockStarkSessionConfig.sessionLogoutStateName);
+			expect(component.routingService.navigateTo).toHaveBeenCalledWith(<string>mockStarkSessionConfig.sessionLogoutStateName);
 		});
 
 		it("should log out the user and navigate to starkSessionLogoutStateName", () => {

--- a/packages/stark-ui/src/modules/date-picker/components/date-picker.component.spec.ts
+++ b/packages/stark-ui/src/modules/date-picker/components/date-picker.component.spec.ts
@@ -61,7 +61,7 @@ class TestHostComponent {
 	 * To be able to test the 'Changes' output
 	 * @param value: Date.
 	 */
-	public onValueChange(value: Date): void {
+	public onValueChange(value: Date | undefined): void {
 		this.value = value;
 	}
 }

--- a/packages/stark-ui/src/modules/minimap/components/minimap.component.spec.ts
+++ b/packages/stark-ui/src/modules/minimap/components/minimap.component.spec.ts
@@ -193,7 +193,8 @@ describe("MinimapComponent", () => {
 					({ label }: StarkMinimapItemProperties) => label === text
 				);
 				labelElement.click();
-				expect(hostComponent.onShowHideItem).toHaveBeenCalledWith(expectedItem);
+				expect(expectedItem).toBeDefined();
+				expect(hostComponent.onShowHideItem).toHaveBeenCalledWith(<StarkMinimapItemProperties>expectedItem);
 			});
 
 			expect(hostComponent.onShowHideItem).toHaveBeenCalledTimes(items.length);

--- a/packages/stark-ui/src/modules/progress-indicator/directives/progress-indicator.directive.spec.ts
+++ b/packages/stark-ui/src/modules/progress-indicator/directives/progress-indicator.directive.spec.ts
@@ -82,7 +82,7 @@ describe("ProgressIndicatorDirective", () => {
 				expect(mockStarkProgressIndicatorService.register).toHaveBeenCalledTimes(1);
 				expect(mockStarkProgressIndicatorService.register).toHaveBeenCalledWith(
 					mockConfig.topic,
-					StarkProgressIndicatorType[mockConfig.type]
+					<StarkProgressIndicatorType><unknown>StarkProgressIndicatorType[mockConfig.type]
 				);
 			});
 

--- a/showcase/package-lock.json
+++ b/showcase/package-lock.json
@@ -1562,7 +1562,7 @@
       "integrity": "sha512-qEdR5Am5ldIT/XCfdwE42/3AR4j5RwHnAv6k3/4ezz8+rj8jlJo39BMFbFmH/Pvf2CG9NIuiNde7pBflg1vYbQ==",
       "dev": true,
       "requires": {
-        "@types/jasmine": "^3.3.12",
+        "@types/jasmine": "~3.4.1",
         "@types/node": "^8.10.37",
         "coveralls": "^3.0.2",
         "istanbul-lib-instrument": "^3.0.0",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
After the automatic upgrade of `@types/jasmine` to v3.4.x, some TS compilation issues were reported on our `.spec.ts` files which break the Travis builds triggered by Greenkeeper.

See: https://travis-ci.org/NationalBankBelgium/stark/builds/590105818


## What is the new behavior?
- The new violations are fixed.
- Adapted the `package.json` file in stark-testing to specify the latest version of `@types/jasmine` being used and to replace the caret range by a tilde range to prevent issues like this from happening again without being noticed.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```