### PR TITLE
test(showcase): remove `withContext()` usage in showcase e2e test

### DIFF
--- a/showcase/e2e/src/app.e2e-spec.ts
+++ b/showcase/e2e/src/app.e2e-spec.ts
@@ -13,6 +13,6 @@ describe("General tests:", () => {
 
 	it("should have stark logo", () => {
 		const subject: ElementFinder = element(by.css(".stark-app-bar stark-app-logo"));
-		expect(subject.isPresent()).withContext("Unable to find logo").toBeTruthy();
+		expect(subject.isPresent()).toBeTruthy("Unable to find logo");
 	});
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Protractor tests are failing due to `withContext()` usage which is recommended by jasmine.

See information regarding the support of Selenium 4 and jasmine 3 in Protractor: https://github.com/angular/protractor/pull/5516


## What is the new behavior?

Remove `withContext()` usage in showcase e2e test to fix the BrowserStack tests

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information