### PR TITLE
fix(stark-demo): replace encapsulated styles of Table Regular Component by global styles since they depend on Angular Material theming

### DIFF
--- a/showcase/src/app/demo-ui/components/table-regular/table-regular-theme.scss
+++ b/showcase/src/app/demo-ui/components/table-regular/table-regular-theme.scss
@@ -2,7 +2,7 @@
 .showcase-table-regular {
   .shadowed {
     .header {
-      padding: 10px 15px;
+      @include mat-elevation(2);
     }
   }
 }

--- a/showcase/src/app/demo-ui/components/table-regular/table-regular.component.ts
+++ b/showcase/src/app/demo-ui/components/table-regular/table-regular.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, ViewEncapsulation } from "@angular/core";
+import { Component, HostBinding, Inject } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
 import { StarkPaginationConfig, StarkTableColumnProperties, StarkTableFilter, StarkTableRowActions } from "@nationalbankbelgium/stark-ui";
 
@@ -34,12 +34,12 @@ const DUMMY_DATA: object[] = [
 
 @Component({
 	selector: "showcase-table-regular",
-	templateUrl: "./table-regular.component.html",
-	styleUrls: ["./table-regular.component.scss"],
-	/* tslint:disable-next-line:use-view-encapsulation */
-	encapsulation: ViewEncapsulation.None // Important
+	templateUrl: "./table-regular.component.html"
 })
 export class TableRegularComponent {
+	@HostBinding("class")
+	public class = "showcase-table-regular";
+
 	public data: object[] = DUMMY_DATA;
 
 	public columns: StarkTableColumnProperties[] = [

--- a/showcase/src/styles/_theme.scss
+++ b/showcase/src/styles/_theme.scss
@@ -14,4 +14,5 @@ Import the local variables file first to set the correct variables, see:
 @import "../app/welcome/components/news-item/news-item-theme";
 @import "../app/styleguide/pages/typography/styleguide-typography-page-theme";
 @import "../app/demo-ui/pages/route-search/demo-route-search-page.component-theme";
+@import "../app/demo-ui/components/table-regular/table-regular-theme";
 @import "../app/styleguide/pages/layout/styleguide-layout-page.theme";

--- a/showcase/src/styles/styles.scss
+++ b/showcase/src/styles/styles.scss
@@ -13,4 +13,5 @@ IMPORTANT: Stark styles are provided as SCSS styles so they should be imported i
 @import "../app/welcome/pages/news/news-page.component";
 @import "../app/welcome/components/news-item/news-item.component";
 @import "../app/demo-ui/pages/message-pane/demo-message-pane-page.component";
+@import "../app/demo-ui/components/table-regular/table-regular.component";
 @import "../app/styleguide/pages/layout/styleguide-layout-page.component";


### PR DESCRIPTION
ISSUES CLOSED: #1311 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1311 


## What is the new behavior?
The styles for the `TableRegularComponent` are now global styles instead of encapsulated styles because they depend on the Angular Material theming (which is also defined globally).

So now running `npm run ngc` in the showcase doesn't throw any error.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```