### PR TITLE
ci(build-main): fix git user information in gh-deploy.sh script

### DIFF
--- a/gh-deploy.sh
+++ b/gh-deploy.sh
@@ -193,12 +193,6 @@ fi
 
 logTrace "Version for which we are producing docs: ${DOCS_VERSION}"
 
-if [[ ${GITHUB_ACTIONS} == true ]]; then
-    logTrace "Configuring Git for GitHub Actions"
-    git config user.name ${COMMIT_AUTHOR_USERNAME}
-    git config user.email ${COMMIT_AUTHOR_EMAIL}
-fi
-
 if [[ ${GH_ACTIONS_TAG} =~ .*-(alpha|beta|rc).* ]]; then
     logTrace "This is a pre-release version, we will publish the docs under the 'next' folder"
     LATEST_DIR_NAME="next"
@@ -263,6 +257,13 @@ logInfo "Pushing the docs to GitHub pages"
 
 cd ${DOCS_WORK_DIR}
 git add -A &> /dev/null # way too long
+
+if [[ ${GITHUB_ACTIONS} == true ]]; then
+    logTrace "Configuring Git for GitHub Actions"
+    git config user.name ${COMMIT_AUTHOR_USERNAME}
+    git config user.email ${COMMIT_AUTHOR_EMAIL}
+fi
+
 git commit --quiet -m "Publishing docs for version: ${DOCS_VERSION}"
 git push --quiet --force
 cd - > /dev/null


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Git user configuration is not applied in the repository cloned in the gh-deploy.sh script.
No commit can be done by the script because of the missing user's git configuration.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The condition to define the user's git configuration has been moved in the cloned repository folder.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
