### PR TITLE
fix(stark-core): fix "class-validator" dependency to version ~0.11.0

### DIFF
--- a/packages/stark-core/package-lock.json
+++ b/packages/stark-core/package-lock.json
@@ -43,15 +43,15 @@
       }
     },
     "@types/jasmine": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.6.4.tgz",
-      "integrity": "sha512-CTdMERA4iGNcxeqzD7pavb4WLIFq6bGnx6nIJD+1D4Knx24GE6QBPrWVhO8UlIy7gf7rbIt3ZD7iIzryRD2TgA==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.6.6.tgz",
+      "integrity": "sha512-kgl+oYOLCBt41iba8cetp+QPOqDAaTJnHtVPCE7JzYmda4juglRBLX35opVcANc7TLA/Lp0DEnajbUNnyxGC+Q==",
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.165",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
-      "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
     },
     "@types/lodash-es": {
       "version": "4.17.4",
@@ -62,15 +62,20 @@
       }
     },
     "@types/node": {
-      "version": "10.17.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
-      "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ==",
+      "version": "10.17.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.55.tgz",
+      "integrity": "sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg==",
       "dev": true
     },
     "@types/uuid": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
       "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
+    },
+    "@types/validator": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.3.tgz",
+      "integrity": "sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w=="
     },
     "@uirouter/angular": {
       "version": "5.0.0",
@@ -82,9 +87,9 @@
       }
     },
     "@uirouter/core": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-6.0.6.tgz",
-      "integrity": "sha512-+i1iNaPQRp1JoEnxi4EsTX30bSvkWtPEenENWdvdIzX615Q3WCWwnbW9DtrwX9gSD5qmWEaQEtGMU0uF3qJ+1g=="
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-6.0.7.tgz",
+      "integrity": "sha512-KUTJxL+6q0PiBnFx4/Z+Hsyg0pSGiaW5yZQeJmUxknecjpTbnXkLU8H2EqRn9N2B+qDRa7Jg8RcgeNDPY72O1w=="
     },
     "@uirouter/rx": {
       "version": "0.6.5",
@@ -100,12 +105,13 @@
       }
     },
     "class-validator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.9.1.tgz",
-      "integrity": "sha512-3wApflrd3ywVZyx4jaasGoFt8pmo4aGLPPAEKCKCsTRWVGPilahD88q3jQjRQwja50rl9a7rsP5LAxJYwGK8/Q==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.11.1.tgz",
+      "integrity": "sha512-6CGdjwJLmKw+sQbK5ZDo1v1yTajkqfPOUDWSYVIlhUiCh6Phy8sAnMFE2XKHAcKAdoOz4jJUQhjPQWPYUuHxrA==",
       "requires": {
+        "@types/validator": "10.11.3",
         "google-libphonenumber": "^3.1.6",
-        "validator": "10.4.0"
+        "validator": "12.0.0"
       }
     },
     "deep-freeze-strict": {
@@ -114,9 +120,9 @@
       "integrity": "sha1-d9BYPKJKab5LvZrC+uQV1VUj5bA="
     },
     "google-libphonenumber": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz",
-      "integrity": "sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw=="
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.18.tgz",
+      "integrity": "sha512-6u+PF7Nf6TXMUNekHxc7pO6iE9PI1n2/q+z80GzFckH5riSKn4K1EeFimA5UqHA4MpxgKHYsVpcj8YDq32ob9g=="
     },
     "ibantools": {
       "version": "3.2.3",
@@ -134,9 +140,9 @@
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "typescript": {
       "version": "2.9.2",
@@ -149,9 +155,9 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "validator": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.4.0.tgz",
-      "integrity": "sha512-Q/wBy3LB1uOyssgNlXSRmaf22NxjvDNZM2MtIQ4jaEOAB61xsh1TQxsq1CgzUMBV1lDrVMogIh8GjG1DYW0zLg=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-12.0.0.tgz",
+      "integrity": "sha512-r5zA1cQBEOgYlesRmSEwc9LkbfNLTtji+vWyaHzRZUxCTHdsX3bd+sdHfs5tGZ2W6ILGGsxWxCNwT/h3IY/3ng=="
     }
   }
 }

--- a/packages/stark-core/package.json
+++ b/packages/stark-core/package.json
@@ -29,7 +29,7 @@
     "@types/uuid": "^3.4.9",
     "@uirouter/angular": "^5.0.0",
     "cerialize": "^0.1.18",
-    "class-validator": "^0.9.1",
+    "class-validator": "~0.11.0",
     "deep-freeze-strict": "^1.1.1",
     "ibantools": "^3.2.3",
     "lodash-es": "^4.17.21",


### PR DESCRIPTION
class-validator > 0.12.0 contains some breaking changes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

stark-core is using `"class-validator": "^0.9.1"`, meaning is currently using the version 0.13.0 which contains some breaking changes.


## What is the new behavior?

"class-validator" dependency is fixed to version "0.11.0" which does not contain important breaking changes.
"class-validator" will be updated to the latest version, currently 0.13.0, in Stark 11. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information