### PR TITLE
feat(stark-ui): add the possibility to custom the rendering of a cell in tables

### DIFF
--- a/packages/stark-ui/src/modules/table/components/column.component.html
+++ b/packages/stark-ui/src/modules/table/components/column.component.html
@@ -36,7 +36,10 @@
 	<!-- and it will receive the right context containing the displayedValue and the row data-->
 	<td mat-cell *matCellDef="let rowItem" [ngClass]="getCellClassNames(rowItem)" (click)="onCellClick($event, rowItem)">
 		<ng-container
-			*ngTemplateOutlet="columnTemplate; context: { $implicit: { rowData: rowItem, displayedValue: getDisplayedValue(rowItem) } }"
+			*ngTemplateOutlet="
+				columnTemplate;
+				context: { $implicit: { rowData: rowItem, rawValue: getRawValue(rowItem), displayedValue: getDisplayedValue(rowItem) } }
+			"
 		></ng-container>
 	</td>
 	<ng-container *ngIf="footerValue !== 'undefined'">

--- a/packages/stark-ui/src/modules/table/components/table.component.html
+++ b/packages/stark-ui/src/modules/table/components/table.component.html
@@ -129,7 +129,18 @@
 			[headerClassName]="col.headerClassName"
 		>
 			<ng-template let-context>
-				<span>{{ context.displayedValue }}</span>
+				<ng-container
+					*ngTemplateOutlet="
+						customRowTemplate;
+						context: {
+							$implicit: context.rowData,
+							rowData: context.rowData,
+							rawValue: context.rawValue,
+							displayedValue: context.displayedValue
+						}
+					"
+				></ng-container>
+				<span *ngIf="!customRowTemplate">{{ context.displayedValue }}</span>
 			</ng-template>
 		</stark-table-column>
 

--- a/packages/stark-ui/src/modules/table/components/table.component.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.ts
@@ -50,6 +50,7 @@ import find from "lodash-es/find";
 import findIndex from "lodash-es/findIndex";
 import { trigger, state, style, transition, animate } from "@angular/animations";
 import { StarkTableExpandDetailDirective } from "../directives/table-expand-detail.directive"
+import { StarkTableRowContentDirective } from "../directives/table-row-content.directive";
 
 /**
  * Name of the component
@@ -422,6 +423,9 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 
 	@ContentChild(StarkTableExpandDetailDirective, { read: TemplateRef })
 	public expandedDetailTemplate!: StarkTableExpandDetailDirective;
+	
+	@ContentChild(StarkTableRowContentDirective, { read: TemplateRef })
+	public customRowTemplate!: StarkTableRowContentDirective;
 
 	/**
 	 * Array of StarkTableColumnComponents defined in this table

--- a/packages/stark-ui/src/modules/table/directives/table-row-content.directive.ts
+++ b/packages/stark-ui/src/modules/table/directives/table-row-content.directive.ts
@@ -1,0 +1,33 @@
+import { Directive, TemplateRef } from "@angular/core";
+
+/**
+ * This directive can be used inside <stark-table> if you want to customize the render of the table's cells
+ * A set of variables are available and therefore can be used to get the proper result :
+ * - rowData : an array that contains information about a data row
+ * - cellRawValue : the value of the cell unformatted
+ * - cellDisplayedValue : the formatted value of the cell
+ *
+ * @example
+ * <stark-table>
+ *     <ng-container [ngSwitch]="true" *starkTableRowContent="let rowData = rowData; let cellRawValue = rawValue; let cellDisplayedValue = displayedValue">
+ *          <!-- anycode you want to use to display table's cells -->
+ *
+ *          <!-- ie: if you want to add an icon under certain circomstances -->
+ *          <div *ngSwitchCase="rowData.id === 1">
+ *             <span style="color: blue">{{ cellDisplayedValue }}</span>
+ *          </div>
+ *          <div *ngSwitchCase="cellRawValue > 23">
+ *             <mat-icon class="mat-icon-rtl-mirror" svgIcon="thumb-up"></mat-icon> {{ cellDisplayedValue }}
+ *          </div>
+ *          <div *ngSwitchDefault>{{ cellDisplayedValue }}</div>
+ *     </ng-container>
+ * </stark-table>
+ */
+@Directive({
+	selector: "[starkTableRowContent]"
+})
+export class StarkTableRowContentDirective {
+	// IMPORTANT: The "projected" content will be injected in the "template" property of this directive
+	// This is a workaround to be able to get the "projected" content and to add it as a nested "projected" content of the <stark-table-column>
+	public constructor(public readonly template: TemplateRef<any>) {}
+}

