### PR TITLE
ci(build-main): mark macos runners as experimental and allow failures on these runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,21 @@ jobs:
   build-and-test:
     name: Build and test on Node.js ${{ matrix.node_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         node_version: ["12", "14"]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest]
+        experimental: [false]
+        # Mark following configurations as "experimental" and allow to continue in case of error
+        # See documentation: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations 
+        include:
+          - os: macos-latest
+            node_version: 12
+            experimental: true
+          - os: macos-latest
+            node_version: 14
+            experimental: true
 
     steps:
       # Some actions should be executed only in one environment.


### PR DESCRIPTION
 ISSUES CLOSED: #2902

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2902


## What is the new behavior?

Allow failures in macos build workflow 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information