### PR TITLE
feat(stark-ui): keep highlight the menu when go to child state

### DIFF
--- a/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.ts
+++ b/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.ts
@@ -203,6 +203,9 @@ export class StarkAppMenuItemComponent extends AbstractStarkUiComponent implemen
 	 * Utility function to check if the component targetState is the current state
 	 */
 	public isCurrentState(): boolean {
+		if(!this.menuGroup.entries) {
+			return this.menuGroup.targetState ? this.routingService.isCurrentUiStateIncludedIn(this.menuGroup.targetState): false;
+		}
 		return this.menuGroup.targetState ? this.routingService.isCurrentUiState(this.menuGroup.targetState) : false;
 	}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When navigate to a child state that is not in the menu, the menu is not highlighted any more.

Issue Number:  #3521 


## What is the new behavior?

Check if the current state is a child state of the menu element if the menu element do not have child menu

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information