### PR TITLE
ci(stark-all): fix dependabot-sync-stark-dependencies workflow with `--no-verify` argument

### DIFF
--- a/.github/workflows/dependabot-sync-stark-dependencies.yml
+++ b/.github/workflows/dependabot-sync-stark-dependencies.yml
@@ -91,7 +91,7 @@ jobs:
           cd showcase
           npm install --package-lock-only --ignore-scripts
           git add package-lock.json
-          git commit -m 'chore(showcase): update "package-lock.json" file'
+          git commit -m 'chore(showcase): update "package-lock.json" file' --no-verify
 
       - name: Push changes
         if: contains(steps.sync-packages-dependencies.outputs.LAST_COMMIT, '/packages/stark-')


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Dependabot PRs are failing due to broken "dependabot-sync-stark-dependencies" workflow.


## What is the new behavior?

"dependabot-sync-stark-dependencies" workflow commits now with `--no-verify` argument in order to bypass issue.

Since the workflow simply updates the package.json and package-lock.json files, it is not necessary to run the checks when committing in the workflow.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information