--- a/packages/stark-ui/src/modules/table/table.module.ts
+++ b/packages/stark-ui/src/modules/table/table.module.ts
@@ -23,16 +23,12 @@ import { translationsFr } from "./assets/translations/fr";
 import { translationsNl } from "./assets/translations/nl";
 import { mergeUiTranslations } from "../../common/translations";
 import { StarkTableExpandDetailDirective } from "./directives/table-expand-detail.directive";
+import { StarkTableRowContentDirective } from "./directives/table-row-content.directive";
 
 @NgModule({
-	declarations: [
-		StarkTableComponent,
-		StarkTableMultisortDialogComponent,
-		StarkTableColumnComponent,
-		StarkTableExpandDetailDirective
-	],
+	declarations: [StarkTableComponent, StarkTableMultisortDialogComponent, StarkTableColumnComponent, StarkTableRowContentDirective, StarkTableExpandDetailDirective],
 	entryComponents: [StarkTableMultisortDialogComponent],
-	exports: [StarkTableComponent, StarkTableColumnComponent, StarkTableExpandDetailDirective],
+	exports: [StarkTableComponent, StarkTableColumnComponent, StarkTableRowContentDirective, StarkTableExpandDetailDirective],
 	imports: [
 		// Common
 		CommonModule,

--- a/showcase/src/app/demo-ui/components/index.ts
+++ b/showcase/src/app/demo-ui/components/index.ts
@@ -5,6 +5,7 @@ export * from "./table-with-custom-actions";
 export * from "./table-with-transcluded-action-bar";
 export * from "./table-with-fixed-header";
 export * from "./table-with-custom-styling";
+export * from "./table-with-custom-cell-rendering";
 export * from "./table-with-fixed-actions";
 export * from "./table-with-footer";
 export * from "./table-with-collapsible-rows";

--- a/showcase/src/app/demo-ui/components/table-with-custom-cell-rendering/index.ts
+++ b/showcase/src/app/demo-ui/components/table-with-custom-cell-rendering/index.ts
@@ -1,0 +1,1 @@
+export * from "./table-with-custom-cell-rendering.component";

--- a/showcase/src/app/demo-ui/components/table-with-custom-cell-rendering/table-with-custom-cell-rendering.component.html
+++ b/showcase/src/app/demo-ui/components/table-with-custom-cell-rendering/table-with-custom-cell-rendering.component.html
@@ -1,0 +1,21 @@
+<stark-table [data]="data" [columnProperties]="columns" [filter]="filter">
+	<header><h1 class="mb0" translate>SHOWCASE.DEMO.TABLE.WITH_CUSTOM_CELL_RENDERING</h1></header>
+	<ng-container
+		[ngSwitch]="true"
+		*starkTableRowContent="let rowData = rowData; let cellRawValue = rawValue; let cellDisplayedValue = displayedValue"
+	>
+		<div *ngSwitchCase="rowData.id === 1"
+			><span style="color: blue">{{ cellDisplayedValue }}</span></div
+		>
+		<div *ngSwitchCase="rowData.id === 2"
+			><span style="color: red">{{ cellDisplayedValue }}</span></div
+		>
+		<div *ngSwitchCase="rowData.id === 3"
+			><i>{{ cellDisplayedValue }}</i></div
+		>
+		<div *ngSwitchCase="cellRawValue > 23">
+			<mat-icon class="mat-icon-rtl-mirror" svgIcon="thumb-up"></mat-icon> {{ cellDisplayedValue }}
+		</div>
+		<div *ngSwitchDefault>{{ cellDisplayedValue }}</div>
+	</ng-container>
+</stark-table>

--- a/showcase/src/app/demo-ui/components/table-with-custom-cell-rendering/table-with-custom-cell-rendering.component.ts
+++ b/showcase/src/app/demo-ui/components/table-with-custom-cell-rendering/table-with-custom-cell-rendering.component.ts
@@ -1,0 +1,37 @@
+import { Component } from "@angular/core";
+import { StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
+
+const DUMMY_DATA: object[] = [
+	{ id: 1, cost: 12, description: "number one" },
+	{ id: 2, cost: 23, description: "second description" },
+	{ id: 3, cost: 5, description: "the third description" },
+	{ id: 4, cost: 33, description: "description number four" },
+	{ id: 5, cost: 54, description: "fifth description" },
+	{ id: 6, cost: 3, description: "the sixth description" },
+	{ id: 7, cost: 7, description: "seventh description" },
+	{ id: 9, cost: 24, description: "description number eight" },
+	{ id: 9, cost: 35, description: "the ninth description" },
+	{ id: 10, cost: 10, description: "description number ten" },
+	{ id: 11, cost: 21, description: "eleventh description", whatever: "<span>whatever</span>" },
+	{ id: 12, cost: 6, description: "the twelfth description", whatever: "<span>whatever</span>" }
+];
+
+@Component({
+	selector: "showcase-table-with-custom-cell-rendering",
+	templateUrl: "./table-with-custom-cell-rendering.component.html"
+})
+export class TableWithCustomCellRenderingComponent {
+	public data: object[] = DUMMY_DATA;
+
+	public columns: StarkTableColumnProperties[] = [
+		{ name: "id", label: "Id" },
+		{
+			name: "cost",
+			label: "SHOWCASE.DEMO.TABLE.LABELS.TITLE",
+			cellClassName: (cost: number): string => (cost === 5 ? "danger" : cost === 21 ? "warning" : "")
+		},
+		{ name: "description", label: "SHOWCASE.DEMO.TABLE.LABELS.DESCRIPTION" }
+	];
+
+	public filter: StarkTableFilter = { globalFilterPresent: false, columns: [] };
+}

--- a/showcase/src/app/demo-ui/demo-ui.module.ts
+++ b/showcase/src/app/demo-ui/demo-ui.module.ts
@@ -74,6 +74,7 @@ import {
 	TableWithFixedActionsComponent,
 	TableWithFixedHeaderComponent,
 	TableWithFooterComponent,
+	TableWithCustomCellRenderingComponent,
 	TableWithSelectionComponent,
 	TableWithTranscludedActionBarComponent,
 	TableWithCollapsibleRowsComponent
@@ -149,6 +150,7 @@ import {
 		TableWithTranscludedActionBarComponent,
 		TableWithFixedHeaderComponent,
 		TableWithFooterComponent,
+		TableWithCustomCellRenderingComponent,
 		TableWithCustomStylingComponent,
 		TableWithFixedActionsComponent,
 		DemoToastPageComponent,

--- a/showcase/src/app/demo-ui/pages/table/demo-table-page.component.html
+++ b/showcase/src/app/demo-ui/pages/table/demo-table-page.component.html
@@ -74,6 +74,15 @@
 	</example-viewer>
 
 	<example-viewer
+		id="collapse"
+		exampleTitle="SHOWCASE.DEMO.TABLE.WITH_CUSTOM_CELL_RENDERING"
+		filesPath="table/with-custom-cell-rendering/table"
+		[extensions]="['HTML', 'TS']"
+	>
+		<showcase-table-with-custom-cell-rendering></showcase-table-with-custom-cell-rendering>
+	</example-viewer>
+
+	<example-viewer
 		id="footer"
 		exampleTitle="SHOWCASE.DEMO.TABLE.WITH_FOOTER"
 		filesPath="table/with-footer/table"

--- a/showcase/src/assets/examples/table/with-custom-cell-rendering/table.html
+++ b/showcase/src/assets/examples/table/with-custom-cell-rendering/table.html
@@ -1,0 +1,22 @@
+<stark-table [data]="data" [columnProperties]="columns" [filter]="filter" (rowClicked)="handleRowClicked($event)">
+	<header><h1 class="mb0" translate>Table with custom cell rendering</h1></header>
+	<ng-container
+		[ngSwitch]="true"
+		*starkTableRowContent="let rowData = rowData; let cellRawValue = rawValue; let cellDisplayedValue = displayedValue"
+	>
+		<div *ngSwitchCase="rowData.id === 1"
+			><span style="color: blue">{{ cellDisplayedValue }}</span></div
+		>
+		<div *ngSwitchCase="rowData.id === 2"
+			><span style="color: red">{{ cellDisplayedValue }}</span></div
+		>
+		<div *ngSwitchCase="rowData.id === 3"
+			><i>{{ cellDisplayedValue }}</i></div
+		>
+		<div *ngSwitchCase="cellRawValue > 23">
+			<mat-icon class="mat-icon-rtl-mirror" svgIcon="thumb-up"></mat-icon>
+			{{ cellDisplayedValue }}
+		</div>
+		<div *ngSwitchDefault>{{ cellDisplayedValue }}</div>
+	</ng-container>
+</stark-table>

--- a/showcase/src/assets/examples/table/with-custom-cell-rendering/table.ts
+++ b/showcase/src/assets/examples/table/with-custom-cell-rendering/table.ts
@@ -1,0 +1,30 @@
+import { Component, Inject } from "@angular/core";
+import { STARK_LOGGING_SERVICE, StarkLoggingService } from "@nationalbankbelgium/stark-core";
+import { StarkTableColumnProperties, StarkTableFilter } from "@nationalbankbelgium/stark-ui";
+
+const DUMMY_DATA: object[] = [
+	{ id: 1, cost: 12, description: "number one" },
+	/*...*/
+	{ id: 11, cost: 21, description: "eleventh description", whatever: "<span>whatever</span>" },
+	{ id: 12, cost: 6, description: "the twelfth description", whatever: "<span>whatever</span>" }
+];
+
+@Component({
+	selector: "showcase-table-with-custom-cell-rendering",
+	templateUrl: "./table-with-custom-cell-rendering.component.html"
+})
+export class TableWithCustomCellRenderingComponent {
+	public data: object[] = DUMMY_DATA;
+
+	public columns: StarkTableColumnProperties[] = [
+		{ name: "id", label: "Id" },
+		{
+			name: "cost",
+			label: "SHOWCASE.DEMO.TABLE.LABELS.TITLE",
+			cellClassName: (cost: number): string => (cost === 5 ? "danger" : cost === 21 ? "warning" : "")
+		},
+		{ name: "description", label: "SHOWCASE.DEMO.TABLE.LABELS.DESCRIPTION" }
+	];
+
+	public filter: StarkTableFilter = { globalFilterPresent: false, columns: [] };
+}

--- a/showcase/src/assets/translations/en.json
+++ b/showcase/src/assets/translations/en.json
@@ -339,6 +339,7 @@
         "WITH_FOOTER": "Table with footer",
         "WITH_TRANSCLUDED_ACTION_BAR": "Table with transcluded Action bar",
         "WITH_CUSTOM_STYLING": "Table with custom styling",
+        "WITH_CUSTOM_CELL_RENDERING": "Table with custom cell rendering",
         "WITH_FIXED_ACTIONS": "Table with fixed row actions",
         "WITH_COLLAPSIBLE_ROWS": "Table with collapsible rows",
         "TITLE": "Table"

--- a/showcase/src/assets/translations/fr.json
+++ b/showcase/src/assets/translations/fr.json
@@ -339,6 +339,7 @@
         "WITH_FOOTER": "Table avec footer",
         "WITH_TRANSCLUDED_ACTION_BAR": "Table avec Action Bar 'transcluded'",
         "WITH_CUSTOM_STYLING": "Table avec mise en page personnalisé",
+        "WITH_CUSTOM_CELL_RENDERING": "Table avec rendu de cellules personnalisé",
         "WITH_FIXED_ACTIONS": "Table avec actions de ligne fixes",
         "WITH_COLLAPSIBLE_ROWS": "Table avec des lignes réductibles",
         "TITLE": "Table"

--- a/showcase/src/assets/translations/nl.json
+++ b/showcase/src/assets/translations/nl.json
@@ -339,6 +339,7 @@
         "WITH_FOOTER": "Tabel met footer",
         "WITH_TRANSCLUDED_ACTION_BAR": "Tabel met 'transcluded' Action Bar",
         "WITH_CUSTOM_STYLING": "Tabel met aangepaste opmaak",
+        "WITH_CUSTOM_CELL_RENDERING": "Table met aangepaste kolommen",
         "WITH_FIXED_ACTIONS": "Tabel met vaste rijacties",
         "WITH_COLLAPSIBLE_ROWS": "Tabel met uitklapbare rijen",
         "TITLE": "Table"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
For now it's impossible to put html inside a cell of a table. Only text is allowed.


## What is the new behavior?
The render of a cell in table is now fully customisable. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information