### PR TITLE
Fix travis npm GitHub actions links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@
 > An Angular 6+ based front-end framework built on top of [Angular](https://angular.io)...
 > Stark features an awesome reusable build using [Webpack](https://webpack.js.org/) and built-in support for state of the art front-end tech
 
-[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
-[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
-[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
-[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
-[![Coverage Status](https://coveralls.io/repos/github/NationalBankBelgium/stark/badge.svg?branch=master)](https://coveralls.io/github/NationalBankBelgium/stark?branch=master)
-[![Dependency Status](https://david-dm.org/NationalBankBelgium/stark.svg)](https://david-dm.org/NationalBankBelgium/stark)
-[![devDependency Status](https://david-dm.org/NationalBankBelgium/stark/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark#info=devDependencies)
+[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-core.svg?logo=npm&logoColor=fff&label=npm+package&color=limegreen)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
+[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-core.svg?logo=npm)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
+[![Build Status](https://img.shields.io/travis/com/NationalBankBelgium/stark.svg?branch=master&logo=travis)](https://travis-ci.com/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/build/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Abuild)
+[![Coverage Status](https://img.shields.io/coveralls/github/NationalBankBelgium/stark/master?logo=coveralls)](https://coveralls.io/github/NationalBankBelgium/stark?branch=master)
+[![Dependency Status](https://img.shields.io/david/nationalbankbelgium/stark-core)](https://david-dm.org/NationalBankBelgium/stark-core)
+[![devDependency Status](https://img.shields.io/david/dev/nationalbankbelgium/stark-core?label=devDependencies)](https://david-dm.org/NationalBankBelgium/stark-core#info=devDependencies)
 [![taylor swift](https://img.shields.io/badge/secured%20by-taylor%20swift-brightgreen.svg)](https://twitter.com/SwiftOnSecurity)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
-[![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square&logo=prettier)](https://github.com/prettier/prettier)
+[![License](https://img.shields.io/npm/l/@nationalbankbelgium/stark-core)](LICENSE)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=NationalBankBelgium/stark)](https://dependabot.com)
 [![BrowserStack Status](https://automate.browserstack.com/badge.svg?badge_key=Tm5SaUZSU2IyN3NRMUJubytEUFdrZUNSRTg1RUhoNjJSbHNFdDJGbUZ0az0tLUtza3NYT3JVdGJoNVJ1Y2Ywa3NUY2c9PQ==--f293e37574a75b6a4f37428b1ff6978c55760aa7)](https://automate.browserstack.com/public-build/Tm5SaUZSU2IyN3NRMUJubytEUFdrZUNSRTg1RUhoNjJSbHNFdDJGbUZ0az0tLUtza3NYT3JVdGJoNVJ1Y2Ywa3NUY2c9PQ==--f293e37574a75b6a4f37428b1ff6978c55760aa7)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
-[![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
 [![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Coverage Status](https://coveralls.io/repos/github/NationalBankBelgium/stark/badge.svg?branch=master)](https://coveralls.io/github/NationalBankBelgium/stark?branch=master)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark.svg)](https://david-dm.org/NationalBankBelgium/stark)
@@ -147,16 +147,15 @@ We're supported by [Jetbrains](https://www.jetbrains.com) and their awesome [sup
 
 ### Travis
 
-We're supported by [Travis](https://travis-ci.org/)
+We're supported by [Travis](https://travis-ci.com/)
 
-<a href="https://travis-ci.org/"><img src="https://travis-ci.com/images/logos/TravisCI-Full-Color.png" width="144px"></a>
+<a href="https://travis-ci.com/"><img src="https://travis-ci.com/images/logos/TravisCI-Full-Color.png" width="144px"></a>
 
 ### GitHub Actions
 
 We're supported by [GitHub Actions](https://github.com/features/actions)
 
 <a href="https://github.com/features/actions"><img src="https://github.githubassets.com/images/modules/site/features/actions-icon-actions.svg" width="144px"></a>
-
 
 ### BrowserStack
 

--- a/packages/stark-build/README.md
+++ b/packages/stark-build/README.md
@@ -1,6 +1,6 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-build.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-build)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-build.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-build)
-[![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
 [![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-build.svg)](https://david-dm.org/NationalBankBelgium/stark-build)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-build/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-build#info=devDependencies)

--- a/packages/stark-build/README.md
+++ b/packages/stark-build/README.md
@@ -1,10 +1,10 @@
-[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-build.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-build)
-[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-build.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-build)
-[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
-[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
-[![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-build.svg)](https://david-dm.org/NationalBankBelgium/stark-build)
-[![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-build/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-build#info=devDependencies)
-[![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)
+[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-build.svg?logo=npm&logoColor=fff&label=npm+package&color=limegreen)](https://www.npmjs.com/package/@nationalbankbelgium/stark-build)
+[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-build.svg?logo=npm)](https://www.npmjs.com/package/@nationalbankbelgium/stark-build)
+[![Build Status](https://img.shields.io/travis/com/NationalBankBelgium/stark.svg?branch=master&logo=travis)](https://travis-ci.com/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/build/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Abuild)
+[![Dependency Status](https://img.shields.io/david/nationalbankbelgium/stark-build)](https://david-dm.org/NationalBankBelgium/stark-build)
+[![devDependency Status](https://img.shields.io/david/dev/nationalbankbelgium/stark-build?label=devDependencies)](https://david-dm.org/NationalBankBelgium/stark-build#info=devDependencies)
+[![License](https://img.shields.io/npm/l/@nationalbankbelgium/stark-build)](LICENSE)
 
 # Stark Build
 

--- a/packages/stark-core/README.md
+++ b/packages/stark-core/README.md
@@ -1,6 +1,6 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
-[![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
 [![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-core.svg)](https://david-dm.org/NationalBankBelgium/stark-core)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-core/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-core#info=devDependencies)

--- a/packages/stark-core/README.md
+++ b/packages/stark-core/README.md
@@ -1,10 +1,10 @@
-[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
-[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-core.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
-[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
-[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
-[![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-core.svg)](https://david-dm.org/NationalBankBelgium/stark-core)
-[![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-core/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-core#info=devDependencies)
-[![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)
+[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-core.svg?logo=npm&logoColor=fff&label=npm+package&color=limegreen)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
+[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-core.svg?logo=npm)](https://www.npmjs.com/package/@nationalbankbelgium/stark-core)
+[![Build Status](https://img.shields.io/travis/com/NationalBankBelgium/stark.svg?branch=master&logo=travis)](https://travis-ci.com/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/build/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Abuild)
+[![Dependency Status](https://img.shields.io/david/nationalbankbelgium/stark-core)](https://david-dm.org/NationalBankBelgium/stark-core)
+[![devDependency Status](https://img.shields.io/david/dev/nationalbankbelgium/stark-core?label=devDependencies)](https://david-dm.org/NationalBankBelgium/stark-core#info=devDependencies)
+[![License](https://img.shields.io/npm/l/@nationalbankbelgium/stark-core)](LICENSE)
 
 # Stark Core
 

--- a/packages/stark-rbac/README.md
+++ b/packages/stark-rbac/README.md
@@ -1,10 +1,10 @@
-[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-rbac.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-rbac)
-[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-rbac.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-rbac)
-[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
-[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
-[![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-rbac.svg)](https://david-dm.org/NationalBankBelgium/stark-rbac)
-[![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-rbac/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-rbac#info=devDependencies)
-[![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)
+[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-rbac.svg?logo=npm&logoColor=fff&label=npm+package&color=limegreen)](https://www.npmjs.com/package/@nationalbankbelgium/stark-rbac)
+[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-rbac.svg?logo=npm)](https://www.npmjs.com/package/@nationalbankbelgium/stark-rbac)
+[![Build Status](https://img.shields.io/travis/com/NationalBankBelgium/stark.svg?branch=master&logo=travis)](https://travis-ci.com/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/build/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Abuild)
+[![Dependency Status](https://img.shields.io/david/nationalbankbelgium/stark-rbac)](https://david-dm.org/NationalBankBelgium/stark-rbac)
+[![devDependency Status](https://img.shields.io/david/dev/nationalbankbelgium/stark-rbac?label=devDependencies)](https://david-dm.org/NationalBankBelgium/stark-rbac#info=devDependencies)
+[![License](https://img.shields.io/npm/l/@nationalbankbelgium/stark-rbac)](LICENSE)
 
 # Stark RBAC
 

--- a/packages/stark-rbac/README.md
+++ b/packages/stark-rbac/README.md
@@ -1,6 +1,6 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-rbac.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-rbac)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-rbac.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-rbac)
-[![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
 [![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-rbac.svg)](https://david-dm.org/NationalBankBelgium/stark-rbac)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-rbac/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-rbac#info=devDependencies)

--- a/packages/stark-testing/README.md
+++ b/packages/stark-testing/README.md
@@ -1,6 +1,6 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-testing.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-testing)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-testing.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-testing)
-[![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
 [![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-testing.svg)](https://david-dm.org/NationalBankBelgium/stark-testing)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-testing/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-testing#info=devDependencies)

--- a/packages/stark-testing/README.md
+++ b/packages/stark-testing/README.md
@@ -1,10 +1,10 @@
-[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-testing.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-testing)
-[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-testing.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-testing)
-[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
-[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
-[![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-testing.svg)](https://david-dm.org/NationalBankBelgium/stark-testing)
-[![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-testing/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-testing#info=devDependencies)
-[![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)
+[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-testing.svg?logo=npm&logoColor=fff&label=npm+package&color=limegreen)](https://www.npmjs.com/package/@nationalbankbelgium/stark-testing)
+[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-testing.svg?logo=npm)](https://www.npmjs.com/package/@nationalbankbelgium/stark-testing)
+[![Build Status](https://img.shields.io/travis/com/NationalBankBelgium/stark.svg?branch=master&logo=travis)](https://travis-ci.com/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/build/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Abuild)
+[![Dependency Status](https://img.shields.io/david/nationalbankbelgium/stark-testing)](https://david-dm.org/NationalBankBelgium/stark-testing)
+[![devDependency Status](https://img.shields.io/david/dev/nationalbankbelgium/stark-testing?label=devDependencies)](https://david-dm.org/NationalBankBelgium/stark-testing#info=devDependencies)
+[![License](https://img.shields.io/npm/l/@nationalbankbelgium/stark-testing)](LICENSE)
 
 # Stark Testing
 

--- a/packages/stark-ui/README.md
+++ b/packages/stark-ui/README.md
@@ -1,6 +1,6 @@
 [![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-ui.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-ui)
 [![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-ui.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-ui)
-[![Build Status](https://travis-ci.org/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.org/NationalBankBelgium/stark)
+[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
 [![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
 [![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-ui.svg)](https://david-dm.org/NationalBankBelgium/stark-ui)
 [![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-ui/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-ui#info=devDependencies)

--- a/packages/stark-ui/README.md
+++ b/packages/stark-ui/README.md
@@ -1,10 +1,10 @@
-[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-ui.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-ui)
-[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-ui.svg)](https://www.npmjs.com/package/@nationalbankbelgium/stark-ui)
-[![Build Status](https://api.travis-ci.com/NationalBankBelgium/stark.svg?branch=master)](https://travis-ci.com/NationalBankBelgium/stark)
-[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/ci/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Aci)
-[![Dependency Status](https://david-dm.org/NationalBankBelgium/stark-ui.svg)](https://david-dm.org/NationalBankBelgium/stark-ui)
-[![devDependency Status](https://david-dm.org/NationalBankBelgium/stark-ui/dev-status.svg)](https://david-dm.org/NationalBankBelgium/stark-ui#info=devDependencies)
-[![License](https://img.shields.io/cocoapods/l/AFNetworking.svg)](LICENSE)
+[![NPM version](https://img.shields.io/npm/v/@nationalbankbelgium/stark-ui.svg?logo=npm&logoColor=fff&label=npm+package&color=limegreen)](https://www.npmjs.com/package/@nationalbankbelgium/stark-ui)
+[![npm](https://img.shields.io/npm/dm/@nationalbankbelgium/stark-ui.svg?logo=npm)](https://www.npmjs.com/package/@nationalbankbelgium/stark-ui)
+[![Build Status](https://img.shields.io/travis/com/NationalBankBelgium/stark.svg?branch=master&logo=travis)](https://travis-ci.com/NationalBankBelgium/stark)
+[![Build Status](https://github.com/NationalBankBelgium/stark/workflows/build/badge.svg)](https://github.com/NationalBankBelgium/stark/actions?query=workflow%3Abuild)
+[![Dependency Status](https://img.shields.io/david/nationalbankbelgium/stark-ui)](https://david-dm.org/NationalBankBelgium/stark-ui)
+[![devDependency Status](https://img.shields.io/david/dev/nationalbankbelgium/stark-ui?label=devDependencies)](https://david-dm.org/NationalBankBelgium/stark-ui#info=devDependencies)
+[![License](https://img.shields.io/npm/l/@nationalbankbelgium/stark-ui)](LICENSE)
 
 # Stark UI
 

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -152,7 +152,7 @@ groupings trying to match Angular concepts:
 |   .prettierignore                     # files and directories to be excluded by prettier
 |   .prettierrc.js                      # prettier configuration file
 |   .stylelintrc                        # stylelint configuration file
-|   .travis.yml                         # YAML file to customize the Travis build (https://travis-ci.org/)
+|   .travis.yml                         # YAML file to customize the Travis build (https://travis-ci.com/)
 |   angular.json                        # Angular configuration file
 |   base.spec.ts                        # initializes the test environment
 |   Dockerfile                          # the commands that will be executed by the Docker Build command

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -377,7 +377,7 @@ and [docker](https://www.docker.com/) and thats all - any other software is not 
 
 ##### MacOS:
 
-`brew cask install docker`
+`brew install --cask docker`
 
 And run docker by Mac bottom menu> launchpad > docker (on first run docker will ask you about password)
 

--- a/starter/README.md
+++ b/starter/README.md
@@ -152,7 +152,7 @@ groupings trying to match Angular concepts:
 |   .prettierignore                     # files and directories to be excluded by prettier
 |   .prettierrc.js                      # prettier configuration file
 |   .stylelintrc                        # stylelint configuration file
-|   .travis.yml                         # YAML file to customize the Travis build (https://travis-ci.org/)
+|   .travis.yml                         # YAML file to customize the Travis build (https://travis-ci.com/)
 |   angular.json                        # Angular configuration file
 |   base.spec.ts                        # initializes the test environment
 |   Dockerfile                          # the commands that will be executed by the Docker Build command

--- a/starter/README.md
+++ b/starter/README.md
@@ -377,7 +377,7 @@ and [docker](https://www.docker.com/) and thats all - any other software is not 
 
 ##### MacOS:
 
-`brew cask install docker`
+`brew install --cask docker`
 
 And run docker by Mac bottom menu> launchpad > docker (on first run docker will ask you about password)
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[X] Other... Please describe: README changes
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Travis-ci links points to travis-ci.org (old) instead of travis-ci.com (new).

ALso, David-dm platform seems not stable and often, we have the following icons appearing in README file:
<img width="168" alt="image" src="https://user-images.githubusercontent.com/10333565/109878224-e7f6fb00-7c6b-11eb-8383-d02690a685a1.png">

<img width="196" alt="image" src="https://user-images.githubusercontent.com/10333565/109878241-f218f980-7c6b-11eb-87b7-880b251ac868.png">

## What is the new behavior?

Adapted travis-ci URLs to use travis-ci.com

Using shields.io icons instead of travis-ci and david-dm ones 😊 

<img width="166" alt="image" src="https://user-images.githubusercontent.com/10333565/109878670-7d928a80-7c6c-11eb-8f60-011377b356de.png">

<img width="189" alt="image" src="https://user-images.githubusercontent.com/10333565/109878706-87b48900-7c6c-11eb-8357-39a1af737c68.png">

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

It comes with more colored badges 👍 