### PR TITLE
fix(stark-ui): session - prevent click outside the Session Timeout Warning Dialog

### DIFF
--- a/packages/stark-ui/src/modules/session-ui/effects/session-timeout-warning.effect.spec.ts
+++ b/packages/stark-ui/src/modules/session-ui/effects/session-timeout-warning.effect.spec.ts
@@ -90,7 +90,7 @@ describe("Effects: StarkSessionTimeoutWarningDialogEffects", () => {
 			expect(mockObserver.error).not.toHaveBeenCalled();
 			expect(mockObserver.complete).not.toHaveBeenCalled();
 			expect(mockDialogService.open).toHaveBeenCalledTimes(1);
-			expect(mockDialogService.open).toHaveBeenCalledWith(StarkSessionTimeoutWarningDialogComponent, { data: 20 });
+			expect(mockDialogService.open).toHaveBeenCalledWith(StarkSessionTimeoutWarningDialogComponent, { data: 20, disableClose: true });
 
 			expect(mockSessionService.resumeUserActivityTracking).not.toHaveBeenCalled();
 

--- a/packages/stark-ui/src/modules/session-ui/effects/session-timeout-warning.effects.ts
+++ b/packages/stark-ui/src/modules/session-ui/effects/session-timeout-warning.effects.ts
@@ -39,7 +39,10 @@ export class StarkSessionTimeoutWarningDialogEffects implements OnRunEffects {
 			map((action: StarkSessionTimeoutCountdownStart) => {
 				this.sessionService.pauseUserActivityTracking();
 				this.dialogService
-					.open<StarkSessionTimeoutWarningDialogComponent>(StarkSessionTimeoutWarningDialogComponent, { data: action.countdown })
+					.open<StarkSessionTimeoutWarningDialogComponent>(StarkSessionTimeoutWarningDialogComponent, {
+						data: action.countdown,
+						disableClose: true
+					})
 					.afterClosed()
 					.subscribe((result: string) => {
 						if (result && result === "keep-logged") {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the Session Timeout Warning Dialog appears, clicking outside the dialog hides the dialog but does not stop the countdown. So the user is disconnected automatically at the end of the countdown. 

Issue Number: #1561 


## What is the new behavior?

Clicking outside of the dialog does not do anything. Like this, the user cannot close the dialog due to a wrong manipulation.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information