### PR TITLE
fix(stark-ui): table column filter positioning

### DIFF
--- a/packages/stark-ui/src/modules/table/components/table.component.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.ts
@@ -1033,11 +1033,11 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 	 */
 	public getColumnFilterPosition(columnName: string): StarkTableColumnFilter["filterPosition"] {
 		if (!(this.filter.columns instanceof Array)) {
-			return undefined;
+			return this.filter.filterPosition;
 		}
 
 		const column = this.filter.columns.find((columnFilter: StarkTableColumnFilter) => columnFilter.columnName === columnName);
-		return column ? column.filterPosition : undefined;
+		return column ? column.filterPosition : this.filter.filterPosition;
 	}
 
 	/**


### PR DESCRIPTION
When definining the ´filterPosition´ on ´StarkTableFilter´ there was not used in the table
Now the ´filterPosition´is used.
ISSUES CLOSED: #3428

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3428 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information