### PR TITLE
feat(stark-ui): route-search - add support for partial matching

### DIFF
--- a/packages/stark-ui/src/modules/route-search/components/route-search.component.spec.ts
+++ b/packages/stark-ui/src/modules/route-search/components/route-search.component.spec.ts
@@ -208,6 +208,11 @@ describe("RouteSearchComponent", () => {
 				expect(result.length).toBe(2);
 				expect(result[0]).toEqual({ label: "Test 1", targetState: "test1", targetStateParams: undefined });
 				expect(result[1]).toEqual({ label: "Test 2", targetState: "test2", targetStateParams: undefined });
+
+				result = component.filterRouteEntries("st");
+				expect(result.length).toBe(2);
+				expect(result[0]).toEqual({ label: "Test 1", targetState: "test1", targetStateParams: undefined });
+				expect(result[1]).toEqual({ label: "Test 2", targetState: "test2", targetStateParams: undefined });
 			});
 
 			it("should return an empty array if the input is not in the list", () => {

--- a/packages/stark-ui/src/modules/route-search/components/route-search.component.ts
+++ b/packages/stark-ui/src/modules/route-search/components/route-search.component.ts
@@ -124,7 +124,7 @@ export class StarkRouteSearchComponent extends AbstractStarkUiComponent implemen
 				routeEntry.label
 					.toString()
 					.toLowerCase()
-					.indexOf(filterValue) === 0
+					.includes(filterValue)
 		);
 	}
 


### PR DESCRIPTION
ISSUES CLOSED: #1335

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is no support for partial matching in `StarkRouteSearchComponent`.

Issue Number: #1335 


## What is the new behavior?
The route-search component now supports the partial matching.
Typing 'logou' proposes the route 'App Logout'.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information