### PR TITLE
Refactor/remove ngcli defaultproject usage

### DIFF
--- a/packages/stark-build/config/build-utils.js
+++ b/packages/stark-build/config/build-utils.js
@@ -1,9 +1,3 @@
-const ts = require("typescript");
-const path = require("path");
-const fs = require("fs");
-const os = require("os");
-const crypto = require("crypto");
-
 const helpers = require("./helpers");
 const ngCliUtils = require("./ng-cli-utils");
 
@@ -22,95 +16,6 @@ const ANGULAR_APP_CONFIG = {
 	serveOptions: angularCliAppConfig.architect.serve.options || {},
 	serveConfigurations: angularCliAppConfig.architect.serve.configurations || {}
 };
-
-function supportES2015(tsConfigPath) {
-	if (!supportES2015.hasOwnProperty("supportES2015")) {
-		const tsTarget = readTsConfig(tsConfigPath).options.target;
-		supportES2015["supportES2015"] = tsTarget !== ts.ScriptTarget.ES3 && tsTarget !== ts.ScriptTarget.ES5;
-	}
-	return supportES2015["supportES2015"];
-}
-
-function readTsConfig(tsConfigPath) {
-	const configResult = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
-	return ts.parseJsonConfigFileContent(configResult.config, ts.sys, path.dirname(tsConfigPath), undefined, tsConfigPath);
-}
-
-/**
- * Read the content of angular.json to get the path of the environment file.
- * It returns the path of the replacement file defined in "fileReplacements" of the environment or the default file
- * in case the replacement file does not exist.
- *
- * See: https://github.com/angular/angular-cli/wiki/angular-workspace
- *
- * @param environment
- * @returns {string} - The path of the environment file of the given environment.
- */
-function getEnvironmentFile(environment) {
-	if (typeof environment === "string") {
-		let fileName = helpers.root("src/environments/environment.ts");
-		let fileNameAlt;
-
-		// the production config is under "production" section instead of "prod" in angular.json
-		// see https://github.com/angular/angular-cli/wiki/stories-application-environments
-		if (environment === "prod") {
-			environment = "production";
-		}
-
-		let angularCliEnvConfig = ANGULAR_APP_CONFIG.config.architect.build.configurations[environment];
-
-		if (angularCliEnvConfig && angularCliEnvConfig.fileReplacements instanceof Array) {
-			for (let fileReplacement of angularCliEnvConfig.fileReplacements) {
-				if (fileReplacement.replace.match(/environment/)) {
-					fileName = helpers.root(angularCliEnvConfig.fileReplacements[0].with);
-					fileNameAlt = helpers.root(angularCliEnvConfig.fileReplacements[0].replace);
-				}
-			}
-		} else {
-			// for "dev" environment the default environment.ts file is used
-			if (environment !== "dev") {
-				throw new Error(
-					`Configuration for '${environment}' not found in angular.json or it contains invalid fileReplacements section.`
-				);
-			}
-		}
-
-		if (fs.existsSync(fileName)) {
-			return fileName;
-		} else if (fs.existsSync(fileNameAlt)) {
-			console.warn(`Could not find environment file for '${environment}', loading default environment file`);
-			return fileNameAlt;
-		} else {
-			throw new Error("Environment file not found.");
-		}
-	}
-}
-
-/**
- * Gets the value at `path` of `object`. If the resolved value is
- * `undefined`, the `defaultValue` is returned in its place.
- *
- * @param {Object} obj The object to query.
- * @param {string|Array} path The path of the property to get.
- * @param {*} [defaultValue] The value returned for `undefined` resolved values.
- * @returns {*} Returns the resolved value.
- */
-function get(obj, path, defaultValue) {
-	let args;
-	if (typeof path === "string") {
-		args = path.split(".");
-	} else {
-		args = path;
-	}
-
-	for (let i = 0; i < args.length; i++) {
-		if (!obj || !obj.hasOwnProperty(args[i])) {
-			return defaultValue;
-		}
-		obj = obj[args[i]];
-	}
-	return obj;
-}
 
 /**
  * Based on "angular.json" file, gets the value for the `property` in specified `environment` in build configuration.
@@ -153,7 +58,3 @@ function getAngularWorkspaceServeProperty(property, environment) {
 exports.ANGULAR_APP_CONFIG = ANGULAR_APP_CONFIG;
 exports.getAngularWorkspaceBuildProperty = getAngularWorkspaceBuildProperty;
 exports.getAngularWorkspaceServeProperty = getAngularWorkspaceServeProperty;
-exports.getEnvironmentFile = getEnvironmentFile;
-exports.readTsConfig = readTsConfig;
-exports.supportES2015 = supportES2015;
-exports.get = get;

--- a/packages/stark-build/config/build-utils.js
+++ b/packages/stark-build/config/build-utils.js
@@ -1,60 +1,65 @@
 const helpers = require("./helpers");
 const ngCliUtils = require("./ng-cli-utils");
 
-const angularCliAppConfig = ngCliUtils.getAngularCliAppConfig(helpers.root("angular.json"));
+class StarkBuildUtils {
+	angularCliAppConfig;
+	ANGULAR_APP_CONFIG;
 
-// default values for baseHref and deployUrl are taken from
-// node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/styles.js
-const ANGULAR_APP_CONFIG = {
-	config: angularCliAppConfig,
-	deployUrl: angularCliAppConfig.architect.build.options.deployUrl || "",
-	baseHref: angularCliAppConfig.architect.build.options.baseHref || "",
-	sourceRoot: angularCliAppConfig.sourceRoot,
-	outputPath: angularCliAppConfig.architect.build.options.outputPath,
-	buildOptions: angularCliAppConfig.architect.build.options || {},
-	buildConfigurations: angularCliAppConfig.architect.build.configurations || {},
-	serveOptions: angularCliAppConfig.architect.serve.options || {},
-	serveConfigurations: angularCliAppConfig.architect.serve.configurations || {}
-};
+	constructor(projectId) {
+		this.angularCliAppConfig = ngCliUtils.getAngularCliAppConfig(helpers.root("angular.json"), projectId);
 
-/**
- * Based on "angular.json" file, gets the value for the `property` in specified `environment` in build configuration.
- * If there is no definition in the `environment`, fallback gets default value in build configuration.
- *
- * @param {string} property The property name
- * @param {string} environment The environment (usually "production" or "development")
- * @returns {*} Returns the value related to the property
- */
-function getAngularWorkspaceBuildProperty(property, environment) {
-	if (
-		typeof ANGULAR_APP_CONFIG.buildConfigurations[environment] !== "undefined" &&
-		typeof ANGULAR_APP_CONFIG.buildConfigurations[environment][property] !== "undefined"
-	) {
-		return ANGULAR_APP_CONFIG.buildConfigurations[environment][property];
-	} else {
-		return ANGULAR_APP_CONFIG.buildOptions[property];
+		// default values for baseHref and deployUrl are taken from
+		// node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/styles.js
+		this.ANGULAR_APP_CONFIG = {
+			config: this.angularCliAppConfig,
+			deployUrl: this.angularCliAppConfig.architect.build.options.deployUrl || "",
+			baseHref: this.angularCliAppConfig.architect.build.options.baseHref || "",
+			sourceRoot: this.angularCliAppConfig.sourceRoot,
+			outputPath: this.angularCliAppConfig.architect.build.options.outputPath,
+			buildOptions: this.angularCliAppConfig.architect.build.options || {},
+			buildConfigurations: this.angularCliAppConfig.architect.build.configurations || {},
+			serveOptions: this.angularCliAppConfig.architect.serve.options || {},
+			serveConfigurations: this.angularCliAppConfig.architect.serve.configurations || {}
+		};
+	}
+
+	/**
+	 * Based on "angular.json" file, gets the value for the `property` in specified `environment` in build configuration.
+	 * If there is no definition in the `environment`, fallback gets default value in build configuration.
+	 *
+	 * @param {string} property The property name
+	 * @param {string} environment The environment (usually "production" or "development")
+	 * @returns {*} Returns the value related to the property
+	 */
+	getAngularWorkspaceBuildProperty(property, environment) {
+		if (
+			typeof this.ANGULAR_APP_CONFIG.buildConfigurations[environment] !== "undefined" &&
+			typeof this.ANGULAR_APP_CONFIG.buildConfigurations[environment][property] !== "undefined"
+		) {
+			return this.ANGULAR_APP_CONFIG.buildConfigurations[environment][property];
+		} else {
+			return this.ANGULAR_APP_CONFIG.buildOptions[property];
+		}
+	}
+
+	/**
+	 * Based on "angular.json" file, gets the value for the `property` in specified `environment` in serve configuration.
+	 * If there is no definition in the `environment`, fallback gets default value in serve configuration.
+	 *
+	 * @param {string} property The property name
+	 * @param {string} environment The environment (usually "production" or "development")
+	 * @returns {*} Returns the value related to the property
+	 */
+	getAngularWorkspaceServeProperty(property, environment) {
+		if (
+			typeof this.ANGULAR_APP_CONFIG.serveConfigurations[environment] !== "undefined" &&
+			typeof this.ANGULAR_APP_CONFIG.serveConfigurations[environment][property] !== "undefined"
+		) {
+			return this.ANGULAR_APP_CONFIG.serveConfigurations[environment][property];
+		} else {
+			return this.ANGULAR_APP_CONFIG.serveOptions[property];
+		}
 	}
 }
 
