### PR TITLE
refactor(stark-all): remove custom "typecheck" rule in tslint configuration after code-style upgrade

### DIFF
--- a/packages/stark-core/tslint.json
+++ b/packages/stark-core/tslint.json
@@ -31,7 +31,6 @@
       }
     ],
     "use-component-view-encapsulation": false,
-    "use-injectable-provided-in": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"]
+    "use-injectable-provided-in": false
   }
 }

--- a/packages/stark-rbac/tslint.json
+++ b/packages/stark-rbac/tslint.json
@@ -31,7 +31,6 @@
       }
     ],
     "no-host-metadata-property": false,
-    "use-injectable-provided-in": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"]
+    "use-injectable-provided-in": false
   }
 }

--- a/packages/stark-ui/tslint.json
+++ b/packages/stark-ui/tslint.json
@@ -32,7 +32,6 @@
     ],
     "use-component-view-encapsulation": false,
     "no-host-metadata-property": false,
-    "use-injectable-provided-in": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"]
+    "use-injectable-provided-in": false
   }
 }

--- a/showcase/tslint.json
+++ b/showcase/tslint.json
@@ -7,7 +7,6 @@
     "tslint-config-prettier"
   ],
   "rules": {
-    "component-selector": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"]
+    "component-selector": false
   }
 }

--- a/starter/package.json
+++ b/starter/package.json
@@ -126,7 +126,7 @@
     "@angular/platform-browser-dynamic": "^8.2.0",
     "@angular/platform-server": "^8.2.0",
     "@angular/router": "^8.2.0",
-    "@nationalbankbelgium/code-style": "^1.4.0",
+    "@nationalbankbelgium/code-style": "^1.5.0",
     "@nationalbankbelgium/stark-core": "latest",
     "@nationalbankbelgium/stark-ui": "latest",
     "@uirouter/visualizer": "~7.2.1",

--- a/starter/tslint.json
+++ b/starter/tslint.json
@@ -7,7 +7,6 @@
     "tslint-config-prettier"
   ],
   "rules": {
-    "component-selector": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"]
+    "component-selector": false
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have the following custom "typecheck" rule in tslint config of all modules in Stark. 

```
"typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"]
```

## What is the new behavior?

Due to code-style upgrade (v1.5.0), the custom rule has been removed in favor of the default one in code-style library:
```
"typedef": [true, "call-signature", "parameter",  "property-declaration"]
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information