### PR TITLE
ci(build-main): fix install of stark deps in release stage of the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,13 +251,8 @@ jobs:
           name: showcase-dist
           path: showcase/dist
 
-      - name: Install Stark packages dependencies
-        run: |
-          npm ci
-          npm run install:ci:stark-build
-          npm run install:ci:stark-core
-          npm run install:ci:stark-rbac
-          npm run install:ci:stark-ui
+      - name: Install Stark dependencies
+        run: npm ci
         if: github.event_name != 'schedule'
 
       - name: Generate docs


### PR DESCRIPTION
Remove old stark install scripts that are no longer valid.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The release stage triggers the following removed scripts:
```bash
npm run install:ci:stark-build
npm run install:ci:stark-core
npm run install:ci:stark-rbac
npm run install:ci:stark-ui
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The release stage has been adapted to no longer use these install scripts.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
