### PR TITLE
fix(stark-core): add support for http 204 status code when persisting logs

### DIFF
--- a/packages/stark-core/src/modules/logging/services/logging.service.ts
+++ b/packages/stark-core/src/modules/logging/services/logging.service.ts
@@ -183,11 +183,15 @@ export class StarkLoggingServiceImpl implements StarkLoggingService {
 
 		const emitXhrResult = (xhrRequest: XMLHttpRequest): void => {
 			if (xhrRequest.readyState === XMLHttpRequest.DONE) {
-				if (xhrRequest.status === StarkHttpStatusCodes.HTTP_200_OK || xhrRequest.status === StarkHttpStatusCodes.HTTP_201_CREATED) {
-					httpRequest$.next();
-					httpRequest$.complete();
-				} else {
-					httpRequest$.error(xhrRequest.status);
+				switch (xhrRequest.status) {
+					case StarkHttpStatusCodes.HTTP_200_OK:
+					case StarkHttpStatusCodes.HTTP_201_CREATED:
+					case StarkHttpStatusCodes.HTTP_204_NO_CONTENT:
+						httpRequest$.next();
+						httpRequest$.complete();
+						break;
+					default:
+						httpRequest$.error(xhrRequest.status);
 				}
 			}
 		};


### PR DESCRIPTION
As Stark does not use returned body when persisting logs, there is no need to force the backend
to send a 201 status code. The 204 status code should be accepted when no content is received.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When persisting logs, Stark does not use response body. For utility resources as logging, Stark should accept 204 http status code in response.


## What is the new behavior?

Stark logging service accept http 204 "no content" status code. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information