### PR TITLE
feat(stark-ui): add option to display items per page in the pagination of table

### DIFF
--- a/packages/stark-ui/src/modules/pagination/components/_pagination-theme.scss
+++ b/packages/stark-ui/src/modules/pagination/components/_pagination-theme.scss
@@ -3,7 +3,8 @@
 
 @media #{$tablet-query} {
   .stark-pagination > div {
-    .pagination-enter-page {
+    .pagination-enter-page,
+    .pagination-items-per-page {
       & input {
         border: solid 1px $divider-color;
       }

--- a/packages/stark-ui/src/modules/pagination/components/_pagination.component.scss
+++ b/packages/stark-ui/src/modules/pagination/components/_pagination.component.scss
@@ -35,7 +35,8 @@
     font-weight: mat-font-weight($typography-config, caption);
     line-height: mat-line-height($typography-config, caption);
 
-    .pagination-enter-page {
+    .pagination-enter-page,
+    .pagination-items-per-page {
       align-items: center;
       display: flex;
       margin-right: 40px;

--- a/packages/stark-ui/src/modules/pagination/components/pagination.component.html
+++ b/packages/stark-ui/src/modules/pagination/components/pagination.component.html
@@ -51,6 +51,7 @@
 	</div>
 
 	<div class="pagination-items-per-page" *ngIf="paginationConfig.itemsPerPageIsPresent !== false">
+		<input [value]="paginationConfig.itemsPerPage" (keyup.enter)="onChangeItemsPerPage($event.target.value)" />
 		<stark-dropdown
 			[options]="paginationConfig.itemsPerPageOptions"
 			[value]="paginationConfig.itemsPerPage"

--- a/packages/stark-ui/src/modules/pagination/components/pagination.component.ts
+++ b/packages/stark-ui/src/modules/pagination/components/pagination.component.ts
@@ -298,10 +298,11 @@ export class StarkPaginationComponent extends MatPaginator implements OnInit, On
 	/**
 	 * Set page to first then call onChangePagination function.
 	 */
-	public onChangeItemsPerPage(itemsPerPage: number): void {
-		if (this.paginationConfig.itemsPerPage !== itemsPerPage) {
+	public onChangeItemsPerPage(itemsPerPage: number | string): void {
+		const newItemsPerPage: number = typeof itemsPerPage === "string" ? parseInt(itemsPerPage, 10) : itemsPerPage;
+		if (this.paginationConfig.itemsPerPage !== newItemsPerPage) {
 			this.paginationConfig.page = 1;
-			this.paginationConfig.itemsPerPage = itemsPerPage;
+			this.paginationConfig.itemsPerPage = newItemsPerPage;
 			this.onChangePagination();
 		}
 	}

--- a/packages/stark-ui/src/modules/table/components/table.component.html
+++ b/packages/stark-ui/src/modules/table/components/table.component.html
@@ -7,7 +7,7 @@
 		<span translate>STARK.TABLE.ITEMS_FOUND</span>
 	</div>
 
-	<stark-pagination htmlSuffixId="{{ htmlId }}-pagination" [paginationConfig]="paginationConfig" mode="compact"></stark-pagination>
+	<stark-pagination htmlSuffixId="{{ htmlId }}-pagination" [paginationConfig]="paginationConfig" [mode]="mode"></stark-pagination>
 
 	<button *ngIf="isMultiSortEnabled" (click)="openMultiSortDialog()" mat-icon-button>
 		<mat-icon class="stark-small-icon" [matTooltip]="'STARK.TABLE.MULTI_COLUMN_SORTING' | translate" svgIcon="sort"></mat-icon>

--- a/packages/stark-ui/src/modules/table/components/table.component.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.ts
@@ -152,6 +152,12 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 	public data: object[] = [];
 
 	/**
+	 * Data that will be display inside your table.
+	 */
+	@Input()
+	public mode: "default" | "compact" = "compact";
+
+	/**
 	 * Object which contains filtering information for the table.
 	 */
 	@Input()

--- a/showcase/src/app/demo-ui/components/index.ts
+++ b/showcase/src/app/demo-ui/components/index.ts
@@ -5,3 +5,4 @@ export * from "./table-with-transcluded-action-bar";
 export * from "./table-with-fixed-header";
 export * from "./table-with-custom-styling";
 export * from "./table-with-fixed-actions";
+export * from "./table-with-custom-items-per-page";

--- a/showcase/src/app/demo-ui/components/table-with-custom-items-per-page/index.ts
+++ b/showcase/src/app/demo-ui/components/table-with-custom-items-per-page/index.ts
@@ -1,0 +1,1 @@
+export * from "./table-with-custom-items-per-page.component";

--- a/showcase/src/app/demo-ui/components/table-with-custom-items-per-page/table-with-custom-items-per-page.component.html
+++ b/showcase/src/app/demo-ui/components/table-with-custom-items-per-page/table-with-custom-items-per-page.component.html
@@ -1,0 +1,10 @@
+<stark-table
+	[data]="data"
+	[columnProperties]="columns"
+	[filter]="filter"
+	[mode]="mode"
+	[tableRowActions]="tableRowActions"
+	customTableActionsType="alt"
+>
+	<header><h1 class="mb0" translate>SHOWCASE.DEMO.TABLE.WITH_CUSTOM_ITEM_PER_PAGE</h1></header>
+</stark-table>

--- a/showcase/src/app/demo-ui/components/table-with-custom-items-per-page/table-with-custom-items-per-page.component.scss
+++ b/showcase/src/app/demo-ui/components/table-with-custom-items-per-page/table-with-custom-items-per-page.component.scss
@@ -1,0 +1,9 @@
+::ng-deep table {
+  td,
+  th {
+    white-space: nowrap;
+    &.mat-cell {
+      padding-right: 20px;
+    }
+  }
+}

--- a/showcase/src/app/demo-ui/components/table-with-custom-items-per-page/table-with-custom-items-per-page.component.ts
+++ b/showcase/src/app/demo-ui/components/table-with-custom-items-per-page/table-with-custom-items-per-page.component.ts
@@ -1,0 +1,152 @@
+import { Component, Inject } from "@angular/core";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import { StarkTableColumnProperties, StarkTableFilter, StarkTableRowActions } from "@nationalbankbelgium/stark-ui";
+
+// tslint:disable:no-duplicate-string
+const DUMMY_DATA: object[] = [
+	{
+		id: 1,
+		title: { label: "first title (value: 1)", value: 1 },
+		description: "number one",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 10,
+		title: { label: "second title (value: 2)", value: 2 },
+		description: "second description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 12,
+		title: { label: "third title (value: 3)", value: 3 },
+		description: "the third description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 2,
+		title: { label: "fourth title (value: 4)", value: 4 },
+		description: "description number four",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 23,
+		title: { label: "fifth title (value: 5)", value: 5 },
+		description: "fifth description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 222,
+		title: { label: "sixth title (value: 6)", value: 6 },
+		description: "the sixth description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 112,
+		title: { label: "seventh title (value: 7)", value: 7 },
+		description: "seventh description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 232,
+		title: { label: "eighth title (value: 8)", value: 8 },
+		description: "description number eight",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 154,
+		title: { label: "ninth title (value: 9)", value: 9 },
+		description: "the ninth description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 27,
+		title: { label: "tenth title (value: 10)", value: 10 },
+		description: "description number ten",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 86,
+		title: { label: "eleventh title (value: 11)", value: 11 },
+		description: "eleventh description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 44,
+		title: { label: "twelfth title (value: 12)", value: 12 },
+		description: "the twelfth description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	}
+];
+// tslint:enable:no-duplicate-string
+
+@Component({
+	selector: "showcase-table-with-custom-items-per-page",
+	templateUrl: "./table-with-custom-items-per-page.component.html",
+	styleUrls: ["./table-with-custom-items-per-page.component.scss"]
+})
+export class TableWithCustomItemsPerPageComponent {
+	public data: object[] = DUMMY_DATA;
+
+	public columns: StarkTableColumnProperties[] = [
+		{ name: "id", label: "Id" },
+		{
+			name: "title",
+			label: "SHOWCASE.DEMO.TABLE.LABELS.TITLE",
+			cellFormatter: (value: { label: string }): string => "~" + value.label
+		},
+		{ name: "description", label: "SHOWCASE.DEMO.TABLE.LABELS.DESCRIPTION" },
+		// tslint:disable:no-duplicate-string
+		{ name: "info", label: "SHOWCASE.DEMO.TABLE.LABELS.EXTRA_INFO" },
+		{ name: "more_info", label: "SHOWCASE.DEMO.TABLE.LABELS.EXTRA_INFO" },
+		{ name: "even_more_info", label: "SHOWCASE.DEMO.TABLE.LABELS.EXTRA_INFO" }
+		// tslint:enable:no-duplicate-string
+	];
+
+	public filter: StarkTableFilter = { globalFilterPresent: false, columns: [] };
+	public mode = "default";
+	public tableRowActions: StarkTableRowActions = {
+		actions: [
+			{
+				id: "edit-item",
+				label: "STARK.ICONS.EDIT_ITEM",
+				icon: "pencil",
+				actionCall: ($event: Event, data: object): void => this.logger.debug("EDIT", $event, data),
+				isEnabled: true
+			},
+			{
+				id: "delete-item",
+				label: "STARK.ICONS.DELETE_ITEM",
+				icon: "delete",
+				actionCall: ($event: Event, data: object): void => this.logger.debug("DELETE", $event, data),
+				isEnabled: true
+			}
+		],
+		isFixed: true
+	};
+
+	public constructor(@Inject(STARK_LOGGING_SERVICE) private logger: StarkLoggingService) {}
+}

--- a/showcase/src/app/demo-ui/demo-ui.module.ts
+++ b/showcase/src/app/demo-ui/demo-ui.module.ts
@@ -73,7 +73,8 @@ import {
 	TableWithFixedActionsComponent,
 	TableWithFixedHeaderComponent,
 	TableWithSelectionComponent,
-	TableWithTranscludedActionBarComponent
+	TableWithTranscludedActionBarComponent,
+	TableWithCustomItemsPerPageComponent
 } from "./components";
 
 @NgModule({
@@ -146,6 +147,7 @@ import {
 		TableWithFixedHeaderComponent,
 		TableWithCustomStylingComponent,
 		TableWithFixedActionsComponent,
+		TableWithCustomItemsPerPageComponent,
 		DemoToastPageComponent,
 		DemoGenericSearchFormComponent,
 		DemoTransformInputDirectivePageComponent

--- a/showcase/src/app/demo-ui/pages/pagination/demo-pagination-page.component.ts
+++ b/showcase/src/app/demo-ui/pages/pagination/demo-pagination-page.component.ts
@@ -6,7 +6,7 @@ type PaginationConfigType = "simple" | "extended" | "advanced" | "compact";
 
 @Component({
 	selector: "demo-pagination",
-	templateUrl: "./demo-pagination-page.component.html",
+	templateUrl: "./demo-pagination-page.component.html"
 })
 export class DemoPaginationPageComponent {
 	public paginationSimpleConfig: StarkPaginationConfig = {
@@ -32,7 +32,7 @@ export class DemoPaginationPageComponent {
 		itemsPerPage: 4,
 		itemsPerPageOptions: [2, 4, 6, 8, 10, 20],
 		itemsPerPageIsPresent: true,
-		pageInputIsPresent: false,
+		pageInputIsPresent: true,
 		pageNavIsPresent: true
 	};
 	public paginateEventAdvanced = "";

--- a/showcase/src/app/demo-ui/pages/table/demo-table-page.component.html
+++ b/showcase/src/app/demo-ui/pages/table/demo-table-page.component.html
@@ -63,5 +63,14 @@
 	>
 		<showcase-table-with-custom-styling></showcase-table-with-custom-styling>
 	</example-viewer>
+
+	<example-viewer
+		id="custom-items-per-page"
+		exampleTitle="SHOWCASE.DEMO.TABLE.WITH_CUSTOM_ITEM_PER_PAGE"
+		filesPath="table/with-custom-items-per-page/table"
+		[extensions]="['HTML', 'TS', 'SCSS']"
+	>
+		<showcase-table-with-custom-items-per-page></showcase-table-with-custom-items-per-page>
+	</example-viewer>
 </section>
 <stark-reference-block [links]="referenceList"></stark-reference-block>

--- a/showcase/src/assets/examples/table/with-custom-items-per-page/table.html
+++ b/showcase/src/assets/examples/table/with-custom-items-per-page/table.html
@@ -1,0 +1,10 @@
+<stark-table
+	[data]="data"
+	[columnProperties]="columns"
+	[filter]="filter"
+	[mode]="mode"
+	[tableRowActions]="tableRowActions"
+	customTableActionsType="alt"
+>
+	<header><h1 class="mb0" translate>SHOWCASE.DEMO.TABLE.WITH_CUSTOM_ITEMS_PER_PAGE</h1></header>
+</stark-table>

--- a/showcase/src/assets/examples/table/with-custom-items-per-page/table.scss
+++ b/showcase/src/assets/examples/table/with-custom-items-per-page/table.scss
@@ -1,0 +1,9 @@
+::ng-deep table {
+  td,
+  th {
+    white-space: nowrap;
+    &.mat-cell {
+      padding-right: 20px;
+    }
+  }
+}

--- a/showcase/src/assets/examples/table/with-custom-items-per-page/table.ts
+++ b/showcase/src/assets/examples/table/with-custom-items-per-page/table.ts
@@ -1,0 +1,152 @@
+import { Component, Inject } from "@angular/core";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import { StarkTableColumnProperties, StarkTableFilter, StarkTableRowActions } from "@nationalbankbelgium/stark-ui";
+
+// tslint:disable:no-duplicate-string
+const DUMMY_DATA: object[] = [
+	{
+		id: 1,
+		title: { label: "first title (value: 1)", value: 1 },
+		description: "number one",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 10,
+		title: { label: "second title (value: 2)", value: 2 },
+		description: "second description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 12,
+		title: { label: "third title (value: 3)", value: 3 },
+		description: "the third description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 2,
+		title: { label: "fourth title (value: 4)", value: 4 },
+		description: "description number four",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 23,
+		title: { label: "fifth title (value: 5)", value: 5 },
+		description: "fifth description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 222,
+		title: { label: "sixth title (value: 6)", value: 6 },
+		description: "the sixth description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 112,
+		title: { label: "seventh title (value: 7)", value: 7 },
+		description: "seventh description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 232,
+		title: { label: "eighth title (value: 8)", value: 8 },
+		description: "description number eight",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 154,
+		title: { label: "ninth title (value: 9)", value: 9 },
+		description: "the ninth description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 27,
+		title: { label: "tenth title (value: 10)", value: 10 },
+		description: "description number ten",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 86,
+		title: { label: "eleventh title (value: 11)", value: 11 },
+		description: "eleventh description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	},
+	{
+		id: 44,
+		title: { label: "twelfth title (value: 12)", value: 12 },
+		description: "the twelfth description",
+		info: "This is some info.",
+		more_info: "This is even more info.",
+		even_more_info: "This is a ludicrous amount of info."
+	}
+];
+// tslint:enable:no-duplicate-string
+
+@Component({
+	selector: "showcase-table-with-custom-items-per-page",
+	templateUrl: "./table-with-custom-items-per-page.component.html",
+	styleUrls: ["./table-with-custom-items-per-page.component.scss"]
+})
+export class TableWithCustomItemsPerPage {
+	public data: object[] = DUMMY_DATA;
+
+	public columns: StarkTableColumnProperties[] = [
+		{ name: "id", label: "Id" },
+		{
+			name: "title",
+			label: "SHOWCASE.DEMO.TABLE.LABELS.TITLE",
+			cellFormatter: (value: { label: string }): string => "~" + value.label
+		},
+		{ name: "description", label: "SHOWCASE.DEMO.TABLE.LABELS.DESCRIPTION" },
+		// tslint:disable:no-duplicate-string
+		{ name: "info", label: "SHOWCASE.DEMO.TABLE.LABELS.EXTRA_INFO" },
+		{ name: "more_info", label: "SHOWCASE.DEMO.TABLE.LABELS.EXTRA_INFO" },
+		{ name: "even_more_info", label: "SHOWCASE.DEMO.TABLE.LABELS.EXTRA_INFO" }
+		// tslint:enable:no-duplicate-string
+	];
+
+	public filter: StarkTableFilter = { globalFilterPresent: false, columns: [] };
+	public mode = "default";
+	public tableRowActions: StarkTableRowActions = {
+		actions: [
+			{
+				id: "edit-item",
+				label: "STARK.ICONS.EDIT_ITEM",
+				icon: "pencil",
+				actionCall: ($event: Event, data: object): void => this.logger.debug("EDIT", $event, data),
+				isEnabled: true
+			},
+			{
+				id: "delete-item",
+				label: "STARK.ICONS.DELETE_ITEM",
+				icon: "delete",
+				actionCall: ($event: Event, data: object): void => this.logger.debug("DELETE", $event, data),
+				isEnabled: true
+			}
+		],
+		isFixed: true
+	};
+
+	public constructor(@Inject(STARK_LOGGING_SERVICE) private logger: StarkLoggingService) {}
+}

--- a/showcase/src/assets/translations/en.json
+++ b/showcase/src/assets/translations/en.json
@@ -335,6 +335,7 @@
         "WITH_TRANSCLUDED_ACTION_BAR": "Table with transcluded Action bar",
         "WITH_CUSTOM_STYLING": "Table with custom styling",
         "WITH_FIXED_ACTIONS": "Table with fixed row actions",
+        "WITH_CUSTOM_ITEM_PER_PAGE": "Table with custom number of items per page",
         "TITLE": "Table"
       },
       "TOAST": {

--- a/showcase/src/assets/translations/fr.json
+++ b/showcase/src/assets/translations/fr.json
@@ -335,6 +335,7 @@
         "WITH_TRANSCLUDED_ACTION_BAR": "Table avec Action Bar 'transcluded'",
         "WITH_CUSTOM_STYLING": "Table avec mise en page personnalisé",
         "WITH_FIXED_ACTIONS": "Table avec actions de ligne fixes",
+        "WITH_CUSTOM_ITEM_PER_PAGE": "Table avec le nombre d'éléments par page personnalisé",
         "TITLE": "Table"
       },
       "TOAST": {

--- a/showcase/src/assets/translations/nl.json
+++ b/showcase/src/assets/translations/nl.json
@@ -335,6 +335,7 @@
         "WITH_TRANSCLUDED_ACTION_BAR": "Tabel met 'transcluded' Action Bar",
         "WITH_CUSTOM_STYLING": "Tabel met aangepaste opmaak",
         "WITH_FIXED_ACTIONS": "Tabel met vaste rijacties",
+        "WITH_CUSTOM_ITEM_PER_PAGE": "Tabel met aangepast aantal items per pagina",
         "TITLE": "Table"
       },
       "TOAST": {


### PR DESCRIPTION
Add an option to let the developer give the ability to his users to change the number of items per
page

ISSUES CLOSED: #1248

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no way for a user to change the number of items per page when he uses the table component.

Issue Number: #1248 


## What is the new behavior?
Now, the developer have the ability to let his users change the number of items per page in a table.
With a drop down or an input.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information