### PR TITLE
ci(release): stop publishing docs in 10.2.x branch during release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,10 +220,11 @@ jobs:
           npm run install:ci:stark-rbac
           npm run install:ci:stark-ui
         if: github.event_name != 'schedule'
-        
-      - name: Generate docs
-        run: npm run docs:publish -- --github-api-key=${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name != 'schedule'
+      
+      # Don't publish docs in maintenance branches  
+      # - name: Generate docs
+      #  run: npm run docs:publish -- --github-api-key=${{ secrets.GITHUB_TOKEN }}
+      #  if: github.event_name != 'schedule'
         
       - name: Set npm token
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Releasing a new 10.2.x version of Stark does not work due to an issue with docs generation in CI.

## What is the new behavior?

Releasing a new 10.2.x version of Stark does no longer generate docs.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information