### PR TITLE
feat(stark-build): add support to extend index-html.transform.js

### DIFF
--- a/docs/stark-build/NG_CLI_BUILD_CUSTOMIZATIONS.md
+++ b/docs/stark-build/NG_CLI_BUILD_CUSTOMIZATIONS.md
@@ -245,6 +245,53 @@ If you desire to customize it, you can define it in the **baseHref** option of y
 }
 ```
 
+#### If you need to override `starkAppMetadata` or `starkAppConfig` depending on your target configuration you can extend `indexTransform`
+
+```text
+{
+    ...
+    "projects": {
+        "your-app": {
+            ...
+            "architect": {
+                "build": {
+                    ...
+                    "options": {
+                        ...
+                        "indexTransform": "./config/index-html.transform.js"  // default value: "./node_modules/@nationalbankbelgium/stark-build/config/index-html.transform.js"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+in your new index-html.transform
+
+```javascript
+"use strict";
+const starkIndexHtmlTransform = require("@nationalbankbelgium/stark-build/config/index-html.transform");
+
+const commonDataToOverride = {
+  starkAppConfig: {
+    // data to override in starkAppConfig
+  },
+  starkAppMetadata: {
+    // data to override in starkAppMetadata
+  }
+};
+
+module.exports = (targetOptions, indexHtml) => {
+  if (targetOptions.configuration === "config_name_where_override") {
+    return starkIndexHtmlTransform(targetOptions, indexHtml, commonDataToOverride);
+  } else {
+    // continue to use default options
+    return starkIndexHtmlTransform(targetOptions, indexHtml);
+  }
+};
+```
+
 #### [HtmlHeadElements](https://github.com/NationalBankBelgium/stark/blob/master/packages/stark-build/config/html-head-elements "HtmlHeadElements")
 
 This plugin appends head elements during the creation of _index.html_.

--- a/packages/stark-build/config/index-html.transform.js
+++ b/packages/stark-build/config/index-html.transform.js
@@ -1,5 +1,5 @@
 const helpers = require("./helpers");
-const fs = require("fs");
+const fs = require("node:fs");
 const commonData = require("./common-data.js"); // common configuration between environments
 const HtmlHeadElements = require("./html-head-elements");
 const getMetadata = require("./webpack-metadata").getMetadata;
@@ -19,10 +19,17 @@ let METADATA;
 ```
  *
  * @param indexHtml
+ * @param commonDataToOverride
  * @returns {string}
  */
-function replacePlaceholdersByValues(indexHtml) {
+function replacePlaceholdersByValues(indexHtml, commonDataToOverride) {
 	const regex = /(?:<|&lt;)%=\s+starkOptions\.(starkAppMetadata|starkAppConfig|metadata)\.(\w+)\s+%(?:>|&gt;)/g;
+
+	const effectiveCommonData = structuredClone(commonData);
+	if (commonDataToOverride) {
+		effectiveCommonData["starkAppMetadata"] = { ...commonData.starkAppMetadata, ...commonDataToOverride.starkAppMetadata };
+		effectiveCommonData["starkAppConfig"] = { ...commonData.starkAppConfig, ...commonDataToOverride.starkAppConfig };
+	}
 
 	const getRealValue = (placeholder, ...args) => {
 		const configName = args[0];
@@ -33,7 +40,7 @@ function replacePlaceholdersByValues(indexHtml) {
 		if (configName === "metadata") {
 			value = METADATA[property];
 		} else {
-			value = commonData[configName][property];
+			value = effectiveCommonData[configName][property];
 		}
 
 		if (value) {
@@ -43,10 +50,10 @@ function replacePlaceholdersByValues(indexHtml) {
 		return placeholder;
 	};
 
-	return indexHtml.replace(regex, getRealValue);
+	return indexHtml.replaceAll(regex, getRealValue);
 }
 
-module.exports = (targetOptions, indexHtml) => {
+module.exports = function transformIndexHtml(targetOptions, indexHtml, commonDataToOverride) {
 	let indexHtmlToReturn = indexHtml;
 
 	METADATA = getMetadata(targetOptions.project);
@@ -66,5 +73,5 @@ module.exports = (targetOptions, indexHtml) => {
 	    ${indexHtml.slice(i)}`;
 	}
 
-	return replacePlaceholdersByValues(indexHtmlToReturn);
+	return replacePlaceholdersByValues(indexHtmlToReturn, commonDataToOverride);
 };


### PR DESCRIPTION
TO be able to change data when generating index.html, we need to pass the new value in case of extends by others projects.

ISSUES CLOSED: #4055

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #4055

## What is the new behavior?

We can extends index-html.transform.js to add custom logic and add override starkAppMetadata and starkAppConfig values

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
