### PR TITLE
build(build-main): add a timestamp to the name of the packages that are generated locally

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -146,6 +146,11 @@ fi
 if [[ ${GH_ACTIONS_TAG} == "" ]]; then
   logTrace "Setting the version suffix to the latest commit hash" 1
   VERSION_SUFFIX="-$(git log --oneline -1 | awk '{print $1}')" # last commit id
+  
+  # Locally, we need to ensure the generated tgz file is different for each build
+  if [[ ${GITHUB_ACTIONS} != true ]]; then
+    VERSION_SUFFIX="${VERSION_SUFFIX}-$(date +%s)"
+  fi
 else
   logTrace "Build executed for a tag. Not using a version suffix!" 1
   VERSION_SUFFIX="" # no suffix


### PR DESCRIPTION


Previously, a similar tgz filename with the last commit hash was generated for each build. Due to migration to npm v7, we encountered issues when installing new bundled stark packages. npm v7 automatically installed the previous cached version instead of installing new generated tgz file

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Previously, a similar tgz filename with the last commit hash was generated for each build. 
Due to migration to npm v7, we encountered issues when installing new bundled stark packages. npm v7 automatically installed the previous cached version instead of installing new generated tgz file


Issue Number: N/A


## What is the new behavior?

a timestamp is added in the file name localy


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information