### PR TITLE
fix(build-main): changed expected node version to 10 in gh-deploy script

### DIFF
--- a/gh-deploy.sh
+++ b/gh-deploy.sh
@@ -18,7 +18,7 @@ COMMIT_HASH=`git rev-parse --verify HEAD`
 
 TARGET_REPO="git@github.com:NationalBankBelgium/stark.git"
 EXPECTED_REPO_SLUG="NationalBankBelgium/stark"
-EXPECTED_NODE_VERSION="8"
+EXPECTED_NODE_VERSION="10"
 
 COMMIT_AUTHOR_USERNAME="TravisCI"
 COMMIT_AUTHOR_EMAIL="alexis.georges@nbb.be"
@@ -41,7 +41,7 @@ LATEST_DIR_NAME="latest"
 #touch ${LOGS_DIR}/build-perf.log
 #DRY_RUN=true
 #TRAVIS=true
-#TRAVIS_NODE_VERSION="8"
+#TRAVIS_NODE_VERSION="10"
 #TRAVIS_COMMIT=${COMMIT_HASH}
 #TRAVIS_REPO_SLUG="NationalBankBelgium/stark" # yes we're always on the correct repo
 #ENFORCE_SHOWCASE_VERSION_CHECK=false # allows not have consistency between tag version and showcase version


### PR DESCRIPTION
ISSUES CLOSED: #1485

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The node_version expected by the "gh-deploy.sh" script is **8**.
We forgot to change the expected node version when we removed support for Node 8 in #1447 

Issue Number: #1485 


## What is the new behavior?

The expected node_version is **10**.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information