### PR TITLE
feat(stark-core): add support for `httpOnly` cookie in `StarkXSRFService`

### DIFF
--- a/packages/stark-core/src/modules/xsrf/services/xsrf-config.intf.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf-config.intf.ts
@@ -32,4 +32,12 @@ export interface StarkXSRFConfig {
 	 * Alternatively, this can be defined as a {@link StarkXSRFWaitBeforePingingLiteral|literal}
 	 */
 	waitBeforePinging?: (() => Promise<any> | PromiseLike<any> | Observable<any>) | StarkXSRFWaitBeforePingingLiteral;
+
+	/**
+	 * Defines if the XSRF cookie can be overridden or not.
+	 * If `httpOnly` is set to `true`, the `StarkXSRFService` reads the cookie value for each http request.
+	 *
+	 * Default: `false`
+	 */
+	httpOnly?: boolean;
 }

--- a/packages/stark-core/src/modules/xsrf/services/xsrf.service.spec.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf.service.spec.ts
@@ -183,6 +183,48 @@ describe("Service: StarkXSRFService", () => {
 	});
 
 	describe("getXSRFToken", () => {
+		describe("with `httpOnly === true`", () => {
+			beforeEach(() => {
+				mockXsrfConfig = {
+					httpOnly: true
+				};
+
+				xsrfService = new StarkXSRFServiceHelper(
+					appConfig,
+					mockLogger,
+					httpMock,
+					<any>mockDocument,
+					mockInjectorService,
+					mockXsrfConfig
+				);
+			});
+
+			it("should return the XSRF token in case there is one already stored in cookie", () => {
+				const expectedToken = "dummy xsrf cookie token";
+				xsrfService.setCurrentToken(mockXSRFToken);
+				spyOn(xsrfService, "getXSRFCookie").and.returnValue(expectedToken);
+
+				const xsrfToken: string = <string>xsrfService.getXSRFToken();
+
+				expect(xsrfToken).toBe(expectedToken);
+				expect(xsrfService.getXSRFCookie).toHaveBeenCalledTimes(1);
+				expect(mockLogger.warn).not.toHaveBeenCalled();
+			});
+
+			it("should return undefined and log a warning in case there is no XSRF token yet", () => {
+				xsrfService.setCurrentToken(mockXSRFToken);
+				spyOn(xsrfService, "getXSRFCookie").and.returnValue(undefined);
+
+				const xsrfToken: undefined = <undefined>xsrfService.getXSRFToken();
+
+				expect(xsrfToken).toBeUndefined();
+				expect(xsrfService.getXSRFCookie).toHaveBeenCalledTimes(1);
+				expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+				const warningMessage: string = mockLogger.warn.calls.argsFor(0)[0];
+				expect(warningMessage).toContain("no XSRF token found");
+			});
+		});
+
 		it("should return the XSRF token in case there is one already stored", () => {
 			xsrfService.setCurrentToken(mockXSRFToken);
 
@@ -262,6 +304,30 @@ describe("Service: StarkXSRFService", () => {
 			expect(cookieOptions[0]).toBe(xsrfService.getXsrfCookieName() + "=" + mockXSRFToken);
 			expect(cookieOptions[1]).toBe("path='/'");
 			expect(cookieOptions[2]).toMatch(new RegExp(`expires=.*(${new Date().getFullYear()})`));
+		});
+
+		it("should not overwrite the XSRF cookie by the XSRF token that is already stored if `httpOnly !== true`", () => {
+			mockXsrfConfig = {
+				httpOnly: true
+			};
+
+			xsrfService = new StarkXSRFServiceHelper(
+				appConfig,
+				mockLogger,
+				httpMock,
+				<any>mockDocument,
+				mockInjectorService,
+				mockXsrfConfig
+			);
+
+			xsrfService.setCurrentToken(mockXSRFToken);
+			spyOn(xsrfService, "setXSRFCookie").and.callThrough();
+			spyOn(xsrfService, "getXSRFCookie").and.callThrough();
+
+			xsrfService.storeXSRFToken();
+
+			expect(xsrfService.setXSRFCookie).not.toHaveBeenCalled();
+			expect(xsrfService.getXSRFCookie).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/stark-core/src/modules/xsrf/services/xsrf.service.ts
+++ b/packages/stark-core/src/modules/xsrf/services/xsrf.service.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:completed-docs*/
+/* tslint:disable:completed-docs */
 import { Inject, Injectable, Injector } from "@angular/core";
 import { DOCUMENT } from "@angular/common";
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpRequest } from "@angular/common/http";
@@ -88,34 +88,50 @@ export class StarkXSRFServiceImpl implements StarkXSRFService {
 	}
 
 	public getXSRFToken(): string | undefined {
-		const xsrfToken: string | undefined = this.currentToken;
+		let errorMsg: string =
+			starkXSRFServiceName +
+			": no XSRF token found. This could be due to:\n" +
+			"- the backend has not sent the XSRF token properly, either the cookie was not sent or it has a different name";
 
-		if (typeof xsrfToken === "undefined") {
-			const errorMsg: string =
-				starkXSRFServiceName +
-				": no XSRF token found. This could be due to:\n" +
-				"- the backend has not sent the XSRF token properly, either the cookie was not sent or it has a different name\n" +
-				"- the application did not store the XSRF token correctly, either it has a different name or it comes from a different origin";
+		let xsrfToken: string | undefined;
 
-			this.logger.warn(errorMsg);
-			// could throw an error: throw new Error(errorMsg);
+		if (!!this.configOptions && this.configOptions.httpOnly === true) {
+			xsrfToken = this.getXSRFCookie();
+
+			if (typeof xsrfToken === "undefined") {
+				this.logger.warn(errorMsg);
+				// could throw an error: throw new Error(errorMsg);
+			}
 		} else {
-			// overwrite the cookie with the current token to ensure that we always send the same token
-			// regardless of the new tokens sent by the backend(s) in every response
-			this.setXSRFCookie(xsrfToken);
+			xsrfToken = this.currentToken;
+
+			if (typeof xsrfToken === "undefined") {
+				errorMsg +=
+					"\n" +
+					"- the application did not store the XSRF token correctly, either it has a different name or it comes from a different origin";
+
+				this.logger.warn(errorMsg);
+				// could throw an error: throw new Error(errorMsg);
+			} else {
+				// overwrite the cookie with the current token to ensure that we always send the same token
+				// regardless of the new tokens sent by the backend(s) in every response
+				this.setXSRFCookie(xsrfToken);
+			}
 		}
 
 		return xsrfToken;
 	}
 
 	public storeXSRFToken(): void {
-		if (this.currentToken) {
-			// overwrite the cookie with the token we stored (we don't care about the rest of tokens but just the one we stored)
-			this.setXSRFCookie(this.currentToken);
-		} else {
-			// store the token only if it is not stored yet
-			const xsrfCookie: string | undefined = this.getXSRFCookie();
-			this.currentToken = xsrfCookie && xsrfCookie !== "" ? xsrfCookie : undefined;
+		if (!this.configOptions || this.configOptions.httpOnly !== true) {
+			if (this.currentToken) {
+				// overwrite the cookie with the token we stored (we don't care about the rest of tokens but just the one we stored)
+				this.setXSRFCookie(this.currentToken);
+			} else {
+				// store the token only if it is not stored yet
+				const xsrfCookie: string | undefined = this.getXSRFCookie();
+				this.currentToken = xsrfCookie && xsrfCookie !== "" ? xsrfCookie : undefined;
+			}
 		}
 	}
 


### PR DESCRIPTION
Add `httpOnly` property in `StarkXSRFConfig` that can be passed to `StarkXSRFModule.forRoot()`

ISSUES CLOSED: #3136

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3136

## What is the new behavior?

Add support for `httpOnly` cookie thanks to the new `httpOnly` property in `StarkXSRFConfig`

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information