### PR TITLE
feat(stark-core): add support for `httpOnly` cookie in `StarkXSRFService`

### DIFF
--- a/packages/stark-core/src/modules/xsrf/services/xsrf-config.intf.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf-config.intf.ts
@@ -32,4 +32,12 @@ export interface StarkXSRFConfig {
 	 * Alternatively, this can be defined as a {@link StarkXSRFWaitBeforePingingLiteral|literal}
 	 */
 	waitBeforePinging?: (() => Promise<any> | PromiseLike<any> | Observable<any>) | StarkXSRFWaitBeforePingingLiteral;
+
+	/**
+	 * Defines if the XSRF cookie can be overridden or not.
+	 * If `httpOnly` is set to `true`, the `StarkXSRFService` reads the cookie value for each http request.
+	 *
+	 * Default: `false`
+	 */
+	httpOnly?: boolean;
 }

--- a/packages/stark-core/src/modules/xsrf/services/xsrf.service.spec.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf.service.spec.ts
@@ -183,6 +183,48 @@ describe("Service: StarkXSRFService", () => {
 	});
 
 	describe("getXSRFToken", () => {
+		describe("with `httpOnly === true`", () => {
+			beforeEach(() => {
+				mockXsrfConfig = {
+					httpOnly: true
+				};
+
+				xsrfService = new StarkXSRFServiceHelper(
+					appConfig,
+					mockLogger,
+					httpMock,
+					<any>mockDocument,
+					mockInjectorService,
+					mockXsrfConfig
+				);
+			});
+
+			it("should return the XSRF token in case there is one already stored in cookie", () => {
+				const expectedToken = "dummy xsrf cookie token";
+				xsrfService.setCurrentToken(mockXSRFToken);
+				spyOn(xsrfService, "getXSRFCookie").and.returnValue(expectedToken);
+
+				const xsrfToken: string = <string>xsrfService.getXSRFToken();
+
+				expect(xsrfToken).toBe(expectedToken);
+				expect(xsrfService.getXSRFCookie).toHaveBeenCalledTimes(1);
+				expect(mockLogger.warn).not.toHaveBeenCalled();
+			});
+
+			it("should return undefined and log a warning in case there is no XSRF token yet", () => {
+				xsrfService.setCurrentToken(mockXSRFToken);
+				spyOn(xsrfService, "getXSRFCookie").and.returnValue(undefined);
+
+				const xsrfToken: undefined = <undefined>xsrfService.getXSRFToken();
+
+				expect(xsrfToken).toBeUndefined();
+				expect(xsrfService.getXSRFCookie).toHaveBeenCalledTimes(1);
+				expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+				const warningMessage: string = mockLogger.warn.calls.argsFor(0)[0];
+				expect(warningMessage).toContain("no XSRF token found");
+			});
+		});
+
 		it("should return the XSRF token in case there is one already stored", () => {
 			xsrfService.setCurrentToken(mockXSRFToken);
 
@@ -262,6 +304,30 @@ describe("Service: StarkXSRFService", () => {
 			expect(cookieOptions[0]).toBe(xsrfService.getXsrfCookieName() + "=" + mockXSRFToken);
 			expect(cookieOptions[1]).toBe("path='/'");
 			expect(cookieOptions[2]).toMatch(new RegExp(`expires=.*(${new Date().getFullYear()})`));
+		});
+
+		it("should not overwrite the XSRF cookie by the XSRF token that is already stored if `httpOnly !== true`", () => {
+			mockXsrfConfig = {
+				httpOnly: true
+			};
+
+			xsrfService = new StarkXSRFServiceHelper(
+				appConfig,
+				mockLogger,
+				httpMock,
+				<any>mockDocument,
+				mockInjectorService,
+				mockXsrfConfig
+			);
+
+			xsrfService.setCurrentToken(mockXSRFToken);
+			spyOn(xsrfService, "setXSRFCookie").and.callThrough();
+			spyOn(xsrfService, "getXSRFCookie").and.callThrough();
+
+			xsrfService.storeXSRFToken();
+
+			expect(xsrfService.setXSRFCookie).not.toHaveBeenCalled();
+			expect(xsrfService.getXSRFCookie).not.toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
Add `httpOnly` property in `StarkXSRFConfig` that can be passed to `StarkXSRFModule.forRoot()`

ISSUES CLOSED: #3136

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3136

## What is the new behavior?

Add support for `httpOnly` cookie thanks to the new `httpOnly` property in `StarkXSRFConfig`

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information