### PR TITLE
feat(stark-ui): keep highlight the menu when go to child state

### DIFF
--- a/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.spec.ts
+++ b/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.spec.ts
@@ -64,12 +64,15 @@ describe("AppMenuItemComponent", () => {
 	 * Synchronous beforeEach
 	 */
 	beforeEach(() => {
+		mockRoutingService.addTransitionHook.calls.reset();
 		hostFixture = TestBed.createComponent(TestHostComponent);
 		hostComponent = hostFixture.componentInstance;
 		hostComponent.level = 1;
 		hostFixture.detectChanges();
 		component = hostComponent.starkAppMenuItem;
 		mockRoutingService.navigateTo.calls.reset();
+		mockRoutingService.isCurrentUiStateIncludedIn.calls.reset();
+		mockRoutingService.isCurrentUiState.calls.reset();
 	});
 
 	describe("simple menu item", () => {
@@ -142,6 +145,17 @@ describe("AppMenuItemComponent", () => {
 
 			expect(component.deactivated.emit).toHaveBeenCalledTimes(1);
 		});
+
+		it("should activate when child state is selected and do not have child menu", () => {
+			hostFixture.detectChanges();
+			// `stateChange` is attached to `routingTransitionSuccessCallback` in `StarkAppMenuItemComponent`
+			const stateChange = <() => void>mockRoutingService.addTransitionHook.calls.first().args[2];
+			mockRoutingService.isCurrentUiStateIncludedIn.withArgs("test").and.returnValue(true);
+			stateChange();
+			expect(component.isActive).toBeTrue();
+			expect(mockRoutingService.isCurrentUiStateIncludedIn).toHaveBeenCalledWith("test");
+			expect(mockRoutingService.isCurrentUiState).not.toHaveBeenCalledWith("test");
+		});
 	});
 
 	describe("menu item with children", () => {
@@ -168,6 +182,17 @@ describe("AppMenuItemComponent", () => {
 		it("should have an expansion panel", () => {
 			const expansionPanel: HTMLElement = hostFixture.nativeElement.querySelector(".mat-expansion-panel");
 			expect(expansionPanel).toBeDefined();
+		});
+
+		it("should not activate when child state is selected and do not have child menu", () => {
+			hostFixture.detectChanges();
+			// `stateChange` is attached to `routingTransitionSuccessCallback` in `StarkAppMenuItemComponent`
+			const stateChange = <() => void>mockRoutingService.addTransitionHook.calls.first().args[2];
+			mockRoutingService.isCurrentUiState.withArgs("test").and.returnValue(false);
+			stateChange();
+			expect(component.isActive).toBeFalse();
+			expect(mockRoutingService.isCurrentUiStateIncludedIn).not.toHaveBeenCalledWith("test");
+			expect(mockRoutingService.isCurrentUiState).toHaveBeenCalledWith("test");
 		});
 	});
 });

--- a/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.ts
+++ b/packages/stark-ui/src/modules/app-menu/components/app-menu-item.component.ts
@@ -203,6 +203,9 @@ export class StarkAppMenuItemComponent extends AbstractStarkUiComponent implemen
 	 * Utility function to check if the component targetState is the current state
 	 */
 	public isCurrentState(): boolean {
+		if (!this.menuGroup.entries) {
+			return this.menuGroup.targetState ? this.routingService.isCurrentUiStateIncludedIn(this.menuGroup.targetState) : false;
+		}
 		return this.menuGroup.targetState ? this.routingService.isCurrentUiState(this.menuGroup.targetState) : false;
 	}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When navigate to a child state that is not in the menu, the menu is not highlighted any more.

Issue Number:  #3521 


## What is the new behavior?

Check if the current state is a child state of the menu element if the menu element do not have child menu

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information