### PR TITLE
fix(stark-ui): add word-break to stark-toast

### DIFF
--- a/packages/stark-ui/src/modules/toast-notification/components/_toast-notification.component.scss
+++ b/packages/stark-ui/src/modules/toast-notification/components/_toast-notification.component.scss
@@ -7,6 +7,7 @@
   min-height: 0;
   display: flex;
   white-space: normal;
+  word-break: break-word;
   align-items: center;
   padding: 6px 16px 6px 16px;
 


### PR DESCRIPTION
ISSUES CLOSED: #3519

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3519 


## What is the new behavior?

add css break-word for long text displayed in the toast text box


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information