### PR TITLE
fix(stark-core): enable correlation-id generation when `loggingFlushDisabled == true`

### DIFF
--- a/packages/stark-core/src/modules/logging/services/logging.service.ts
+++ b/packages/stark-core/src/modules/logging/services/logging.service.ts
@@ -58,29 +58,28 @@ export class StarkLoggingServiceImpl implements StarkLoggingService {
 		this.consoleWarn = this.getConsole("warn");
 		this.consoleError = this.getConsole("error");
 
-		if (this.appConfig.loggingFlushDisabled) {
-			return;
-		}
-
-		this.backend = this.appConfig.getBackend("logging");
-		this.logPersistSize = <number>this.appConfig.loggingFlushPersistSize;
-		this.logUrl = `${this.backend.url}/${this.appConfig.loggingFlushResourceName}`;
 		this.generateNewCorrelationId();
 
-		this.store.pipe(select(selectStarkLogging)).subscribe((starkLogging: StarkLogging) => {
-			this.starkLogging = starkLogging;
-			this.persistLogMessages();
-		});
+		if (!this.appConfig.loggingFlushDisabled) {
+			this.backend = this.appConfig.getBackend("logging");
+			this.logPersistSize = <number>this.appConfig.loggingFlushPersistSize;
+			this.logUrl = `${this.backend.url}/${this.appConfig.loggingFlushResourceName}`;
 
-		if (window) {
-			window.addEventListener("beforeunload", (_ev: BeforeUnloadEvent) => {
-				// Persist the remaining log entries that are still in the store, before leaving the application.
-				// We need to call the REST service synchronously,
-				// because the browser has to wait for the REST service to complete.
-
-				const data: string = JSON.stringify(Serialize(this.starkLogging, StarkLoggingImpl));
-				this.sendRequest(this.logUrl, data, false);
+			this.store.pipe(select(selectStarkLogging)).subscribe((starkLogging: StarkLogging) => {
+				this.starkLogging = starkLogging;
+				this.persistLogMessages();
 			});
+
+			if (window) {
+				window.addEventListener("beforeunload", (_ev: BeforeUnloadEvent) => {
+					// Persist the remaining log entries that are still in the store, before leaving the application.
+					// We need to call the REST service synchronously,
+					// because the browser has to wait for the REST service to complete.
+
+					const data: string = JSON.stringify(Serialize(this.starkLogging, StarkLoggingImpl));
+					this.sendRequest(this.logUrl, data, false);
+				});
+			}
 		}
 
 		this.debug(starkLoggingServiceName + " loaded");


### PR DESCRIPTION
ISSUES CLOSED: #3620

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?


Issue Number: #3620 

## What is the new behavior?

The correlation-id is now generated even when the loggingFlush is disabled.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