-/**
- * Based on "angular.json" file, gets the value for the `property` in specified `environment` in serve configuration.
- * If there is no definition in the `environment`, fallback gets default value in serve configuration.
- *
- * @param {string} property The property name
- * @param {string} environment The environment (usually "production" or "development")
- * @returns {*} Returns the value related to the property
- */
-function getAngularWorkspaceServeProperty(property, environment) {
-	if (
-		typeof ANGULAR_APP_CONFIG.serveConfigurations[environment] !== "undefined" &&
-		typeof ANGULAR_APP_CONFIG.serveConfigurations[environment][property] !== "undefined"
-	) {
-		return ANGULAR_APP_CONFIG.serveConfigurations[environment][property];
-	} else {
-		return ANGULAR_APP_CONFIG.serveOptions[property];
-	}
-}
-
-exports.ANGULAR_APP_CONFIG = ANGULAR_APP_CONFIG;
-exports.getAngularWorkspaceBuildProperty = getAngularWorkspaceBuildProperty;
-exports.getAngularWorkspaceServeProperty = getAngularWorkspaceServeProperty;
+exports.StarkBuildUtils = StarkBuildUtils;

--- a/packages/stark-build/config/index-html.transform.js
+++ b/packages/stark-build/config/index-html.transform.js
@@ -2,7 +2,8 @@ const helpers = require("./helpers");
 const fs = require("fs");
 const commonData = require("./common-data.js"); // common configuration between environments
 const HtmlHeadElements = require("./html-head-elements");
