### PR TITLE
fix(stark-ui): multi-sorting on stark-table not working after sorting…

### DIFF
--- a/packages/stark-ui/src/modules/table/components/table.component.ts
+++ b/packages/stark-ui/src/modules/table/components/table.component.ts
@@ -864,22 +864,23 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 	 */
 	public onReorderChange(column: StarkColumnSortChangedOutput): void {
 		if (column.sortable) {
-			this.resetSorting(column);
 			const sortedColumn = find(this.columns, { name: column.name });
 			if (sortedColumn) {
 				sortedColumn.sortPriority = 1;
 				switch (column.sortDirection) {
 					case "asc":
-						sortedColumn.sortDirection = "desc";
+						this.orderProperties = ["-" + sortedColumn.name];
 						break;
 					case "desc":
-						sortedColumn.sortDirection = "";
+						this.orderProperties = [];
 						break;
 					default:
-						sortedColumn.sortDirection = "asc";
+						this.orderProperties = [sortedColumn.name];
 						break;
 				}
 			}
+			this.isMultiSorting = false;
+			this.cdRef.detectChanges();
 			this.sortData();
 		}
 	}
@@ -919,6 +920,7 @@ export class StarkTableComponent extends AbstractStarkUiComponent implements OnI
 				}
 
 				this.orderProperties = newOrderProperties; // enforcing immutability :)
+				this.isMultiSorting = this.orderProperties.length > 1;
 				this.cdRef.detectChanges(); // needed due to ChangeDetectionStrategy.OnPush in order to refresh the columns
 
 				this.sortData();


### PR DESCRIPTION
… on single field

Fix the issue using the chnageDetection strategy.

ISSUES CLOSED: #3580

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The sort icon did not update when closing the dialog

Issue Number:
#3580


## What is the new behavior?
The sort icon did not update when closing the dialog

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information