### PR TITLE
fix(stark-testing): make sure to use chrome from `puppeteer`

### DIFF
--- a/docs/MIGRATION_ANGULAR_16.md
+++ b/docs/MIGRATION_ANGULAR_16.md
@@ -102,6 +102,16 @@ in `package.json` remove the following script
 }
 ```
 
+### adapt `karma.conf.js`
+
+```txt
+	//lines to removed
+
+	// Puppeteer: https://github.com/GoogleChrome/puppeteer/
+	// takes care of download Chrome and making it available (can do much more :p)
+	process.env.CHROME_BIN = require("puppeteer").executablePath();
+```
+
 ### test
 
 - remove `node_module` directory

--- a/docs/MIGRATION_GUIDE_STARK_12.md
+++ b/docs/MIGRATION_GUIDE_STARK_12.md
@@ -839,6 +839,21 @@ Due to this, following changes have to be made in application using `stark-testi
   "test-fast:ci": "npm run ng -- test --watch=false --code-coverage"
   ```
 
+-- Adapt "karma.conf.js"
+
+```txt
+	/**
+ 	* Load karma config from Stark
+ 	*/
+	const defaultKarmaConfig = require("./node_modules/@nationalbankbelgium/stark-testing/karma.conf.js").rawKarmaConfig;
+
+	//Add following lines
+
+	// Puppeteer: https://github.com/GoogleChrome/puppeteer/
+	// takes care of download Chrome and making it available (can do much more :p)
+	process.env.CHROME_BIN = require("puppeteer").executablePath();
+```
+
 ## Stark-UI
 
 ### 1. Update styles

--- a/packages/stark-testing/karma.conf.js
+++ b/packages/stark-testing/karma.conf.js
@@ -3,6 +3,10 @@ const helpers = require("./helpers");
 const ci = require("ci-info");
 const isCI = process.argv.indexOf("--watch=false") > -1 || !!ci.isCI;
 
+// Puppeteer: https://github.com/GoogleChrome/puppeteer/
+// takes care of download Chrome and making it available (can do much more :p)
+process.env.CHROME_BIN = require("puppeteer").executablePath();
+
 const rawKarmaConfig = {
 	// base path that will be used to resolve all patterns (e.g. files, exclude)
 	basePath: "",


### PR DESCRIPTION
In test, we use `puppeteer` to setup chrome

ISSUES CLOSED: #4028

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Applications using stark-testing doesn't use chrome coming from `puppeteer`

Issue Number: #4028

## What is the new behavior?

Application using stark-testing use chrome coming from `puppeteer`

Documentation has been updated when using stark 12.0.0-alpha.x and 12.0.0-beta.x

## Does this PR introduce a breaking change?

```
[] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