-const METADATA = require("./webpack-metadata").METADATA;
+const getMetadata = require("./webpack-metadata").getMetadata;
+let METADATA;
 
 /**
  * Check if one or more placeholders are present in the generated "index.html" and replace them
@@ -48,6 +49,7 @@ function replacePlaceholdersByValues(indexHtml) {
 module.exports = (targetOptions, indexHtml) => {
 	let indexHtmlToReturn = indexHtml;
 
+	METADATA = getMetadata(targetOptions.project);
 	/**
 	 * Generate html tags based on javascript maps.
 	 *

--- a/packages/stark-build/config/ng-cli-utils.js
+++ b/packages/stark-build/config/ng-cli-utils.js
@@ -1,15 +1,15 @@
 const fs = require("fs");
 
-function getAngularCliAppConfig(angularCliAppConfigPath) {
+function getAngularCliAppConfig(angularCliAppConfigPath, projectId) {
 	if (fs.existsSync(angularCliAppConfigPath)) {
 		const angularCliConfig = require(angularCliAppConfigPath);
 		const cliConfig = validateAngularCLIConfig(angularCliConfig);
 		if (cliConfig) {
-			if (cliConfig.defaultProject && cliConfig.projects[cliConfig.defaultProject]) {
-				return cliConfig.projects[cliConfig.defaultProject];
+			if (typeof projectId === "string" && cliConfig.projects[projectId]) {
+				return cliConfig.projects[projectId];
 			} else {
 				throw new Error(
-					"The configuration of the default project in angular.json is wrong. Please adapt it to follow Angular CLI guidelines."
+					`The configuration of the ${projectId} project in angular.json doesn't exit. Please adapt it to follow Angular CLI guidelines.`
 				);
 			}
 		} else {

--- a/packages/stark-build/config/ng-cli-utils.js
+++ b/packages/stark-build/config/ng-cli-utils.js
@@ -1,18 +1,4 @@
-const path = require("path");
 const fs = require("fs");
-const cliUtilConfig = require("@angular/cli/utilities/config");
-
-function isDirectory(pathToCheck) {
-	try {
-		return fs.statSync(pathToCheck).isDirectory();
-	} catch (_) {
-		return false;
-	}
-}
-
-function getDirectoriesNames(source) {
-	return fs.readdirSync(source).filter((name) => isDirectory(path.join(source, name)));
-}
 
 function getAngularCliAppConfig(angularCliAppConfigPath) {
 	if (fs.existsSync(angularCliAppConfigPath)) {
@@ -64,10 +50,6 @@ function getNgCliAction() {
 	return stringifiedArgs.match(cliActionRegex)[1];
 }
 
-function getWorkspace() {
-	return cliUtilConfig.getWorkspace();
-}
-
 function hasNgCliCommandOption(option) {
 	const stringifiedArgs = process.argv.join(" ");
 	/**
@@ -110,10 +92,7 @@ function getNgCliCommandOption(option) {
 }
 
 exports.getAngularCliAppConfig = getAngularCliAppConfig;
-exports.getDirectoriesNames = getDirectoriesNames;
-exports.getWorkspace = getWorkspace;
 exports.getNgCliAction = getNgCliAction;
 exports.getNgCliCommandOption = getNgCliCommandOption;
 exports.hasNgCliCommandOption = hasNgCliCommandOption;
-exports.isDirectory = isDirectory;
 exports.validateAngularCLIConfig = validateAngularCLIConfig;

--- a/packages/stark-build/config/webpack-metadata.js
+++ b/packages/stark-build/config/webpack-metadata.js
@@ -1,45 +1,47 @@
 // Helpers
 const helpers = require("./helpers");
 const ngCliUtils = require("./ng-cli-utils");
-const buildUtils = require("./build-utils");
+const StarkBuildUtils = require("./build-utils").StarkBuildUtils;
 
-const isProd =
-	ngCliUtils.hasNgCliCommandOption("prod") ||
-	ngCliUtils.getNgCliCommandOption("c") === "production" ||
-	ngCliUtils.getNgCliCommandOption("configuration") === "production";
-const configENV = isProd ? "production" : "development";
+function getMetadata(projectId) {
+	const buildUtils = new StarkBuildUtils(projectId);
 
-const isHMR =
-	ngCliUtils.getNgCliCommandOption("configuration") === "hmr" || ngCliUtils.hasNgCliCommandOption("hmr") || isProd
-		? buildUtils.ANGULAR_APP_CONFIG.buildConfigurations.production.hmr
-		: buildUtils.ANGULAR_APP_CONFIG.buildOptions.hmr || false;
+	const isProd =
+		ngCliUtils.hasNgCliCommandOption("prod") ||
+		ngCliUtils.getNgCliCommandOption("c") === "production" ||
+		ngCliUtils.getNgCliCommandOption("configuration") === "production";
+	const configENV = isProd ? "production" : "development";
 
-const isWatch =
-	ngCliUtils.getNgCliAction() === "serve" ||
-	(ngCliUtils.hasNgCliCommandOption("watch") && ngCliUtils.getNgCliCommandOption("watch") === "true") ||
-	buildUtils.getAngularWorkspaceBuildProperty("baseHref", configENV) === true;
+	const isHMR =
+		ngCliUtils.getNgCliCommandOption("configuration") === "hmr" || ngCliUtils.hasNgCliCommandOption("hmr") || isProd
+			? buildUtils.ANGULAR_APP_CONFIG.buildConfigurations.production.hmr
+			: buildUtils.ANGULAR_APP_CONFIG.buildOptions.hmr || false;
 
-const METADATA = {
-	// Default value in production: `true`, otherwise: `false`. See: https://v8.angular.io/guide/aot-compiler#choosing-a-compiler
-	AOT: ngCliUtils.hasNgCliCommandOption("aot") || buildUtils.getAngularWorkspaceBuildProperty("aot", configENV) || isProd,
-	BASE_URL: ngCliUtils.getNgCliCommandOption("baseHref") || buildUtils.getAngularWorkspaceBuildProperty("baseHref", configENV),
-	E2E: ngCliUtils.getNgCliAction("e2e"),
-	ENV: configENV,
-	HOST:
-		ngCliUtils.getNgCliAction() === "serve"
-			? ngCliUtils.getNgCliCommandOption("host") || buildUtils.getAngularWorkspaceServeProperty("host", configENV) || "localhost"
-			: undefined, // by default is "localhost"
-	HMR: isHMR,
-	// PUBLIC: process.env.PUBLIC_DEV || HOST + ':' + PORT  // TODO check if needed/useful in our case?
-	IS_DEV_SERVER: ngCliUtils.getNgCliAction() === "serve" && !isProd, // NG CLI command 'serve"
-	PORT:
-		ngCliUtils.getNgCliAction() === "serve"
-			? ngCliUtils.getNgCliCommandOption("port") || buildUtils.getAngularWorkspaceServeProperty("port", configENV) || 4200
-			: undefined, // by default is 4200
-	TITLE: "Stark Application by @NationalBankBelgium",
-	TS_CONFIG_PATH: buildUtils.ANGULAR_APP_CONFIG.buildOptions.tsConfig,
-	WATCH: isWatch,
-	environment: isProd ? (helpers.hasProcessFlag("e2e") ? "e2e.prod" : "prod") : isHMR ? "hmr" : "dev"
-};
+	const isWatch =
+		ngCliUtils.getNgCliAction() === "serve" ||
+		(ngCliUtils.hasNgCliCommandOption("watch") && ngCliUtils.getNgCliCommandOption("watch") === "true");
 
-exports.METADATA = METADATA;
+	return {
+		// Default value in production: `true`, otherwise: `false`. See: https://v8.angular.io/guide/aot-compiler#choosing-a-compiler
+		AOT: ngCliUtils.hasNgCliCommandOption("aot") || buildUtils.getAngularWorkspaceBuildProperty("aot", configENV) || isProd,
+		BASE_URL: ngCliUtils.getNgCliCommandOption("baseHref") || buildUtils.getAngularWorkspaceBuildProperty("baseHref", configENV),
+		E2E: ngCliUtils.getNgCliAction("e2e"),
+		ENV: configENV,
+		HOST:
+			ngCliUtils.getNgCliAction() === "serve"
+				? ngCliUtils.getNgCliCommandOption("host") || buildUtils.getAngularWorkspaceServeProperty("host", configENV) || "localhost"
+				: undefined, // by default is "localhost"
+		HMR: isHMR,
+		IS_DEV_SERVER: ngCliUtils.getNgCliAction() === "serve" && !isProd, // NG CLI command 'serve"
+		PORT:
+			ngCliUtils.getNgCliAction() === "serve"
+				? ngCliUtils.getNgCliCommandOption("port") || buildUtils.getAngularWorkspaceServeProperty("port", configENV) || 4200
+				: undefined, // by default is 4200
+		TITLE: "Stark Application by @NationalBankBelgium",
+		TS_CONFIG_PATH: buildUtils.ANGULAR_APP_CONFIG.buildOptions.tsConfig,
+		WATCH: isWatch,
+		environment: isProd ? (helpers.hasProcessFlag("e2e") ? "e2e.prod" : "prod") : isHMR ? "hmr" : "dev"
+	};
+}
+
+exports.getMetadata = getMetadata;

--- a/packages/stark-build/config/webpack.config.js
+++ b/packages/stark-build/config/webpack.config.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const helpers = require("./helpers");
-const buildUtils = require("./build-utils");
 const fs = require("fs");
 
 /**
@@ -173,7 +172,7 @@ module.exports = (config, options) => {
 					devServer: {
 						// See: https://webpack.js.org/configuration/dev-server/#devserverdevmiddleware
 						devMiddleware: {
-							writeToDisk: true,
+							writeToDisk: true
 						},
 
 						compress: true,

--- a/packages/stark-build/config/webpack.config.js
+++ b/packages/stark-build/config/webpack.config.js
@@ -11,28 +11,11 @@ const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 const StylelintPlugin = require("stylelint-webpack-plugin");
 const webpackMerge = require("webpack-merge").merge;
-const METADATA = require("./webpack-metadata").METADATA;
+const getMetadata = require("./webpack-metadata").getMetadata;
 const ESLintPlugin = require("eslint-webpack-plugin");
 
 // Dev custom config
 const webpackCustomConfig = require(helpers.root("config/webpack-custom-config.dev.json"));
-
-// Directives to be used in CSP header
-const cspDirectives = [
-	"base-uri 'self'",
-	// "default-src 'self'", // FIXME: enable as soon as the issue is fixed in Angular (https://github.com/angular/angular-cli/issues/6872 )
-	"child-src 'self'",
-	"connect-src 'self' ws://" + METADATA.HOST + ":" + METADATA.PORT + " " + webpackCustomConfig["cspConnectSrc"], // ws://HOST:PORT" is due to Webpack
-	`font-src 'self' ${webpackCustomConfig["cspFontSrc"] || ""}`,
-	"form-action 'self' " + webpackCustomConfig["cspFormAction"],
-	"frame-src 'self'", // deprecated. Use child-src instead. Used here because child-src is not yet supported by Firefox. Remove as soon as it is fully supported
-	"frame-ancestors 'none'", // the app will not be allowed to be embedded in an iframe (roughly equivalent to X-Frame-Options: DENY)
-	"img-src 'self' data: image/png", // data: image/png is due to ui-router visualizer loading PNG images
-	"media-src 'self'",
-	"object-src 'self' data:"
-	// "script-src 'self'", // FIXME: enable as soon as the issue is fixed in Angular (https://github.com/angular/angular-cli/issues/6872 )
-	// "style-src 'self' 'nonce-uiroutervisualizer' 'nonce-cef324d21ec5483c8819cc7a5e33c4a2'" // we define the same nonce value as in the style-loader // FIXME: DomSharedStylesHost.prototype._addStylesToHost in platform-browser.js adds inline style!
-];
 
 /**
  * Custom extra configuration for Webpack, in addition to Angular CLI Webpack configuration.
@@ -43,6 +26,25 @@ const cspDirectives = [
  */
 module.exports = (config, options) => {
 	const BUNDLE_ANALYZER = !!process.env.BUNDLE_ANALYZER; // env BUNDLE_ANALYZER variable set via cross-env
+
+	const METADATA = getMetadata(config.output.uniqueName);
+
+	// Directives to be used in CSP header
+	const cspDirectives = [
+		"base-uri 'self'",
+		// "default-src 'self'", // FIXME: enable as soon as the issue is fixed in Angular (https://github.com/angular/angular-cli/issues/6872 )
+		"child-src 'self'",
+		"connect-src 'self' ws://" + METADATA.HOST + ":" + METADATA.PORT + " " + webpackCustomConfig["cspConnectSrc"], // ws://HOST:PORT" is due to Webpack
+		`font-src 'self' ${webpackCustomConfig["cspFontSrc"] || ""}`,
+		"form-action 'self' " + webpackCustomConfig["cspFormAction"],
+		"frame-src 'self'", // deprecated. Use child-src instead. Used here because child-src is not yet supported by Firefox. Remove as soon as it is fully supported
+		"frame-ancestors 'none'", // the app will not be allowed to be embedded in an iframe (roughly equivalent to X-Frame-Options: DENY)
+		"img-src 'self' data: image/png", // data: image/png is due to ui-router visualizer loading PNG images
+		"media-src 'self'",
+		"object-src 'self' data:"
+		// "script-src 'self'", // FIXME: enable as soon as the issue is fixed in Angular (https://github.com/angular/angular-cli/issues/6872 )
+		// "style-src 'self' 'nonce-uiroutervisualizer' 'nonce-cef324d21ec5483c8819cc7a5e33c4a2'" // we define the same nonce value as in the style-loader // FIXME: DomSharedStylesHost.prototype._addStylesToHost in platform-browser.js adds inline style!
+	];
 
 	return webpackMerge(config, {
 		/**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`stark-build` is using the deprecated `defaultProject` property from the "angular.json" file in order to read values from the file. 

Issue Number: N/A

## What is the new behavior?

The usage of the `defaultProject` property has been replaced by the projectId provided by `@angular-builders/custom-webpack`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
