### PR TITLE
fix(stark-ui): enhance styling of date time picker component to display the 'clear' button correctly aligned in IE 11

### DIFF
--- a/packages/stark-ui/src/modules/date-time-picker/components/date-time-picker.component.html
+++ b/packages/stark-ui/src/modules/date-time-picker/components/date-time-picker.component.html
@@ -11,21 +11,23 @@
 		[min]="min"
 	></stark-date-picker>
 
-	<input
-		matInput
-		#timeInput
-		id="{{ pickerId + '-time-input' }}"
-		name="{{ pickerName + '-time-input' }}"
-		class="time-input"
-		formControlName="time"
-		(change)="onDateTimeChange()"
-		[starkTimestampMask]="timeMask"
-		[required]="required"
-	/>
-	<div class="mat-form-field-suffix mat-datepicker-toggle">
-		<button mat-icon-button (click)="focusTimeInput($event)" [disabled]="disabled">
-			<mat-icon svgIcon="clock"></mat-icon>
-		</button>
+	<div class="time-picker">
+		<input
+			matInput
+			#timeInput
+			id="{{ pickerId + '-time-input' }}"
+			name="{{ pickerName + '-time-input' }}"
+			class="time-input"
+			formControlName="time"
+			(change)="onDateTimeChange()"
+			[starkTimestampMask]="timeMask"
+			[required]="required"
+		/>
+		<div class="mat-form-field-suffix mat-datepicker-toggle">
+			<button mat-icon-button (click)="focusTimeInput($event)" [disabled]="disabled">
+				<mat-icon svgIcon="clock"></mat-icon>
+			</button>
+		</div>
 	</div>
 </div>
 

--- a/packages/stark-ui/src/modules/date-time-picker/components/date-time-picker.component.scss
+++ b/packages/stark-ui/src/modules/date-time-picker/components/date-time-picker.component.scss
@@ -21,9 +21,13 @@
     }
 
     /* Time */
-    > .time-input {
-      flex: 1;
-      max-width: 60px;
+    > .time-picker {
+      display: inline-flex;
+      justify-content: space-around;
+      
+      .time-input {
+        max-width: 60px;
+      }
     }
   }
 
@@ -42,7 +46,7 @@
     width: 20px;
     line-height: 20px;
     position: absolute;
-    margin-left: 280px; /* should be the same width of the 'stark-date-time-picker-form-field-wrapper' (see above) */
+    right: -20px; /* to render it to the right of the date-time-wrapper */
 
     &.hidden {
       display: none;

--- a/packages/stark-ui/src/modules/date-time-picker/components/date-time-picker.component.spec.ts
+++ b/packages/stark-ui/src/modules/date-time-picker/components/date-time-picker.component.spec.ts
@@ -185,7 +185,7 @@ describe("DateTimePickerComponent", () => {
 			formFieldDebugElement = hostFixture.debugElement.query(By.directive(MatFormField));
 			expect(formFieldDebugElement.classes[formFieldInvalidClass]).toBe(false);
 
-			const timeInputDebugElement = hostFixture.debugElement.query(By.css(".date-time-wrapper > input"));
+			const timeInputDebugElement = hostFixture.debugElement.query(By.css(".time-picker > input"));
 			expect(timeInputDebugElement).toBeTruthy();
 			// more verbose way to create and trigger an event (the only way it works in IE)
 			// https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events


### PR DESCRIPTION
ISSUES CLOSED: #1430

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1430 


## What is the new behavior?
The "clear' button (X) is now be placed correctly to the right next to the date time picker field also in Internet Explorer 11 (apart from all major browsers: Chrome, Edge and Firefox):

![date-time-picker-clear-button-ok](https://user-images.githubusercontent.com/5698318/74084765-a13bcf00-4a72-11ea-833c-2348a019cb7c.PNG)


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->