### PR TITLE
ci(stark-all): temporary disable BrowserStack for Pull Requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
           username: ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           project-name: "Stark Showcase"
-        if: env.IS_MAIN_ENVIRONMENT == 1
+        if: env.IS_MAIN_ENVIRONMENT == 1 && github.event_name == 'push'
 
       - name: BrowserStack Local Tunnel Setup
         uses: browserstack/github-actions/setup-local@master
@@ -134,23 +134,23 @@ jobs:
           local-testing: "start"
           local-logging-level: "all-logs"
           local-identifier: "github-actions-${{ github.run_number }}"
-        if: env.IS_MAIN_ENVIRONMENT == 1
+        if: env.IS_MAIN_ENVIRONMENT == 1 && github.event_name == 'push'
     
       - name: Running application under test
         run: npm run server:prod:ci &
-        if: env.IS_MAIN_ENVIRONMENT == 1
+        if: env.IS_MAIN_ENVIRONMENT == 1 && github.event_name == 'push'
         working-directory: showcase
         
       - name: Running test on BrowserStack
         run: npm run protractor:browserstack
-        if: env.IS_MAIN_ENVIRONMENT == 1
+        if: env.IS_MAIN_ENVIRONMENT == 1 && github.event_name == 'push'
         working-directory: showcase
     
       - name: BrowserStackLocal Stop
         uses: browserstack/github-actions/setup-local@master
         with:
           local-testing: stop
-        if: env.IS_MAIN_ENVIRONMENT == 1
+        if: env.IS_MAIN_ENVIRONMENT == 1 && github.event_name == 'push'
         
       - name: Generate docs coverage
         run: npm run docs:travis-ci:coverage
@@ -169,8 +169,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: "combined-lcov.info"
         if: env.IS_MAIN_ENVIRONMENT == 1
-      
-      
+
   release:
     name: Release
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Secrets required to use BrowserStack actions are not accessible during build of pull request.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Actions CI does not work currently for PRs across forks. Secrets `BROWSERSTACK_ACCESS_KEY` and `BROWSERSTACK_USERNAME` are not accessible during build of a Pull Request from a fork.

Issue Number: N/A


## What is the new behavior?

Temporary disable BrowserStack check for pull request. A final solution should be implemented later.
It will probably be based on [workflow_run](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run).

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information