### PR TITLE
 fix(stark-ui): app-data - fixed issues with detail-slot not displayed correctly on small screens

### DIFF
--- a/packages/stark-ui/src/modules/app-data/app-data.module.ts
+++ b/packages/stark-ui/src/modules/app-data/app-data.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { MatButtonModule } from "@angular/material/button";
 import { MatIconModule } from "@angular/material/icon";
+import { MatMenuModule } from '@angular/material/menu';
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { StarkAppDataComponent } from "./components";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
@@ -13,7 +14,7 @@ import { StarkLocale } from "@nationalbankbelgium/stark-core";
 
 @NgModule({
 	declarations: [StarkAppDataComponent],
-	imports: [CommonModule, MatButtonModule, MatIconModule, MatTooltipModule, TranslateModule],
+	imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule, TranslateModule],
 	exports: [StarkAppDataComponent]
 })
 export class StarkAppDataModule {

--- a/packages/stark-ui/src/modules/app-data/components/_app-data-theme.scss
+++ b/packages/stark-ui/src/modules/app-data/components/_app-data-theme.scss
@@ -17,34 +17,31 @@
 /* ------------------------------------------------ */
 /*             app data "dropdown" mode             */
 /* ------------------------------------------------ */
-.stark-app-data.dropdown {
-  & .stark-app-data-summary {
-    padding-top: 4px;
+.stark-app-data {
+  &.dropdown {
+    & .stark-app-data-summary {
+      padding-top: 4px;
 
-    & .label {
-      color: $primary-light-text-color;
+      & .label {
+        color: $primary-light-text-color;
+      }
+
+      & .value {
+        color: #fff;
+      }
     }
-
-    & .value {
-      color: #fff;
-    }
-  }
-
-  & .stark-app-data-detail {
-    background-color: #fff;
-    color: #000;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
   }
 }
 
 /* ------------------------------------------------ */
-/*               app data "menu" mode               */
+/*              app data "detail" slot              */
 /* ------------------------------------------------ */
-.stark-app-data.menu {
+.stark-app-data.mat-menu-panel {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+
   & .stark-app-data-detail {
     background-color: #fff;
     color: #000;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
   }
 }
 

--- a/packages/stark-ui/src/modules/app-data/components/_app-data.component.scss
+++ b/packages/stark-ui/src/modules/app-data/components/_app-data.component.scss
@@ -22,54 +22,42 @@
 /* ------------------------------------------------ */
 /*             app data "dropdown" mode             */
 /* ------------------------------------------------ */
-.stark-app-data.dropdown {
-  position: relative;
-  display: flex;
-  width: 250px;
-  margin-right: 10px;
-  line-height: 1.2;
-  border-radius: 20px;
-  padding: 2px 0 2px 20px;
-
-  & .stark-app-data-summary {
-    padding-top: 4px;
+.stark-app-data {
+  &.dropdown {
+    position: relative;
+    display: flex;
     width: 250px;
+    margin-right: 10px;
+    line-height: 1.2;
+    border-radius: 20px;
+    padding: 2px 0 2px 20px;
+
+    & .stark-app-data-summary {
+      padding-top: 4px;
+      width: 250px;
+    }
+
+    & svg {
+      transition: transform 0.4s;
+    }
+
+    & .is-open svg {
+      transform: rotate(180deg);
+    }
   }
 
-  & svg {
-    transition: transform 0.4s;
-  }
-
-  & .is-open svg {
-    transform: rotate(180deg);
-  }
-
-  & .stark-app-data-detail {
-    position: absolute;
-    top: 100%;
-    width: 250px;
-    right: 0;
-    left: 0;
-    padding: 10px;
-    line-height: 1.5;
-    border-radius: 5px;
-    z-index: 100;
+  &.dropdown-detail {
+    width: 270px;
   }
 }
 
 /* ------------------------------------------------ */
-/*               app data "menu" mode               */
+/*              app data "detail" slot              */
 /* ------------------------------------------------ */
-.stark-app-data.menu {
-  display: block;
-
+.stark-app-data.mat-menu-panel {
   & .stark-app-data-detail {
-    position: absolute;
-    width: 200px;
-    padding: 10px;
+    padding: 2px 10px;
     line-height: 1.5;
-    border-radius: 5px;
-    z-index: 100;
 
     & .label {
       font-weight: 500;

--- a/packages/stark-ui/src/modules/app-data/components/app-data.component.html
+++ b/packages/stark-ui/src/modules/app-data/components/app-data.component.html
@@ -1,7 +1,9 @@
 <!-- the projected detail content should be put in an ng-template so that it can be rendered multiple times in this template -->
 <!-- solution taken from https://github.com/angular/angular/issues/22972#issuecomment-407358396 -->
 <ng-template #appDataDetail>
-	<ng-content select=".detail-slot"></ng-content>
+	<div class="stark-app-data-detail" (click)="$event.stopPropagation()">
+		<ng-content select=".detail-slot"></ng-content>
+	</div>
 </ng-template>
 
 <div *ngIf="mode === 'dropdown'" class="stark-app-data dropdown">
@@ -9,25 +11,36 @@
 		<ng-content select=".summary-slot"></ng-content>
 	</div>
 
-	<button mat-icon-button aria-label="Application Data" (click)="toggleDetail()" [ngClass]="{ 'is-open': !isDetailHidden }" mat-button>
+	<button
+		mat-icon-button
+		aria-label="Application Data"
+		#dropdownDetailTrigger="matMenuTrigger"
+		[matMenuTriggerFor]="dropdownDetail"
+		[class.is-open]="dropdownDetailTrigger.menuOpen"
+		mat-button
+	>
 		<mat-icon svgIcon="menu-down"></mat-icon>
 	</button>
-	<div class="stark-app-data-detail stark-fade-animation" *ngIf="!isDetailHidden">
-		<ng-container *ngTemplateOutlet="appDataDetail"></ng-container>
-	</div>
+	<mat-menu #dropdownDetail="matMenu" xPosition="before" yPosition="below" class="stark-app-data dropdown-detail">
+		<ng-template matMenuContent>
+			<ng-container *ngTemplateOutlet="appDataDetail"></ng-container>
+		</ng-template>
+	</mat-menu>
 </div>
 
 <div *ngIf="mode === 'menu'" class="stark-app-data menu">
 	<button
+		mat-button
 		mat-icon-button
 		aria-label="Application Data"
-		(click)="toggleDetail()"
-		mat-button
+		[matMenuTriggerFor]="menuDetail"
 		[matTooltip]="'STARK.ICONS.APP_DATA' | translate"
 	>
 		<mat-icon svgIcon="dots-vertical"></mat-icon>
 	</button>
-	<div class="stark-app-data-detail animate-show-hide" *ngIf="!isDetailHidden">
-		<ng-container *ngTemplateOutlet="appDataDetail"></ng-container>
-	</div>
+	<mat-menu #menuDetail="matMenu" yPosition="below" class="stark-app-data menu-detail">
+		<ng-template matMenuContent>
+			<ng-container *ngTemplateOutlet="appDataDetail"></ng-container>
+		</ng-template>
+	</mat-menu>
 </div>

--- a/packages/stark-ui/src/modules/app-data/components/app-data.component.spec.ts
+++ b/packages/stark-ui/src/modules/app-data/components/app-data.component.spec.ts
@@ -1,7 +1,7 @@
-/* tslint:disable:completed-docs no-life-cycle-call */
-import { StarkAppDataComponent } from "./app-data.component";
+/* tslint:disable:completed-docs max-inline-declarations no-life-cycle-call */
+import { StarkAppDataComponent, StarkAppDataComponentMode } from "./app-data.component";
 import { STARK_LOGGING_SERVICE } from "@nationalbankbelgium/stark-core";
-import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { async, fakeAsync, inject, tick, ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatButtonModule } from "@angular/material/button";
 import { MatIconModule } from "@angular/material/icon";
 import { MatMenuModule } from "@angular/material/menu";
@@ -9,35 +9,85 @@ import { CommonModule } from "@angular/common";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { MockStarkLoggingService } from "@nationalbankbelgium/stark-core/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { HAMMER_LOADER } from "@angular/platform-browser";
+import { Subject } from "rxjs";
+import { ViewChild, Component, NO_ERRORS_SCHEMA } from "@angular/core";
+import { OverlayContainer } from "@angular/cdk/overlay";
+
+@Component({
+	selector: `host-component`,
+	template: `
+		<stark-app-data [mode]="mode">
+			<div class="summary-slot">This is the summary</div>
+			<div class="detail-slot">This is the detail</div>
+		</stark-app-data>
+	`
+})
+class TestHostComponent {
+	@ViewChild(StarkAppDataComponent)
+	public appDataComponent!: StarkAppDataComponent;
+	public mode?: StarkAppDataComponentMode;
+}
 
 // tslint:disable:no-big-function no-identical-functions
 describe("AppDataComponent", () => {
 	let component: StarkAppDataComponent;
-	let fixture: ComponentFixture<StarkAppDataComponent>;
+	let hostComponent: TestHostComponent;
+	let hostFixture: ComponentFixture<TestHostComponent>;
+
+	// Rendered menu context
+	let overlayContainer: OverlayContainer;
+	let overlayContainerElement: HTMLElement;
+
+	const detailSlotContent = "This is the detail";
+	const summarySlotContent = "This is the summary";
 
 	const mockLogger: MockStarkLoggingService = new MockStarkLoggingService();
 
 	beforeEach(async(() => {
 		return TestBed.configureTestingModule({
-			declarations: [StarkAppDataComponent],
-			imports: [CommonModule, MatButtonModule, MatIconModule, MatMenuModule, MatTooltipModule, TranslateModule.forRoot()],
-			providers: [{ provide: STARK_LOGGING_SERVICE, useValue: mockLogger }, TranslateService]
+			declarations: [StarkAppDataComponent, TestHostComponent],
+			imports: [
+				CommonModule,
+				MatButtonModule,
+				MatIconModule,
+				MatMenuModule,
+				MatTooltipModule,
+				NoopAnimationsModule,
+				TranslateModule.forRoot()
+			],
+			providers: [
+				{ provide: STARK_LOGGING_SERVICE, useValue: mockLogger },
+				{
+					// See https://github.com/NationalBankBelgium/stark/issues/1088
+					provide: HAMMER_LOADER,
+					useValue: (): Promise<any> => new Subject<any>().toPromise()
+				},
+				TranslateService
+			],
+			schemas: [NO_ERRORS_SCHEMA] // tells the Angular compiler to ignore unrecognized elements and attributes (svgIcon)
 		}).compileComponents();
 	}));
 
 	beforeEach(() => {
-		fixture = TestBed.createComponent(StarkAppDataComponent);
-		component = fixture.componentInstance;
+		// OverlayContainer needs to be injected to get the context for the rendered menu dropdown
+		inject([OverlayContainer], (oc: OverlayContainer) => {
+			overlayContainer = oc;
+			overlayContainerElement = overlayContainer.getContainerElement();
+		})();
 
-		spyOn(component, "removeWindowClickHandler").and.callThrough();
-		spyOn(component, "attachWindowClickHandler").and.callThrough();
-		spyOn(window, "addEventListener").and.callThrough();
-		spyOn(window, "removeEventListener").and.callThrough();
+		hostFixture = TestBed.createComponent(TestHostComponent);
+		hostComponent = hostFixture.componentInstance;
+		hostFixture.detectChanges();
+
+		component = hostComponent.appDataComponent;
 	});
 
 	describe("on initialization", () => {
 		it("should set internal component properties", () => {
-			expect(fixture).toBeDefined();
+			expect(hostFixture).toBeDefined();
+			expect(hostComponent).toBeDefined();
 			expect(component).toBeDefined();
 
 			expect(component.logger).not.toBeNull();
@@ -45,70 +95,118 @@ describe("AppDataComponent", () => {
 		});
 	});
 
-	describe("OnInit", () => {
-		it("OnInit", () => {
-			component.ngOnInit();
+	describe("using 'dropdown' mode", () => {
+		// Prepare hostComponent
+		beforeEach(() => {
+			hostComponent.mode = "dropdown";
+			hostFixture.detectChanges();
+		});
 
-			expect(component.isDetailHidden).toBe(true);
+		describe("summary", () => {
+			it("should display the summary content", () => {
+				const summary: HTMLElement = hostFixture.nativeElement.querySelector(".stark-app-data-summary");
+				expect(summary).toBeDefined();
+				expect(summary.innerText).toContain(summarySlotContent);
+			});
+		});
+
+		describe("detail", () => {
+			it("detail information should NOT be displayed on init", () => {
+				expect(overlayContainerElement.textContent).toBe("");
+			});
+
+			describe("open detail", () => {
+				beforeEach(() => {
+					// Open Detail
+					const button: HTMLButtonElement = hostFixture.nativeElement.querySelector(".stark-app-data.dropdown button");
+					button.click();
+					hostFixture.detectChanges();
+				});
+
+				it("clicking button should display detail information", () => {
+					expect(overlayContainerElement.textContent).toBe(detailSlotContent);
+					const matPanelElement = <HTMLElement>overlayContainerElement.querySelector(".mat-menu-panel");
+					expect(matPanelElement.classList).toContain("stark-app-data");
+					expect(matPanelElement.classList).toContain("dropdown-detail");
+				});
+
+				it("clicking outside the mat-menu-panel should close the detail", fakeAsync(() => {
+					const backdrop = <HTMLElement>overlayContainerElement.querySelector(".cdk-overlay-backdrop");
+					backdrop.click();
+					hostFixture.detectChanges();
+					tick(500);
+
+					expect(overlayContainerElement.textContent).toBe("");
+				}));
+
+				it("clicking inside the mat-menu-panel should NOT close the detail", fakeAsync(() => {
+					const detail = <HTMLElement>overlayContainerElement.querySelector(".stark-app-data-detail");
+					expect(detail).not.toBeNull();
+					detail.click();
+					hostFixture.detectChanges();
+					tick(500);
+
+					expect(overlayContainerElement.textContent).toBe(detailSlotContent);
+				}));
+			});
 		});
 	});
 
-	describe("ToggleDetail", () => {
-		it("should toggle the isDetailHidden boolean property in dropdown mode.", () => {
-			component.mode = "dropdown";
-
-			expect(component.isDetailHidden).toBe(true);
-			component.toggleDetail();
-			expect(component.isDetailHidden).toBe(false);
-			component.toggleDetail();
-			expect(component.isDetailHidden).toBe(true);
+	describe("using 'menu' mode", () => {
+		// Prepare hostComponent
+		beforeEach(() => {
+			hostComponent.mode = "menu";
+			hostFixture.detectChanges();
 		});
 
-		it("should toggle the isDetailHidden boolean property in menu mode.", () => {
-			component.mode = "menu";
-			expect(component.isDetailHidden).toBe(true);
-			component.toggleDetail();
-			expect(component.isDetailHidden).toBe(false);
-			component.toggleDetail();
-			expect(component.isDetailHidden).toBe(true);
+		describe("summary", () => {
+			it("should NOT display the summary content", () => {
+				const summary: HTMLElement | null = hostFixture.nativeElement.querySelector(".stark-app-data-summary");
+				expect(summary).toBeNull();
+			});
 		});
 
-		it("should toggle the isDetailHidden boolean property in default mode.", () => {
-			component.mode = undefined;
-			expect(component.isDetailHidden).toBe(true);
-			component.toggleDetail();
-			expect(component.isDetailHidden).toBe(false);
-			component.toggleDetail();
-			expect(component.isDetailHidden).toBe(true);
-		});
-	});
+		describe("detail", () => {
+			it("detail information should NOT be displayed on init", () => {
+				expect(overlayContainerElement.textContent).toBe("");
+			});
 
-	describe("ngOnDestroy", () => {
-		it("should call windowClickHandlerMethod", () => {
-			component.ngOnDestroy();
-			expect(component.removeWindowClickHandler).toHaveBeenCalledTimes(1);
-		});
-	});
+			describe("open detail", () => {
+				beforeEach(() => {
+					// Open Detail
+					const button: HTMLButtonElement = hostFixture.nativeElement.querySelector(".stark-app-data.menu button");
+					button.click();
+					hostFixture.detectChanges();
+				});
 
-	describe("attachWindowClickHandler", () => {
-		it("should add a clickHandler event to the windows", () => {
-			component.attachWindowClickHandler();
-			expect(window.addEventListener).toHaveBeenCalledTimes(1);
-		});
-	});
+				it("clicking button should display detail information", () => {
+					expect(overlayContainerElement.textContent).toBe(detailSlotContent);
+					const matPanelElement = <HTMLElement>overlayContainerElement.querySelector(".mat-menu-panel");
+					expect(matPanelElement.classList).toContain("stark-app-data");
+					expect(matPanelElement.classList).toContain("menu-detail");
+				});
 
-	describe("removeWindowClickHandler", () => {
-		it("should remove the clickHandler event from the windows if the clickHandler has been defined", () => {
-			component.attachWindowClickHandler();
-			component.removeWindowClickHandler();
-			expect(window.removeEventListener).toHaveBeenCalledTimes(1);
-			expect(component.windowClickHandler).toBeUndefined();
-		});
+				it("clicking outside the mat-menu-panel should close the detail", fakeAsync(() => {
+					const backdrop = <HTMLElement>overlayContainerElement.querySelector(".cdk-overlay-backdrop");
+					backdrop.click();
+					hostFixture.detectChanges();
+					tick(500);
 
-		it("should not remove the clickHandler event from the windows if the clickHandler has not been defined", () => {
-			component.windowClickHandler = undefined;
-			component.removeWindowClickHandler();
-			expect(window.removeEventListener).not.toHaveBeenCalled();
+					expect(overlayContainerElement.textContent).toBe("");
+				}));
+
+				it("clicking inside the mat-menu-panel should NOT close the detail", fakeAsync(() => {
+					expect(overlayContainerElement.textContent).toBe(detailSlotContent);
+
+					const detail = <HTMLElement>overlayContainerElement.querySelector(".stark-app-data-detail");
+					expect(detail).not.toBeNull();
+					detail.click();
+					hostFixture.detectChanges();
+					tick(500);
+
+					expect(overlayContainerElement.textContent).toBe(detailSlotContent);
+				}));
+			});
 		});
 	});
 });

--- a/packages/stark-ui/src/modules/app-data/components/app-data.component.ts
+++ b/packages/stark-ui/src/modules/app-data/components/app-data.component.ts
@@ -1,16 +1,5 @@
-import {
-	ChangeDetectionStrategy,
-	Component,
-	ElementRef,
-	Inject,
-	Input,
-	OnDestroy,
-	OnInit,
-	Renderer2,
-	ViewEncapsulation
-} from "@angular/core";
+import { ChangeDetectionStrategy, Component, ElementRef, Inject, Input, OnInit, Renderer2, ViewEncapsulation } from "@angular/core";
 import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
-import { StarkDOMUtil } from "../../../util/dom";
 import { AbstractStarkUiComponent } from "../../../common/classes/abstract-component";
 
 /**
@@ -35,15 +24,12 @@ export type StarkAppDataComponentMode = "dropdown" | "menu";
 		class: componentName
 	}
 })
-export class StarkAppDataComponent extends AbstractStarkUiComponent implements OnInit, OnDestroy {
+export class StarkAppDataComponent extends AbstractStarkUiComponent implements OnInit {
 	/**
 	 * The mode in which the component should be displayed.
+	 * Default: "dropdown"
 	 */
 	@Input() public mode?: StarkAppDataComponentMode = "dropdown";
-
-	public isDetailHidden = true;
-
-	public windowClickHandler?: EventListener;
 
 	public constructor(
 		@Inject(STARK_LOGGING_SERVICE) public logger: StarkLoggingService,
@@ -58,59 +44,5 @@ export class StarkAppDataComponent extends AbstractStarkUiComponent implements O
 	 */
 	public ngOnInit(): void {
 		this.logger.debug(componentName + ": controller initialized");
-
-		this.isDetailHidden = true;
-	}
-
-	/**
-	 * Component lifecycle hook
-	 */
-	public ngOnDestroy(): void {
-		this.removeWindowClickHandler();
-	}
-
-	/**
-	 * Manage the fact that the detail are shown or hidden.
-	 */
-	public toggleDetail(): void {
-		this.isDetailHidden = !this.isDetailHidden;
-
-		if (this.isDetailHidden) {
-			this.removeWindowClickHandler();
-		} else {
-			this.attachWindowClickHandler();
-		}
-	}
-
-	/**
-	 * Method use to attach a click handler to the window
-	 */
-	public attachWindowClickHandler(): void {
-		this.windowClickHandler = (event: Event): void => {
-			if (this.isDetailHidden) {
-				return;
-			}
-
-			const parentElement: Element | undefined = StarkDOMUtil.searchParentElementByClass(<Element>event.target, componentName);
-			if (parentElement) {
-				return;
-			}
-
-			this.toggleDetail();
-		};
-
-		window.addEventListener("click", this.windowClickHandler);
-		this.logger.debug(componentName + ": clickHandler added");
-	}
-
-	/**
-	 * Method to remove a click handler from the windows
-	 */
-	public removeWindowClickHandler(): void {
-		if (this.windowClickHandler) {
-			this.logger.debug(componentName + ": clickHandler removed");
-			window.removeEventListener("click", this.windowClickHandler);
-			this.windowClickHandler = undefined;
-		}
 	}
 }


### PR DESCRIPTION
rewrite component to use mat-menu instead of custom implementation

ISSUES CLOSED: #1555

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1555 


## What is the new behavior?

Issues with the detail-slot have been resolved thanks to a rewrite of the app-data component.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

~For an unknown reason, in DEV mode, when clicking multiple times quickly on the arrow button to open the detail, the following error is triggered:~

```
Error: ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked. Previous value: 'is-open: true'. Current value: 'is-open: false'.
```

~If building the project with `npm run build:prod` and serving the files with `npm run server:prod`, the issue does not happen. If anyone has an idea how to solve this, it would be great :blush:~

**EDIT:** After looking into this, I found a way to make it work all the time. 
Now I use the ng-template as proposed here: https://material.angular.io/components/menu/overview#lazy-rendering

```html
<mat-menu>
	<ng-template matMenuContent>
		<div class="stark-app-data-detail" (click)="$event.stopPropagation()">
			<ng-container *ngTemplateOutlet="appDataDetail"></ng-container>
		</div>
	</ng-template>
</mat-menu>
```