### PR TITLE
fix(stark-ui): fix `ViewDestroyedError` issue linked to formControl usage

### DIFF
--- a/packages/stark-ui/src/modules/date-picker/components/date-picker.component.ts
+++ b/packages/stark-ui/src/modules/date-picker/components/date-picker.component.ts
@@ -229,7 +229,6 @@ export class StarkDatePickerComponent
 			this._value = value;
 			this.stateChanges.next();
 		}
-		this.cdRef.detectChanges();
 	}
 
 	/**

--- a/packages/stark-ui/src/modules/date-time-picker/components/date-time-picker.component.ts
+++ b/packages/stark-ui/src/modules/date-time-picker/components/date-time-picker.component.ts
@@ -134,7 +134,6 @@ export class StarkDateTimePickerComponent extends AbstractStarkUiComponent
 			});
 		}
 		this._value = value;
-		this.cdRef.detectChanges(); // to refresh all the validations in the internal date picker
 		this.stateChanges.next();
 	}
 


### PR DESCRIPTION
Modifying formControl value after destroying `stark-date-picker` or `stark-datetime-picker`
components triggers the following error:
  `Error: ViewDestroyedError: Attempt to use a destroyed view: detectChanges`

ISSUES CLOSED: #2874

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2874


## What is the new behavior?

Stop calling `cdRef.detectChanges()` in `set value()` methods in date-picker and date-time-picker components.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information