### PR TITLE
feat(stark-ui): add logout button on the Session Timeout Warning dialog

### DIFF
--- a/packages/stark-ui/src/modules/session-ui/assets/translations/en.ts
+++ b/packages/stark-ui/src/modules/session-ui/assets/translations/en.ts
@@ -24,6 +24,7 @@ export const translationsEn: object = {
 			LOGIN: "Log in again"
 		},
 		SESSION_TIMEOUT: {
+			CLOSE_SESSION: "Logout",
 			SECONDS: " seconds.",
 			STAY_CONNECTED: "Stay connected",
 			TITLE: "Session about to expire",

--- a/packages/stark-ui/src/modules/session-ui/assets/translations/fr.ts
+++ b/packages/stark-ui/src/modules/session-ui/assets/translations/fr.ts
@@ -24,6 +24,7 @@ export const translationsFr: object = {
 			LOGIN: "Connexion"
 		},
 		SESSION_TIMEOUT: {
+			CLOSE_SESSION: "Se déconnecter",
 			SECONDS: " secondes.",
 			STAY_CONNECTED: "Rester connecté",
 			TITLE: "Session sur le point d'expirer",

--- a/packages/stark-ui/src/modules/session-ui/assets/translations/nl.ts
+++ b/packages/stark-ui/src/modules/session-ui/assets/translations/nl.ts
@@ -24,6 +24,7 @@ export const translationsNl: object = {
 			LOGIN: "Opnieuw aanmelden"
 		},
 		SESSION_TIMEOUT: {
+			CLOSE_SESSION: "Afmelden",
 			SECONDS: " seconden vervallen.",
 			STAY_CONNECTED: "Blijf verbonden",
 			TITLE: "Sessie verlopen",

--- a/packages/stark-ui/src/modules/session-ui/components/session-timeout-warning-dialog/session-timeout-warning-dialog.component.html
+++ b/packages/stark-ui/src/modules/session-ui/components/session-timeout-warning-dialog/session-timeout-warning-dialog.component.html
@@ -11,5 +11,8 @@
 		<button mat-raised-button color="primary" (click)="keepSession()" aria-label="Close Dialog">
 			<span translate>STARK.SESSION_TIMEOUT.STAY_CONNECTED</span>
 		</button>
+		<button mat-raised-button (click)="closeSession()" aria-label="Close Dialog">
+			<span translate>STARK.SESSION_TIMEOUT.CLOSE_SESSION</span>
+		</button>
 	</div>
 </div>

--- a/packages/stark-ui/src/modules/session-ui/components/session-timeout-warning-dialog/session-timeout-warning-dialog.component.spec.ts
+++ b/packages/stark-ui/src/modules/session-ui/components/session-timeout-warning-dialog/session-timeout-warning-dialog.component.spec.ts
@@ -66,4 +66,14 @@ describe("SessionTimeoutWarningDialogComponent", () => {
 			expect(mockDialogRef.close).toHaveBeenCalledWith("keep-logged");
 		}));
 	});
+
+	describe("closeSession", () => {
+		it("should close the windows when the button is clicked", fakeAsync(() => {
+			component.ngOnInit();
+			component.closeSession();
+
+			expect(mockDialogRef.close).toHaveBeenCalledTimes(1);
+			expect(mockDialogRef.close).toHaveBeenCalledWith("close-session");
+		}));
+	});
 });

--- a/packages/stark-ui/src/modules/session-ui/components/session-timeout-warning-dialog/session-timeout-warning-dialog.component.ts
+++ b/packages/stark-ui/src/modules/session-ui/components/session-timeout-warning-dialog/session-timeout-warning-dialog.component.ts
@@ -59,4 +59,11 @@ export class StarkSessionTimeoutWarningDialogComponent implements OnInit {
 	public keepSession(): void {
 		this.dialogRef.close("keep-logged");
 	}
+
+	/**
+	 * This methods is used to close the dialog and to send an answer indicating that the user sould loggoff.
+	 */
+	public closeSession(): void {
+		this.dialogRef.close("close-session");
+	}
 }

--- a/packages/stark-ui/src/modules/session-ui/effects/session-timeout-warning.effects.ts
+++ b/packages/stark-ui/src/modules/session-ui/effects/session-timeout-warning.effects.ts
@@ -55,8 +55,12 @@ export class StarkSessionTimeoutWarningDialogEffects implements OnRunEffects {
 					})
 					.afterClosed()
 					.subscribe((result: string) => {
-						if (result && result === "keep-logged") {
-							this.sessionService.resumeUserActivityTracking();
+						if (result) {
+							if (result === "keep-logged") {
+								this.sessionService.resumeUserActivityTracking();
+							} else if (result === "close-session") {
+								this.sessionService.logout();
+							}
 						}
 					});
 			})


### PR DESCRIPTION
ISSUES CLOSED: #1731

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1731


## What is the new behavior?
A logout button is added on the waring time out popup

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information