### PR TITLE
fix(stark-core): add missing correlation-id header in the HTTP request sent to flush the logs

### DIFF
--- a/packages/stark-core/src/modules/logging/services/logging.service.ts
+++ b/packages/stark-core/src/modules/logging/services/logging.service.ts
@@ -134,11 +134,11 @@ export class StarkLoggingServiceImpl implements StarkLoggingService {
 	protected constructLogMessage(messageType: StarkLogMessageType, ...args: any[]): StarkLogMessage {
 		const parsedArgs: string[] = args.map((arg: any) => this.parseArg(arg));
 		const parsedMessage: string = parsedArgs.join(" | ");
-		return new StarkLogMessageImpl(messageType, parsedMessage, this._correlationId, undefined);
+		return new StarkLogMessageImpl(messageType, parsedMessage, this.correlationId, undefined);
 	}
 
 	protected constructErrorLogMessage(message: string, error: StarkError): StarkLogMessage {
-		return new StarkLogMessageImpl(StarkLogMessageType.ERROR, message, this._correlationId, error);
+		return new StarkLogMessageImpl(StarkLogMessageType.ERROR, message, this.correlationId, error);
 	}
 
 	protected persistLogMessages(isForced: boolean = false): void {
@@ -207,6 +207,7 @@ export class StarkLoggingServiceImpl implements StarkLoggingService {
 				this.xsrfService.configureXHR(xhr);
 			}
 			xhr.setRequestHeader(StarkHttpHeaders.CONTENT_TYPE, "application/json");
+			xhr.setRequestHeader(this.correlationIdHttpHeaderName, this.correlationId);
 			xhr.send(serializedData);
 		} catch (e) {
 			httpRequest$.error(e);


### PR DESCRIPTION
ISSUES CLOSED: #1319

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1319 


## What is the new behavior?
The HTTP request triggered to flush the logs to the backend now also contains the `correlation-id` header with the correspondent value.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```