### PR TITLE
fix(stark-ui): app-sidebar - header is now visible on iOS devices (iTouch, iPhone, iPad)

### DIFF
--- a/packages/stark-ui/src/modules/app-sidebar/components/_app-sidebar.component.scss
+++ b/packages/stark-ui/src/modules/app-sidebar/components/_app-sidebar.component.scss
@@ -50,12 +50,24 @@
 }
 
 .stark-app-sidebar .mat-sidenav-content {
-  margin-top: $stark-header-size;
+  &:not(.stark-ios-device) {
+    margin-top: $stark-header-size;
+  }
+
+  &.stark-ios-device .stark-main-container {
+    margin-top: $stark-header-size;
+  }
 }
 
 @media #{$tablet-screen-query} {
   .stark-app-sidebar .mat-sidenav-content {
-    margin-top: $stark-header-size-desktop;
+    &:not(.stark-ios-device) {
+      margin-top: $stark-header-size-desktop;
+    }
+
+    &.stark-ios-device .stark-main-container {
+      margin-top: $stark-header-size-desktop;
+    }
   }
 }
 

--- a/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.html
+++ b/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.html
@@ -22,7 +22,7 @@
 	<mat-sidenav #appSidenavRight class="stark-app-sidenav-right" mode="over" position="end" [fixedInViewport]="true" [fixedBottomGap]="0">
 		<ng-content select="[stark-app-sidenav-right]"></ng-content>
 	</mat-sidenav>
-	<mat-sidenav-content>
+	<mat-sidenav-content [class.stark-ios-device]="isiOSDevice">
 		<ng-content select="[stark-app-sidenav-content]"></ng-content>
 	</mat-sidenav-content>
 </mat-sidenav-container>

--- a/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.ts
+++ b/packages/stark-ui/src/modules/app-sidebar/components/app-sidebar.component.ts
@@ -101,6 +101,11 @@ export class StarkAppSidebarComponent extends AbstractStarkUiComponent implement
 	public toggleSidebarSubscription!: Subscription;
 
 	/**
+	 * Either the browser is running on iOS or not
+	 */
+	public isiOSDevice = false;
+
+	/**
 	 * Function to deregister the routing transition hook
 	 */
 	public deregisterTransitionHook!: Function;
@@ -153,6 +158,9 @@ export class StarkAppSidebarComponent extends AbstractStarkUiComponent implement
 		this.deregisterTransitionHook = this.routingService.addTransitionHook(StarkRoutingTransitionHook.ON_SUCCESS, {}, () => {
 			this.onSuccessfulTransition();
 		});
+
+		// Detection method documented here: https://stackoverflow.com/questions/9038625/detect-if-device-is-ios#answer-9039885
+		this.isiOSDevice = !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
 	}
 
 	/**


### PR DESCRIPTION
ISSUES CLOSED: #1338

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The header is not displayed on iOS devices (iTouch, iPhone, iPad). 

Issue Number: #1338 

## What is the new behavior?

Adding a new class `stark-ios-device` on `<mat-sidenav-content>` when the device is running on iOS.

Using this class, we remove the fact that the scrollbar which is displayed below the header like here:
![image](https://user-images.githubusercontent.com/10333565/73461123-e4fb4e00-4379-11ea-8069-918394b45e9f.png)

Thanks to that the header is displayed correctly on iOS devices. 
Unfortunately the scrollbar takes all the screen and if the user scrolls to the bottom, it makes the header disappearing. It's better than before but not perfect.

![image](https://user-images.githubusercontent.com/10333565/73461598-53d4a900-4372-11ea-8d9f-01839addc31a.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information