### PR TITLE
ci(stark-all): increase max PR number that Dependabot can create

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,74 +1,74 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@angular/*"
-    versions:
-    - ">=8"
-  - dependency-name: "@angular-builders/*"
-    versions:
-    - ">=8"
-  - dependency-name: "@angular-devkit/build-ng-packagr"
-    versions:
-    - ">=0.800"
-  - dependency-name: "@angular-devkit/build-angular"
-    versions:
-    - ">=0.800"
-  - dependency-name: "@mdi/angular-material"
-    versions:
-    - ">=5"
-  - dependency-name: "@uirouter/angular"
-    versions:
-    - ">=6"
-  - dependency-name: typescript
-    versions:
-    - ">= 0"
-  - dependency-name: "@types/node"
-    versions:
-    - ">=11"
-  commit-message:
-    prefix: chore
-    include: scope
-- package-ecosystem: npm
-  directory: "/showcase"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@angular/*"
-    versions:
-    - ">=8"
-  - dependency-name: typescript
-    versions:
-    - ">= 0"
-  - dependency-name: "@types/node"
-    versions:
-    - ">=11"
-  commit-message:
-    prefix: chore
-    include: scope
-- package-ecosystem: npm
-  directory: "/starter"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@angular/*"
-    versions:
-    - ">=8"
-  - dependency-name: typescript
-    versions:
-    - ">= 0"
-  - dependency-name: "@types/node"
-    versions:
-    - ">=11"
-  commit-message:
-    prefix: chore
-    include: scope
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 40
+    ignore:
+      - dependency-name: "@angular/*"
+        versions:
+          - ">=8"
+      - dependency-name: "@angular-builders/*"
+        versions:
+          - ">=8"
+      - dependency-name: "@angular-devkit/build-ng-packagr"
+        versions:
+          - ">=0.800"
+      - dependency-name: "@angular-devkit/build-angular"
+        versions:
+          - ">=0.800"
+      - dependency-name: "@mdi/angular-material"
+        versions:
+          - ">=5"
+      - dependency-name: "@uirouter/angular"
+        versions:
+          - ">=6"
+      - dependency-name: typescript
+        versions:
+          - ">= 0"
+      - dependency-name: "@types/node"
+        versions:
+          - ">=11"
+    commit-message:
+      prefix: chore
+      include: scope
+  - package-ecosystem: npm
+    directory: "/showcase"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@angular/*"
+        versions:
+          - ">=8"
+      - dependency-name: typescript
+        versions:
+          - ">= 0"
+      - dependency-name: "@types/node"
+        versions:
+          - ">=11"
+    commit-message:
+      prefix: chore
+      include: scope
+  - package-ecosystem: npm
+    directory: "/starter"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@angular/*"
+        versions:
+          - ">=8"
+      - dependency-name: typescript
+        versions:
+          - ">= 0"
+      - dependency-name: "@types/node"
+        versions:
+          - ">=11"
+    commit-message:
+      prefix: chore
+      include: scope


### PR DESCRIPTION
Due to centralization of dependencies into root folder and no longer in packages/stark-* folders,
the max number of PRs should be increased to accept enough PRs for root dependencies.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Dependabot cannot create enough PRs for root folder after centralization of dependencies into root folder.


## What is the new behavior?

Dependabot can create 40 PRs in parallel for root folder

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information