### PR TITLE
ci(starter): disable starter integration in Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ install:
   - mkdir -p $LOGS_DIR
   - touch $LOGS_DIR/build-perf.log
   - npm ci
-  # The condition is there due to an unexpected issue with Travis when running on NodeJS 12: https://github.com/NationalBankBelgium/stark/issues/2059
-  - if [[ ${NODE_VERSION} =~ ^v10.*$ ]]; then npm run install:ci:all; else npm run install:travis-ci:all; fi
+  # FIXME Use ci scripts instead of travis-ci. Due to unexpected error with starter. See: https://github.com/NationalBankBelgium/stark/issues/2059
+  - npm run install:travis-ci:all
   - npm run build:showcase:ghpages
 
 env:
@@ -49,14 +49,13 @@ cache:
 #  chrome: stable
 
 script:
-  # The condition is there due to an unexpected issue with Travis when running on NodeJS 12: https://github.com/NationalBankBelgium/stark/issues/2059
-  - if [[ ${NODE_VERSION} =~ ^v10.*$ ]]; then npm run lint:all; else npm run lint:travis-ci:all; fi
-  - if [[ ${NODE_VERSION} =~ ^v10.*$ ]]; then npm run test:ci:all; else npm run test:travis-ci:all; fi
+  # FIXME Use ci scripts instead of travis-ci. Due to unexpected error with starter. See: https://github.com/NationalBankBelgium/stark/issues/2059
+  - npm run lint:travis-ci:all
+  - npm run test:travis-ci:all
   # E2E tests only need to be run on 1 node version (v10)
   # and the secure environmentals BROWSERSTACK_USERNAME, BROWSERSTACK_ACCESS_KEY should be set. (only on secure builds)
   - if [[ ${NODE_VERSION} =~ ^v10.*$ && -n "${BROWSERSTACK_USERNAME}" && -n "${BROWSERSTACK_ACCESS_KEY}"  ]]; then npm run test:showcase:e2e:browserstack; else echo "Skipping browserstack tests."; fi
-  # The condition is there due to an unexpected issue with Travis when running on NodeJS 12: https://github.com/NationalBankBelgium/stark/issues/2059
-  - if [[ ${NODE_VERSION} =~ ^v10.*$ ]]; then npm run docs:coverage; else npm run docs:travis-ci:coverage; fi
+  - npm run docs:travis-ci:coverage
   - npm run docs:publish
   - npm run release:publish
   - bash ./scripts/ci/print-logs.sh


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Travis CI does not work for starter in NodeJS 10.

Issue Number: #2488 


## What is the new behavior?
Travis CI should work if no code issue.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
