### PR TITLE
fix(stark-ui): table actions column is not displayed anymore if no row actions are defined

### DIFF
--- a/packages/stark-ui/src/modules/table/components/table.component.html
+++ b/packages/stark-ui/src/modules/table/components/table.component.html
@@ -129,7 +129,7 @@
 		<ng-content select=".stark-table-columns"></ng-content>
 
 		<stark-table-column
-			*ngIf="tableRowActions && tableRowActions.actions"
+			*ngIf="tableRowActions && tableRowActions.actions && tableRowActions.actions.length"
 			[sortable]="false"
 			[name]="'STARK.TABLE.ACTIONS' | translate"
 			[stickyEnd]="tableRowActions.isFixed"

--- a/packages/stark-ui/src/modules/table/components/table.component.spec.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.spec.ts
@@ -1038,6 +1038,45 @@ describe("TableComponent", () => {
 		});
 	});
 
+	describe("column actions", () => {
+		const actionsColumnSelector = "table thead tr th.mat-column-STARK-TABLE-ACTIONS";
+
+		it("should display the 'actions' column when 'tableRowActions' contains some actions", () => {
+			hostComponent.tableRowActions = {
+				actions: [
+					{
+						id: "edit-item",
+						label: "STARK.ICONS.EDIT_ITEM",
+						icon: "pencil",
+						actionCall: (): void => undefined,
+						isEnabled: true
+					}
+				]
+			};
+			hostFixture.detectChanges();
+			component.ngAfterViewInit();
+
+			const actionsColumnElement = hostFixture.nativeElement.querySelector(actionsColumnSelector);
+			expect(actionsColumnElement).not.toBeNull();
+		});
+
+		it("should NOT display the 'actions' column when 'tableRowActions' input does NOT contain any action", () => {
+			hostComponent.tableRowActions = { actions: [] };
+			hostFixture.detectChanges();
+
+			const actionsColumnElement = hostFixture.nativeElement.querySelector(actionsColumnSelector);
+			expect(actionsColumnElement).toBeNull();
+		});
+
+		it("should NOT display the 'actions' column when 'tableRowActions' input is NOT defined", () => {
+			hostComponent.tableRowActions = undefined;
+			hostFixture.detectChanges();
+
+			const actionsColumnElement = hostFixture.nativeElement.querySelector(actionsColumnSelector);
+			expect(actionsColumnElement).toBeNull();
+		});
+	});
+
 	describe("column visibility", () => {
 		const columns: StarkTableColumnProperties[] = [{ name: "a" }, { name: "b", isVisible: false }, { name: "c", isVisible: true }];
 		const data: any = [{ a: 1, b: "b1", c: "c1" }, { a: 2, b: "b2", c: "c2" }, { a: 3, b: "b3", c: "c3" }];


### PR DESCRIPTION
ISSUES CLOSED: #1462

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If no row actions are defined, the Stark Table component displays the **Actions** column.

Issue Number: #1462 


## What is the new behavior?

If no row actions are defined, the Stark Table component does **not** display the **Actions** column.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information