### PR TITLE
ci(stark-all): add support for GitHub Actions

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -26,7 +26,7 @@ module.exports = {
 		},
 		{
 			value: "ci",
-			name: "ci:     Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)"
+			name: "ci:     Changes to our CI configuration files and scripts (example scopes: GitHub Actions, Travis, Circle, BrowserStack, SauceLabs)"
 		},
 		{
 			value: "chore",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,226 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+      #- /^\d+\.\d+\.\d(-alpha\.\d+|-beta\.\d+|-rc\.\d+)?$/
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - master
+
+env:
+  TZ: "Europe/Brussels"
+  MAIN_NODEJS: "10"
+  NPM_VERSION: "6.9.2"
+  LOGS_DIR: /tmp/stark/logs
+  LOGS_FILE: /tmp/stark/logs/build-perf.log
+  HUSKY_SKIP_INSTALL: true
+
+jobs:
+  build-and-test:
+    name: Build and test on Node.js ${{ matrix.node_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node_version: [ "10", "12" ]
+        os: [ ubuntu-latest, macOS-latest ]
+
+    steps:
+      # Some actions should be executed only in one environment.
+      # This variable determines if it is the main environment, it means the same than the one we have internally.
+      - name: Set environment variable 'IS_MAIN_ENVIRONMENT'
+        run: |
+          if [[ '${{ matrix.node_version }}' == '${{ env.MAIN_NODEJS }}' ]] && [[ '${{ matrix.os }}' == 'ubuntu-latest' ]]; then
+            echo "IS_MAIN_ENVIRONMENT=1" >> $GITHUB_ENV
+          else
+            echo "IS_MAIN_ENVIRONMENT=0" >> $GITHUB_ENV
+          fi
+        
+      # See: https://github.com/marketplace/actions/checkout
+      - uses: actions/checkout@v2
+
+      # See: https://github.com/marketplace/actions/setup-node-js-environment
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+
+      # See: https://github.com/marketplace/actions/cache
+      # See doc: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules-${{ matrix.node_version }}-${{ matrix.os }}
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      
+      - name: Install npm ${{ env.NPM_VERSION }}
+        run: npm i -g npm@${{ env.NPM_VERSION }}
+        
+      - name: Get tag name if exists
+        run: |
+          TAG_NAME=$(echo $GITHUB_REF | sed -n "s/^refs\/tags\/\(\S*\).*$/\1/p")
+          echo "GH_ACTIONS_TAG=${TAG_NAME}" >> $GITHUB_ENV
+        
+      - name: List main variables
+        run: |
+          echo "Commit SHA  : ${GITHUB_SHA}"
+          echo "Reference   : ${GITHUB_REF}"
+          echo "Repository  : ${GITHUB_REPOSITORY}"
+          echo "Event       : ${GITHUB_EVENT_NAME}"
+          echo "Author      : ${GITHUB_ACTOR}"
+          echo "Main ENV    : ${{ env.IS_MAIN_ENVIRONMENT }}"
+          NODE_VERSION="$(node -v)"
+          echo "Node version: $NODE_VERSION"
+          # This ensures that we are authenticated without requiring to have an actual .npmrc file within the project
+          # echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          
+      - name: Create file & folder for GitHub Actions logs
+        run: |  
+          # cfr scripts/_ghactions-group.sh
+          mkdir -p ${{ env.LOGS_DIR }}
+          touch ${{ env.LOGS_FILE }}
+            
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm run install:travis-ci:all
+
+      - name: Linting
+        run: npm run lint:travis-ci:all
+
+      - name: Testing
+        run: npm run test:travis-ci:all
+        
+      - name: "Build showcase:ghpages"
+        run: npm run build:showcase:ghpages
+
+      # See: https://github.com/marketplace/actions/upload-artifact
+      - name: Upload stark packages-dist folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: stark-dist
+          path: dist/packages-dist
+        if: env.IS_MAIN_ENVIRONMENT == 1
+
+      # See: https://github.com/marketplace/actions/upload-artifact
+      - name: Upload showcase dist folder
+        uses: actions/upload-artifact@v2
+        with:
+          name: showcase-dist
+          path: showcase/dist
+        if: env.IS_MAIN_ENVIRONMENT == 1
+        
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@master
+        with:
+          username: ${{ secrets.BROWSERSTACK_USERNAME }}
+          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          project-name: "Stark Showcase"
+        if: env.IS_MAIN_ENVIRONMENT == 1
+
+      - name: BrowserStack Local Tunnel Setup
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: "start"
+          local-logging-level: "all-logs"
+          local-identifier: "github-actions-${{ github.run_number }}"
+        if: env.IS_MAIN_ENVIRONMENT == 1
+    
+      - name: Running application under test
+        run: npm run server:prod:ci &
+        if: env.IS_MAIN_ENVIRONMENT == 1
+        working-directory: showcase
+        
+      - name: Running test on BrowserStack
+        run: npm run protractor:browserstack
+        if: env.IS_MAIN_ENVIRONMENT == 1
+        working-directory: showcase
+    
+      - name: BrowserStackLocal Stop
+        uses: browserstack/github-actions/setup-local@master
+        with:
+          local-testing: stop
+        if: env.IS_MAIN_ENVIRONMENT == 1
+        
+      - name: Generate docs coverage
+        run: npm run docs:travis-ci:coverage
+        if: env.IS_MAIN_ENVIRONMENT == 1
+
+      - name: Save logs
+        run: bash ./scripts/ci/print-gh-logs.sh
+        
+      - name: Combine coveralls reports
+        run: node combine-packages-coverage.js
+        if: env.IS_MAIN_ENVIRONMENT == 1
+        
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: "combined-lcov.info"
+        if: env.IS_MAIN_ENVIRONMENT == 1
+      
+      
+  release:
+    name: Release
+    runs-on: "ubuntu-latest"
+    needs: build-and-test
+    if: (startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule') && github.repository == 'NationalBankBelgium/stark'
+    steps:
+      - name: Get tag name if exists
+        run: |
+          TAG_NAME=$(echo $GITHUB_REF | sed -n "s/^refs\/tags\/\(\S*\).*$/\1/p")
+          echo "GH_ACTIONS_TAG=${TAG_NAME}" >> $GITHUB_ENV
+
+      # See: https://github.com/marketplace/actions/checkout
+      - uses: actions/checkout@v2
+
+      # See: https://github.com/marketplace/actions/setup-node-js-environment
+      - name: Use Node.js ${{ env.MAIN_NODEJS }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.MAIN_NODEJS }}
+
+      - name: Install npm ${{ env.NPM_VERSION }}
+        run: npm i -g npm@${{ env.NPM_VERSION }}
+        
+      - name: Create file & folder for GitHub Actions logs
+        run: |
+          # cfr scripts/_ghactions-group.sh
+          mkdir -p ${{ env.LOGS_DIR }}
+          touch ${{ env.LOGS_FILE }}
+        
+      - uses: actions/download-artifact@v2
+        with:
+          name: stark-dist
+          path: dist/packages-dist
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: showcase-dist
+          path: showcase/dist
+
+      - name: Install Stark packages dependencies
+        run: |
+          npm ci
+          npm run install:ci:stark-build
+          npm run install:ci:stark-core
+          npm run install:ci:stark-rbac
+          npm run install:ci:stark-ui
+        if: github.event_name != 'schedule'
+
+      - name: Release is currently managed in Travis plan
+        run: echo "Check Travis plan for release process"
+
+      - name: Save logs
+        run: bash ./scripts/ci/print-gh-logs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ before_install:
   - npm i -g npm@6.9.2
   - NODE_VERSION="$(node -v)"
   - echo $NODE_VERSION
+  # Testing part is now handled by GitHub Actions. In a next PR, we'll the configuration to handle release process also in GitHub Actions.
+  # See: https://github.com/NationalBankBelgium/stark/issues/2493
+  - if [[ ${TRAVIS_TAG} == "" && ${TRAVIS_EVENT_TYPE} != "cron" ]]; then echo "Travis CI should be used ONLY for release process. Testing part should be done by GitHub Actions"; travis_terminate 0; fi  
   # This ensures that we are authenticated without requiring to have an actual .npmrc file within the project
   - 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc'
 
@@ -37,7 +40,6 @@ env:
 branches:
   only:
     - master
-    - /^dependabot/npm_and_yarn/.*$/
     - /^\d+\.\d+\.\d(-alpha\.\d+|-beta\.\d+|-rc\.\d+)?$/
 
 cache:
@@ -54,11 +56,9 @@ script:
   - npm run test:travis-ci:all
   # E2E tests only need to be run on 1 node version (v10)
   # and the secure environmentals BROWSERSTACK_USERNAME, BROWSERSTACK_ACCESS_KEY should be set. (only on secure builds)
-  - if [[ ${NODE_VERSION} =~ ^v10.*$ && -n "${BROWSERSTACK_USERNAME}" && -n "${BROWSERSTACK_ACCESS_KEY}"  ]]; then npm run test:showcase:e2e:browserstack; else echo "Skipping browserstack tests."; fi
+  # E2E is now handled in GitHub Actions
+  # - if [[ ${NODE_VERSION} =~ ^v10.*$ && -n "${BROWSERSTACK_USERNAME}" && -n "${BROWSERSTACK_ACCESS_KEY}"  ]]; then npm run test:showcase:e2e:browserstack; else echo "Skipping browserstack tests."; fi
   - npm run docs:travis-ci:coverage
   - npm run docs:publish
   - npm run release:publish
   - bash ./scripts/ci/print-logs.sh
-
-after_success:
-  - npm run test:ci:coveralls:combined

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
 [![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Coverage Status](https://coveralls.io/repos/github/NationalBankBelgium/stark/badge.svg?branch=master)](https://coveralls.io/github/NationalBankBelgium/stark?branch=master)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark.svg)](https://david-dm.org/NationalBankBelgium/stark)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark#info=devDependencies)
@@ -149,6 +150,13 @@ We're supported by [Jetbrains](https://www.jetbrains.com) and their awesome [sup
 We're supported by [Travis](https://travis-ci.org/)
 
 <a href="https://travis-ci.org/"><img src="https://travis-ci.com/images/logos/TravisCI-Full-Color.png" width="144px"></a>
+
+### GitHub Actions
+
+We're supported by [GitHub Actions](https://github.com/features/actions)
+
+<a href="https://github.com/features/actions"><img src="https://github.githubassets.com/images/modules/site/features/actions-icon-actions.svg" width="144px"></a>
+
 
 ### BrowserStack
 

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,7 @@ readonly currentDir=$(cd $(dirname $0); pwd)
 
 export NODE_PATH=${NODE_PATH:-}:${currentDir}/node_modules
 
+source ${currentDir}/scripts/ci/_ghactions-group.sh
 source ${currentDir}/scripts/ci/_travis-fold.sh
 source ${currentDir}/util-functions.sh
 source ${currentDir}/build-functions.sh
@@ -39,6 +40,9 @@ BUNDLE=true
 COMPILE_SOURCE=true
 
 TRAVIS=${TRAVIS:-}
+GITHUB_ACTIONS=${GITHUB_ACTIONS:-}
+GITHUB_EVENT_NAME=${GITHUB_EVENT_NAME:-""}
+GH_ACTIONS_TAG=${GH_ACTIONS_TAG:-""}
 
 VERBOSE=false
 TRACE=false
@@ -143,15 +147,19 @@ if [[ -z ${TRAVIS_EVENT_TYPE+x} ]]; then
   TRAVIS_EVENT_TYPE=""
 fi
 
-if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
-  logInfo "Nightly build initiated by Travis cron job. Using nightly version as version prefix!" 1
+if [[ ${TRAVIS_EVENT_TYPE} == "cron" || ${GITHUB_EVENT_NAME} == "schedule" ]]; then
+  if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
+    logInfo "Nightly build initiated by Travis cron job. Using nightly version as version prefix!" 1
+  else
+    logInfo "Nightly build initiated by GitHub Actions scheduled job. Using nightly version as version prefix!" 1
+  fi
   VERSION_PREFIX=$(node -p "require('./package.json').config.nightlyVersion")
 else
   logInfo "Normal build. Using current version as version prefix" 1
   VERSION_PREFIX=$(node -p "require('./package.json').version")
 fi
 
-if [[ ${TRAVIS_TAG} == "" ]]; then
+if [[ ${TRAVIS_TAG} == "" || ${GH_ACTIONS_TAG} == "" ]]; then
   logTrace "Setting the version suffix to the latest commit hash" 1
   VERSION_SUFFIX="-$(git log --oneline -1 | awk '{print $1}')" # last commit id
 else
@@ -175,9 +183,15 @@ logInfo "============================================="
 NG=`pwd`/node_modules/.bin/ng
 
 if [[ ${BUILD_ALL} == true ]]; then
-  travisFoldStart "clean dist" "no-xtrace"
+  if [[ ${GITHUB_ACTIONS} == true ]]; then
+    ghActionsGroupStart "clean dist" "no-xtrace"
     rm -rf ./dist/packages
-  travisFoldEnd "clean dist"
+    ghActionsGroupEnd "clean dist"
+  else
+    travisFoldStart "clean dist" "no-xtrace"
+    rm -rf ./dist/packages
+    travisFoldEnd "clean dist"
+  fi
 fi
 
 if [[ ${BUILD_ALL} == true ]]; then
@@ -192,7 +206,11 @@ fi
 if [[ ${BUILD_ALL} == false ]]; then
   for PACKAGE in ${ALL_PACKAGES[@]}
   do
-    travisFoldStart "clean dist for ${PACKAGE}" "no-xtrace"
+    if [[ ${GITHUB_ACTIONS} == true ]]; then
+      ghActionsGroupStart "clean dist for ${PACKAGE}" "no-xtrace"
+    else
+      travisFoldStart "clean dist for ${PACKAGE}" "no-xtrace"
+    fi
     rm -rf ./dist/packages/${PACKAGE}
     if [[ ${BUNDLE} == true ]]; then
       rm -rf ./dist/packages-dist/${PACKAGE}
@@ -205,15 +223,26 @@ if [[ ${BUILD_ALL} == false ]]; then
     if [[ ! -d "./dist/packages-dist" ]]; then
       mkdir -p ./dist/packages-dist
     fi
+  
+    if [[ ${GITHUB_ACTIONS} == true ]]; then
+      ghActionsGroupEnd "clean dist for ${PACKAGE}"
+    else
+      travisFoldEnd "clean dist for ${PACKAGE}"
+    fi
   done
-  travisFoldEnd "clean dist for ${PACKAGE}"
 fi
 
 mkdir -p ${ROOT_OUT_DIR}
 
 for PACKAGE in ${ALL_PACKAGES[@]}
 do
-  travisFoldStart "global build: ${PACKAGE}" "no-xtrace"
+  if [[ ${GITHUB_ACTIONS} == true ]]; then
+    logInfo "============================================="
+    logInfo "Global build: ${PACKAGE}"
+    logInfo "============================================="
+  else
+    travisFoldStart "global build: ${PACKAGE}" "no-xtrace"
+  fi
     SRC_DIR=${ROOT_DIR}/${PACKAGE}
     logTrace "SRC_DIR: $SRC_DIR" 1
     OUT_DIR=${ROOT_OUT_DIR}/${PACKAGE}
@@ -224,7 +253,11 @@ do
     LICENSE_BANNER=${ROOT_DIR}/license-banner.txt
   
     if [[ ${#PACKAGES[@]} > 0 && $(containsElement "${PACKAGE}" "${PACKAGES[@]}"; echo $?) == 0 ]]; then
-      travisFoldStart "build package: ${PACKAGE}" "no-xtrace"
+      if [[ ${GITHUB_ACTIONS} == true ]]; then
+        ghActionsGroupStart "build package: ${PACKAGE}" "no-xtrace"
+      else
+        travisFoldStart "build package: ${PACKAGE}" "no-xtrace"
+      fi
         rm -rf ${OUT_DIR}
         rm -f ${ROOT_OUT_DIR}/${PACKAGE}.js
         
@@ -266,11 +299,19 @@ do
         addBanners ${FESM5_DIR}
         addBanners ${BUNDLES_DIR}
         
-      travisFoldEnd "build package: ${PACKAGE}"
+      if [[ ${GITHUB_ACTIONS} == true ]]; then
+        ghActionsGroupEnd "build package: ${PACKAGE}"
+      else
+        travisFoldEnd "build package: ${PACKAGE}"
+      fi
     fi
     
     if [[ ${#NODE_PACKAGES[@]} > 0 && $(containsElement "${PACKAGE}" "${NODE_PACKAGES[@]}"; echo $?) == 0 ]]; then
-      travisFoldStart "build node package: ${PACKAGE}" "no-xtrace"
+      if [[ ${GITHUB_ACTIONS} == true ]]; then
+        ghActionsGroupStart "build node package: ${PACKAGE}" "no-xtrace"
+      else
+        travisFoldStart "build node package: ${PACKAGE}" "no-xtrace"
+      fi
       
       # contents only need to be copied to the destination folder
       logInfo "Copy ${PACKAGE} to ${OUT_DIR}"
@@ -280,11 +321,19 @@ do
   
       logInfo "Copy $PACKAGE contents"
       syncFiles ${OUT_DIR} ${NPM_DIR} "-a"
-  
-      travisFoldEnd "build node package: ${PACKAGE}"
+      
+      if [[ ${GITHUB_ACTIONS} == true ]]; then
+        ghActionsGroupEnd "build node package: ${PACKAGE}"
+      else
+        travisFoldEnd "build node package: ${PACKAGE}"
+      fi
     fi
   
-    travisFoldStart "general tasks: ${PACKAGE}" "no-xtrace"
+    if [[ ${GITHUB_ACTIONS} == true ]]; then
+      ghActionsGroupStart "general tasks: ${PACKAGE}" "no-xtrace"
+    else
+      travisFoldStart "general tasks: ${PACKAGE}" "no-xtrace"
+    fi
       if [[ -d ${NPM_DIR} ]]; then
         logInfo "Copy $PACKAGE README.md file to $NPM_DIR"
         cp ${ROOT_DIR}/README.md ${NPM_DIR}/
@@ -310,10 +359,22 @@ do
         adaptNpmPackageLockDependencies ${PACKAGE} ${VERSION} "./starter/package-lock.json" 1
 
       fi
-    travisFoldEnd "general tasks: ${PACKAGE}"
+
+    if [[ ${GITHUB_ACTIONS} == true ]]; then
+      ghActionsGroupEnd "general tasks: ${PACKAGE}"
+    else
+      travisFoldEnd "general tasks: ${PACKAGE}"
+    fi
   
-  travisFoldEnd "global build: ${PACKAGE}"
+  if [[ ${TRAVIS} == true ]]; then
+    travisFoldEnd "global build: ${PACKAGE}"
+  fi
 done
 
 # Print return arrows as a log separator
-travisFoldReturnArrows
+if [[ ${GITHUB_ACTIONS} == true ]]; then
+  ghActionsGroupReturnArrows
+else
+  travisFoldReturnArrows
+fi
+

--- a/combine-packages-coverage.js
+++ b/combine-packages-coverage.js
@@ -56,6 +56,7 @@ for (const fileName of fileNames) {
 // then concatenate the files (but wait X milliseconds for the files to be overwritten in the previous step)
 setTimeout(() => {
 	const combinedStream = new StreamConcat(nextStream);
+	const combinedLcovFileName = fs.createWriteStream("combined-lcov.info");
 
-	combinedStream.pipe(process.stdout);
+	combinedStream.pipe(combinedLcovFileName);
 }, 250);

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -37,7 +37,7 @@ Keeping e2e tests separate like this prevents confusion when testing multiple co
 
 ## BrowserStack (optional)
 
-The showcase app uses Travis CI and BrowserStack to automatically run e2e-tests on multiple setups (Chrome, Firefox, IE, Safari, Android, IOS, ...).
+The showcase app uses GitHub Actions and BrowserStack to automatically run e2e-tests on multiple setups (Chrome, Firefox, IE, Safari, Android, IOS, ...).
 
 If you want to run your e2e-tests automatically on multiple setups one of the easiest solutions is BrowserStack.
 They offer a free solution for open source projects.
@@ -69,9 +69,9 @@ _For more documentation see:_
 -   _[https://github.com/angular/protractor/blob/master/lib/config.ts](https://github.com/angular/protractor/blob/master/lib/config.ts)_
 -   _[https://www.browserstack.com/automate/capabilities](https://www.browserstack.com/automate/capabilities)_
 
-### Integrating BrowserStack with Travis CI
+### Integrating BrowserStack with GitHub Actions
 
-To integrate the BrowserStack testing with Travis-CI simply add the same environmentals as before. **Remember to keep them private.**
+To integrate the BrowserStack testing with GitHub Actions simply add the same environmentals as before. **Remember to keep them private.**
 
 ### Common errors
 

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -1,0 +1,221 @@
+# GitHub Actions with Stark
+
+This documentation explains the main features we use in the build plan,
+based on GitHub Actions.
+
+## Actions
+
+### actions/checkout@v2
+
+This official action can be used to check out the repository code in order to
+execute tests, build, etc. No parameter is needed to use this action with the current repository.
+
+All the information about this action can be found on [github.com/marketplace/actions/checkout](https://github.com/marketplace/actions/checkout).
+
+### actions/setup-node@v2
+
+This official action can be used to install a specific version of NodeJS in the virtual machine.
+It requires the parameter `node-version: '12'` with any version of node.
+
+In Stark build, we execute our tests/build with multiple versions of NodeJS thanks to `strategy.matrix`. See:
+
+```yaml
+name: Build and test on Node.js ${{ matrix.node_version }}
+runs-on: ubuntu-latest
+strategy:
+  matrix:
+    node_version: [ "10", "12" ]
+
+steps:
+  - name: Use Node.js ${{ matrix.node_version }}
+    uses: actions/setup-node@v2
+    with:
+      node-version: ${{ matrix.node_version }}
+```
+
+All the information about this action can be found on [github.com/marketplace/actions/setup-node-js-environment](https://github.com/marketplace/actions/setup-node-js-environment).
+
+### actions/cache@v2
+
+This official action can be used to improve performances of build plans. 
+In Stark build plan, we use this action to cache the npm cache thanks to the following config:
+
+```yaml
+- name: Cache node modules
+  uses: actions/cache@v2
+  env:
+    cache-name: cache-node-modules-${{ matrix.node_version }}-${{ matrix.os }}
+  with:
+    # npm cache files are stored in `~/.npm` on Linux/macOS
+    path: ~/.npm
+    key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+    restore-keys: |
+	  ${{ runner.os }}-build-${{ env.cache-name }}-
+	  ${{ runner.os }}-build-
+	  ${{ runner.os }}-
+```
+
+All the information about this action can be found on [github.com/marketplace/actions/cache](https://github.com/marketplace/actions/cache).
+
+More documentation about this action be found in [GitHub documentation](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows)
+
+### actions/upload-artifact@v2 - actions/download-artifact@v2
+
+These official actions can be used to share data between jobs. The uploaded content is available for download after 
+the job execution.
+
+See the following example to understand how these actions can be used:
+
+```yaml
+- name: Upload stark packages-dist folder
+  uses: actions/upload-artifact@v2
+  with:
+    name: stark-dist
+    path: dist/packages-dist
+
+- name: Download stark packages-dist folder
+  uses: actions/download-artifact@v2
+  with:
+    name: stark-dist
+    path: dist/packages-dist
+```
+
+All the information about these actions can be found on [github.com/marketplace/actions/upload-a-build-artifact](https://github.com/marketplace/actions/upload-a-build-artifact) 
+and [github.com/marketplace/actions/download-a-build-artifact](https://github.com/marketplace/actions/download-a-build-artifact).
+
+## BrowserStack actions
+
+Running BrowserStack in GitHub Actions requires setting different actions as explained on [github.com/browserstack/github-actions](https://github.com/browserstack/github-actions).
+
+You can find the Stark configuration below:
+
+```yaml
+steps:
+  - name: BrowserStack Env Setup
+    uses: browserstack/github-actions/setup-env@master
+    with:
+      username: ${{ secrets.BROWSERSTACK_USERNAME }}
+      access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      project-name: "Stark Showcase"
+    if: env.IS_MAIN_ENVIRONMENT == 1
+
+  - name: BrowserStack Local Tunnel Setup
+    uses: browserstack/github-actions/setup-local@master
+    with:
+      local-testing: "start"
+      local-logging-level: "all-logs"
+      local-identifier: "github-actions-${{ github.run_number }}"
+    if: env.IS_MAIN_ENVIRONMENT == 1
+
+  - name: Running application under test
+    run: npm run server:prod:ci &
+    if: env.IS_MAIN_ENVIRONMENT == 1
+    working-directory: showcase
+
+  - name: Running test on BrowserStack
+    run: npm run protractor:browserstack
+    if: env.IS_MAIN_ENVIRONMENT == 1
+    working-directory: showcase
+
+  - name: BrowserStackLocal Stop
+    uses: browserstack/github-actions/setup-local@master
+    with:
+      local-testing: stop
+    if: env.IS_MAIN_ENVIRONMENT == 1
+```
+
+## Coveralls Action
+
+This action, provided by Coveralls itself, facilitates the usage of Coveralls in a CI plan. 
+It requires a GitHub token to have a read access to the repo and, optionally, a path to lcov files.
+
+In Stark, we have the following configuration:
+
+```yaml
+- name: Coveralls
+  uses: coverallsapp/github-action@master
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    path-to-lcov: "combined-lcov.info"
+```
+
+All the information about this action can be found on [github.com/marketplace/actions/coveralls-github-action](https://github.com/marketplace/actions/coveralls-github-action).
+
+## Built-in methods
+
+### Conditional tasks
+
+Every task can be conditional in GitHub Actions, using the `if` word in the definition.
+
+For instance:
+
+```yaml
+jobs:
+  first_job:
+    # ..
+    if: github.event_name != 'schedule'
+    
+    steps:
+      - name: A conditional task
+        run: npm run lint
+        if: github.event_name == 'pull_request'
+```
+
+In this example, the job "first_job" will be executed if the build is not triggered and then
+the task running `npm run lint` will be triggered only if the build is triggered for a pull request.
+
+### Functions
+
+GitHub Actions provide some functions that can be used in the plan definition.
+The full documentation is available on [GitHub Docs](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#functions).
+
+For instance, in `if` condition, the following functions can be used:
+
+| Function name | Description | Example |
+| ------------- | ----------- | ------- |
+| contains - `contains(search, item)` | Returns `true` if `search` string contains `itemp` string | `contains(github.ref, 'dependabot')` |
+| startsWith - `startsWith(searchString, searchValue)` | Returns `true` if `searchString` starts with `searchValue` | `startsWith(github.ref, 'refs/tags/')` |
+
+### Share variable in multiple tasks
+
+Sometimes, it can be required to use a variable in multiple steps in a plan.
+
+For instance, in Stark, we define a variable `IS_MAIN_ENVIRONMENT` to trigger some logic as BrowserStack or Coveralls only once.
+To define our variable, we populate the `GITHUB_ENV` variable with the definition of our variable:
+
+```yaml
+- name: Set environment variable 'IS_MAIN_ENVIRONMENT'
+  run: |
+    if [[ '${{ matrix.node_version }}' == '10' ]] && [[ '${{ matrix.os }}' == 'ubuntu-latest' ]]; then
+      echo "IS_MAIN_ENVIRONMENT=1" >> $GITHUB_ENV
+    else
+      echo "IS_MAIN_ENVIRONMENT=0" >> $GITHUB_ENV
+    fi
+
+# ...
+
+- name: Generate docs coverage
+  run: npm run docs:travis-ci:coverage
+  if: env.IS_MAIN_ENVIRONMENT == 1
+```
+
+## Variables
+
+GitHub Actions provide a set of environment variables that can be used in build plans.
+
+In Stark, the following vars are used to build:
+
+| Variable name | Description |
+| ------------- | ----------- |
+| GITHUB_ACTIONS | Value is `true` when running in GitHub Actions CI |
+| GITHUB_EVENT_NAME | Describes event type of the build (ie: `"schedule"`, `"pull_request"`...) |
+| GITHUB_SHA | 	The commit SHA that triggered the workflow |
+| GITHUB_REF | The branch or tag ref that triggered the workflow (ie: `refs/heads/feature-branch-1`)|
+| GITHUB_REPOSITORY | The repository name for which GitHub Actions are triggered (ie: `NationalBankBelgium/Stark`) |
+| GITHUB_ACTOR | The name of the person or app that initiated the workflow |
+| secrets.GITHUB_TOKEN | GitHub token of the actor of the commit (used for push action) |
+
+
+All the information about the environment variables can be found in [official GitHub documentation](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables).
+
+Besides the Environment Variables, workflow variables can also be used. All the information can be found in [official GitHub "workflow and syntax" documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "test:ci:stark-ui": "cd packages/stark-ui && npm run test-fast:ci && cd ../..",
     "test:ci:showcase": "cd showcase && npm run test-fast:ci && cd ../..",
     "test:ci:starter": "cd starter && npm run test-fast:ci && cd ../..",
-    "test:ci:coveralls:combined": "node combine-packages-coverage.js | packages/stark-testing/node_modules/coveralls/bin/coveralls.js",
+    "test:ci:coveralls:combined": "node combine-packages-coverage.js",
     "tsc": "tsc",
     "tslint": "tslint",
     "tslint-check:all": "npm run tslint-check:stark-core && npm run tslint-check:stark-ui && npm run tslint-check:stark-rbac && npm run tslint-check:starter && npm run tslint-check:showcase",

--- a/packages/stark-build/README.md
+++ b/packages/stark-build/README.md
@@ -1,6 +1,7 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-build.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-build)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-build.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-build)
 [![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-build.svg)](https://david-dm.org/NationalBankBelgium/stark-build)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-build/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-build#info=devDependencies)
 [![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)

--- a/packages/stark-core/README.md
+++ b/packages/stark-core/README.md
@@ -1,6 +1,7 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
 [![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-core.svg)](https://david-dm.org/NationalBankBelgium/stark-core)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-core/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-core#info=devDependencies)
 [![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)

--- a/packages/stark-rbac/README.md
+++ b/packages/stark-rbac/README.md
@@ -1,6 +1,7 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-rbac.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-rbac)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-rbac.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-rbac)
 [![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-rbac.svg)](https://david-dm.org/NationalBankBelgium/stark-rbac)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-rbac/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-rbac#info=devDependencies)
 [![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)

--- a/packages/stark-testing/README.md
+++ b/packages/stark-testing/README.md
@@ -1,6 +1,7 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-testing.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-testing)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-testing.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-testing)
 [![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-testing.svg)](https://david-dm.org/NationalBankBelgium/stark-testing)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-testing/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-testing#info=devDependencies)
 [![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)

--- a/packages/stark-ui/README.md
+++ b/packages/stark-ui/README.md
@@ -1,6 +1,7 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-ui.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-ui)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-ui.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-ui)
 [![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-ui.svg)](https://david-dm.org/NationalBankBelgium/stark-ui)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-ui/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-ui#info=devDependencies)
 [![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)

--- a/scripts/ci/_ghactions-group.sh
+++ b/scripts/ci/_ghactions-group.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# private variable to track groups within this script
+ghActionsGroupStack=()
+
+GITHUB_ACTIONS=${GITHUB_ACTIONS:-}
+LOGS_FILE=${LOGS_FILE:-""}
+
+function ghActionsGroupStart() {
+  local groupName="${0#./}  ${1}"
+  # get current time as nanoseconds since the beginning of the epoch
+  groupStartTime=$(date +%s%N)
+  # convert all non alphanum chars except for "-" and "." to "--"
+  local sanitizedGroupName=${groupName//[^[:alnum:]\-\.]/--}
+  # strip trailing "-"
+  sanitizedGroupName=${sanitizedGroupName%-}
+  # push the groupName onto the stack
+  ghActionsGroupStack+=("${sanitizedGroupName}|${groupStartTime}")
+
+  echo ""
+  if [[ ${GITHUB_ACTIONS} == true ]]; then
+    echo "::group::${groupName}"
+  fi
+  local enterArrow="===>  ${groupName}  ==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>==>"
+  # keep all messages consistently wide 80chars regardless of the groupName
+  echo ${enterArrow:0:100}
+  if [[ ${2:-} != "no-xtrace" ]]; then
+    # turn on verbose mode so that we have better visibility into what's going on
+    # http://tldp.org/LDP/Bash-Beginners-Guide/html/sect_02_03.html#table_02_01
+    set -x
+  fi
+}
+
+function ghActionsGroupEnd() {
+  set +x
+  local groupName="${0#./}  ${1}"
+  # convert all non alphanum chars except for "-" and "." to "--"
+  local sanitizedGroupName=${groupName//[^[:alnum:]\-\.]/--}
+  # strip trailing "-"
+  sanitizedGroupName=${sanitizedGroupName%-}
+
+  # consult and update ghActionsGroupStack
+  local lastGroupIndex=$(expr ${#ghActionsGroupStack[@]} - 1)
+  local lastGroupString=${ghActionsGroupStack[$lastGroupIndex]}
+  # split the string by | and then turn that into an array
+  local lastGroupArray=(${lastGroupString//\|/ })
+  local lastSanitizedGroupName=${lastGroupArray[0]}
+
+  if [[ ${GITHUB_ACTIONS} == true ]]; then
+    local lastGroupStartTime=${lastGroupArray[1]}
+    local groupFinishTime=$(date +%s%N)
+    local groupDuration=$(expr ${groupFinishTime} - ${lastGroupStartTime})
+    local displayedDuration=$(echo "scale=1; ${groupDuration}/1000000000" | bc | awk '{printf "%.1f\n", $0}')
+
+    # write into build-perf.log file
+    local logIndent=$(expr ${lastGroupIndex} \* 2)
+    printf "%6ss%${logIndent}s: %s\n" ${displayedDuration} " " "${groupName}" >> ${LOGS_FILE}
+  fi
+
+  # pop
+  ghActionsGroupStack=(${ghActionsGroupStack[@]:0:lastGroupIndex})
+
+  # check for misalignment
+  if [[ ${lastSanitizedGroupName} != ${sanitizedGroupName} ]]; then
+    echo "GitHub Actions group mis-alignment detected! ghActionsGroupEnd expected sanitized fold name '${lastSanitizedGroupName}', but received '${sanitizedGroupName}' (after sanitization)"
+    exit 1
+  fi
+
+  local returnArrow="<===  ${groupName}  <==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<=="
+  # keep all messages consistently wide 80chars regardless of the groupName
+  echo ${returnArrow:0:100}
+  echo ""
+  if [[ ${GITHUB_ACTIONS} == true ]]; then
+    echo "::endgroup::"
+  fi
+}
+
+function ghActionsGroupReturnArrows() {
+  # print out return arrows so that it's easy to see the end of the script in the log
+  echo ""
+  returnArrow="<===  ${0#./}  <==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<=="
+  # keep all messages consistently wide 80chars regardless of the groupName
+  echo ${returnArrow:0:100}
+  echo "<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==<==="
+  echo ""
+}

--- a/scripts/ci/print-gh-logs.sh
+++ b/scripts/ci/print-gh-logs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -u -e -o pipefail
+
+# Setup environment
+readonly thisDir=$(cd $(dirname $0); pwd)
+source ${thisDir}/_ghactions-group.sh
+
+
+for FILE in ${LOGS_DIR}/*; do
+  ghActionsGroupStart "print log file: ${FILE}"
+    cat $FILE
+  ghActionsGroupEnd "print log file: ${FILE}"
+done
+
+# Print return arrows as a log separator
+ghActionsGroupReturnArrows

--- a/showcase/e2e/protractor.browserstack.conf.js
+++ b/showcase/e2e/protractor.browserstack.conf.js
@@ -1,8 +1,6 @@
 const browserstack = require("browserstack-local");
-const { BROWSERSTACK_USERNAME, BROWSERSTACK_ACCESS_KEY, TRAVIS_BUILD_NUMBER } = process.env;
+const { BROWSERSTACK_USERNAME, BROWSERSTACK_ACCESS_KEY, BROWSERSTACK_LOCAL_IDENTIFIER, BROWSERSTACK_PROJECT_NAME } = process.env;
 const defaultConfig = require("../node_modules/@nationalbankbelgium/stark-testing/protractor.conf.js").config;
-
-const BROWSERSTACK_LOCAL_IDENTIFIER = TRAVIS_BUILD_NUMBER ? `travis-${TRAVIS_BUILD_NUMBER}` : "local";
 
 /**
  * Specifies the different capabilities for BrowserStack.
@@ -57,40 +55,6 @@ const CAPABILITIES = [
 	}
 ];
 
-if (!BROWSERSTACK_USERNAME || !BROWSERSTACK_ACCESS_KEY) {
-	throw new Error(
-		"The environmentals 'BROWSERSTACK_USERNAME' and 'BROWSERSTACK_ACCESS_KEY' need to be set to run tests on BrowserStack."
-	);
-}
-
-/**
- * Code to start BrowserStack local before start of test.
- * @returns {Promise<void>}
- */
-const beforeLaunch = async () => {
-	console.log("Connecting to BrowserStack local...");
-
-	exports.bs_local = new browserstack.Local();
-	await new Promise((resolve, reject) =>
-		exports.bs_local.start({ key: BROWSERSTACK_ACCESS_KEY, localIdentifier: BROWSERSTACK_LOCAL_IDENTIFIER }, error =>
-			error ? reject(error) : resolve()
-		)
-	);
-
-	console.log("BrowserStack local is connected. Starting tests...");
-};
-
-/**
- * Code to stop BrowserStack local after end of test.
- * @param exitCode
- * @returns {Promise<void>}
- */
-const afterLaunch = async exitCode => {
-	console.log(`Tests finished with exit code ${exitCode}.`);
-	console.log("Stopping BrowserStack local...");
-	await new Promise(resolve => exports.bs_local.stop(resolve));
-	console.log("BrowserStack local stopped.");
-};
 
 /**
  * The config object for protractor. @see {@link https://github.com/angular/protractor/blob/master/lib/config.ts}
@@ -120,7 +84,7 @@ const config = {
 		"browserstack.networkLogs": "true",
 		"browserstack.localIdentifier": BROWSERSTACK_LOCAL_IDENTIFIER,
 
-		project: "Stark Showcase",
+		project: BROWSERSTACK_PROJECT_NAME,
 		build: BROWSERSTACK_LOCAL_IDENTIFIER
 	},
 
@@ -128,9 +92,6 @@ const config = {
 	 * Specifies all the different environments in which the tests are ran.
 	 */
 	multiCapabilities: CAPABILITIES,
-
-	beforeLaunch,
-	afterLaunch
 };
 
 exports.config = {


### PR DESCRIPTION
Set BrowserStack configuration in GitHub Actions instead of Travis-CI

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We encounter issues with Travis (especially with BrowserStack and starter).
We would like to replace Travis CI by GitHub Actions but we are not ready yet (because not fully tested).

Issue Number: N/A


## What is the new behavior?

We add GitHub Actions next to Travis and we keep all the release process in Travis (we don't break anything right now 😊)


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The result is available on my fork: https://github.com/SuperITMan/stark/runs/1983229753