### PR TITLE
fix(build-main): fix `npm run commit` script in order to fix the usage on Windows OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "clean:modules:stark-ui": "cd packages/stark-ui && npm run clean:modules dist && cd ../..",
     "clean:modules:showcase": "cd showcase && npm run clean:modules && cd ..",
     "clean:modules:starter": "cd starter && npm run clean:modules && cd ..",
-    "commit": "./node_modules/.bin/git-cz",
+    "commit": "cz",
     "docs": "npm run docs:clean && npm run docs:all",
     "docs:all": "npm run docs:stark-core:generate && npm run docs:stark-ui:generate && npm run docs:stark-rbac:generate && npm run docs:starter:generate",
     "docs:clean": "npx rimraf reports/api-docs",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Cannot use `npm run commit` command on Windows. 

```shell
$ npm run commit

> stark-srcr@10.2.0 commit
> ./node_modules/.bin/git-cz

'.' is not recognized as an internal or external command,
operable program or batch file.
```

## What is the new behavior?

Can use `npm run commit` command on Windows, Mac and Linux

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information