### PR TITLE
fix(stark-build): fix prettier - Module not found: Error: Can't resolve '@microsoft/typescript-etw'

### DIFF
--- a/packages/stark-build/config/webpack-partial.common.js
+++ b/packages/stark-build/config/webpack-partial.common.js
@@ -72,6 +72,9 @@ module.exports = metadata => {
 		 * See: https://webpack.js.org/configuration/module
 		 */
 		module: {
+			// FIXME Remove the following line once Prettier 2.0.0 is released. See: https://github.com/NationalBankBelgium/stark/issues/1483
+			noParse: /prettier\/parser-typescript/,
+
 			rules: [
 				/**
 				 * TSLint loader support for *.ts files


### PR DESCRIPTION
ISSUES CLOSED: #1483

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Incorrect warning is present in console due to prettier.

Issue Number: #1483


## What is the new behavior?

The warning about `prettier/typescript` is not present anymore.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information