### PR TITLE
ci(showcase): fix BrowserStack randomly failing test by adding a `localIdentifier`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,4 +154,4 @@ We're supported by [Travis](https://travis-ci.org/)
 
 We're supported by [BrowserStack](https://www.browserstack.com)
 
-<a href="https://www.browserstack.com"><img src="https://bstacksupport.zendesk.com/attachments/token/22M109zCUfkKcqXrJKzapE2f7/?name=browserstack-logo-600x315.png" width="144px"></a>
+<a href="https://www.browserstack.com"><img src="http://www.browserstack.com/images/layout/browserstack-logo-600x315.png" width="144px"></a>

--- a/showcase/e2e/protractor.browserstack.conf.js
+++ b/showcase/e2e/protractor.browserstack.conf.js
@@ -2,6 +2,8 @@ const browserstack = require("browserstack-local");
 const { BROWSERSTACK_USERNAME, BROWSERSTACK_ACCESS_KEY, TRAVIS_BUILD_NUMBER } = process.env;
 const defaultConfig = require("../node_modules/@nationalbankbelgium/stark-testing/protractor.conf.js").config;
 
+const BROWSERSTACK_LOCAL_IDENTIFIER = TRAVIS_BUILD_NUMBER ? `travis-${TRAVIS_BUILD_NUMBER}` : "local";
+
 /**
  * Specifies the different capabilities for BrowserStack.
  * Here you can configure what OS / Browser you want to run your tests on.
@@ -70,7 +72,9 @@ const beforeLaunch = async () => {
 
 	exports.bs_local = new browserstack.Local();
 	await new Promise((resolve, reject) =>
-		exports.bs_local.start({ key: BROWSERSTACK_ACCESS_KEY }, error => (error ? reject(error) : resolve()))
+		exports.bs_local.start({ key: BROWSERSTACK_ACCESS_KEY, localIdentifier: BROWSERSTACK_LOCAL_IDENTIFIER }, error =>
+			error ? reject(error) : resolve()
+		)
 	);
 
 	console.log("BrowserStack local is connected. Starting tests...");
@@ -114,9 +118,10 @@ const config = {
 		"browserstack.debug": "true",
 		"browserstack.console": "errors",
 		"browserstack.networkLogs": "true",
+		"browserstack.localIdentifier": BROWSERSTACK_LOCAL_IDENTIFIER,
 
 		project: "Stark Showcase",
-		build: TRAVIS_BUILD_NUMBER ? `travis ${TRAVIS_BUILD_NUMBER}` : "local"
+		build: BROWSERSTACK_LOCAL_IDENTIFIER
 	},
 
 	/**


### PR DESCRIPTION
Received support from BrowserStack and applied their sample config:
https://gist.github.com/HeenaNanwaniGit/52fe377a355077be653e056508d0b271

Added a `localIdentifier` in the `commonCapabilities` and in the options passed to
the `bs_local.start` function in protrator.browserstack configuration.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Sometimes, tests are failing because of an issue with the tests executed in BrowserStack. It happens randomly.

Issue Number: N/A


## What is the new behavior?

I contacted the support of BrowserStack and they propose we add a `localIdentifier` in our configuration to potentially fix the issue we have.

excerpt from the email received: 
```text
On review of the shared script, I see that on line number 73 binary is started without local identifier:
​
​exports.bs_local.start({ key: BROWSERSTACK_ACCESS_KEY }, error => (error ? reject(error) : resolve()))

Could you add a local identifier as mentioned in the below code snippet?

exports.bs_local.start({'key': exports.config['browserstackKey'], 'localIdentifier': 'abc' }, function(error)
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Thanks to the BrowserStack team for the great support they provided! :+1: 