### PR TITLE
test(stark-core): remove obsolete workaround for failing RoutingService unit tests in Chrome v60 to v69

### DIFF
--- a/packages/stark-core/src/modules/routing/services/routing.service.spec.ts
+++ b/packages/stark-core/src/modules/routing/services/routing.service.spec.ts
@@ -348,8 +348,7 @@ describe("Service: StarkRoutingService", () => {
 
 	const routerModule: UIRouterModule = UIRouterModule.forRoot({
 		useHash: true,
-		states: mockStates,
-		deferIntercept: true // FIXME: this option shouldn't be used but is needed for Chrome and HeadlessChrome otherwise it doesn't work. Why?
+		states: mockStates
 	});
 
 	beforeEach(() => {


### PR DESCRIPTION
ISSUES CLOSED: #300

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #300


## What is the new behavior?
Removed workaround since the error mentioned in #300 does't happen anymore (most likely as of Chrome 70+).

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```