### PR TITLE
ci(build-main): disable failing MacOS runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,21 +24,10 @@ jobs:
   build-and-test:
     name: Build and test on Node.js ${{ matrix.node_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         node_version: ["12", "14"]
         os: [ubuntu-latest]
-        experimental: [false]
-        # Mark following configurations as "experimental" and allow to continue in case of error
-        # See documentation: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations 
-        include:
-          - os: macos-latest
-            node_version: 12
-            experimental: true
-          - os: macos-latest
-            node_version: 14
-            experimental: true
 
     steps:
       # Some actions should be executed only in one environment.
@@ -67,7 +56,7 @@ jobs:
         env:
           cache-name: cache-node-modules-${{ matrix.node_version }}-${{ matrix.os }}
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
+          # npm cache files are stored in `~/.npm` on Linux
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |


### PR DESCRIPTION
MacOS jobs are always failing due to a GitHub limitation when downloading the GeckoDriver from GitHub for `Protractor`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

All the plans running on macos runners are failing due to a download, by Protractor, of GeckoDriver on GitHub.
It hits an API rate limit of GitHub: https://github.com/actions/runner-images/issues/602


## What is the new behavior?

We can easily see if a PR is ok if no failed jobs.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information